### PR TITLE
Refactor transform.jl

### DIFF
--- a/src/Turing.jl
+++ b/src/Turing.jl
@@ -65,8 +65,6 @@ global const CACHERESET  = 0b00
 global const CACHEIDCS   = 0b10
 global const CACHERANGES = 0b01
 
-global TRANS_CACHE = Dict{Tuple,Any}()
-
 #######################
 # Sampler abstraction #
 #######################

--- a/src/core/util.jl
+++ b/src/core/util.jl
@@ -2,8 +2,8 @@
 # Math #
 ########
 
-@inline invlogit(x::Union{T,Vector{T},Matrix{T}}) where T<:Real = one(T) ./ (one(T) .+ exp.(-x))
-@inline logit(x::Union{T,Vector{T},Matrix{T}}) where T<:Real = log.(x ./ (one(T) - x))
+@inline invlogit(x::T) where T<:Real = one(T) / (one(T) + exp(-x))
+@inline logit(x::T) where T<:Real = log(x / (one(T) - x))
 
 # More stable, faster version of rand(Categorical)
 function randcat(p::Vector{Float64})

--- a/src/helper.jl
+++ b/src/helper.jl
@@ -23,9 +23,9 @@ import Base: <=
 # Helper functions for vectorize/reconstruct values #
 #####################################################
 
-@inline vectorize(d::UnivariateDistribution,   r::T) where {T <: Real} = Vector{Real}([r])
-@inline vectorize(d::MultivariateDistribution, r::Vector{T}) where {T <: Real} = Vector{Real}(r)
-@inline vectorize(d::MatrixDistribution,       r::Matrix{T}) where {T <: Real} = Vector{Real}(vec(r))
+vectorize(d::UnivariateDistribution, r::Real) = Vector{Real}([r])
+vectorize(d::MultivariateDistribution, r::AbstractVector{<:Real}) = Vector{Real}(r)
+vectorize(d::MatrixDistribution, r::AbstractMatrix{<:Real}) = Vector{Real}(vec(r))
 
 # NOTE:
 # We cannot use reconstruct{T} because val is always Vector{Real} then T will be Real.
@@ -38,6 +38,7 @@ import Base: <=
 @inline reconstruct(d::UnivariateDistribution,   val::Union{Vector,SubArray}, T::Type) = val[1]
 @inline reconstruct(d::MultivariateDistribution, val::Union{Vector,SubArray}, T::Type) = Array{T, 1}(val)
 @inline reconstruct(d::MatrixDistribution,       val::Union{Vector,SubArray}, T::Type) = Array{T, 2}(reshape(val, size(d)...))
+
 
 @inline reconstruct!(r, d::Distribution, val::Union{Vector,SubArray}) = reconstruct!(r, d, val, typeof(val[1]))
 @inline reconstruct!(r, d::MultivariateDistribution, val::Union{Vector,SubArray}, T::Type) = (r[:] = val; r)

--- a/src/transform.jl
+++ b/src/transform.jl
@@ -206,38 +206,30 @@ const PDMatDistribution = Union{InverseWishart, Wishart}
 
 function link(d::PDMatDistribution, X::AbstractMatrix{T}) where {T<:Real}
   Y = cholesky(X).L
-  dim = size(Y)
-  for m in 1:dim[1]
+  for m in 1:size(Y, 1)
     Y[m, m] = log(Y[m, m])
   end
-  for m in 1:dim[1], n in m+1:dim[2]
-    Y[m, n] = zero(T)
-  end
-  Matrix{T}(Y)
+  return Y
 end
 
-###### FIX THIS. IT'S BROKEN!
-function invlink(d::PDMatDistribution, Z::AbstractMatrix{<:Real}) where {T<:Real}
-  dim = size(z)
-  for m in 1:dim[1]
-    z[m, m] = exp.(z[m, m])
+function invlink(d::PDMatDistribution, Y::LowerTriangular{T}) where {T<:Real}
+  X, dim = copy(Y), size(Y)
+  for m in 1:size(X, 1)
+    X[m, m] = exp(X[m, m])
   end
-  for m in 1:dim[1], n in m+1:dim[2]
-    z[m, n] = zero(T)
-  end
-  Matrix{T}(z * z')
+  return X * X'
 end
 
-function logpdf_with_trans(d::PDMatDistribution, x::AbstractMatrix{<:Real}, transform::Bool)
-  lp = logpdf(d, x)
+function logpdf_with_trans(d::PDMatDistribution, X::AbstractMatrix{<:Real}, transform::Bool)
+  lp = logpdf(d, X)
   if transform && isfinite(lp)
-    U = cholesky(x).U
+    U = cholesky(X).U
     for i in 1:dim(d)
       lp += (dim(d) - i + 2.0) * log(U[i, i])
     end
     lp += dim(d) * log(2.0)
   end
-  lp
+  return lp
 end
 
 

--- a/src/transform.jl
+++ b/src/transform.jl
@@ -209,15 +209,15 @@ function link(d::PDMatDistribution, X::AbstractMatrix{T}) where {T<:Real}
   for m in 1:size(Y, 1)
     Y[m, m] = log(Y[m, m])
   end
-  return Y
+  return Matrix(Y)
 end
 
-function invlink(d::PDMatDistribution, Y::LowerTriangular{T}) where {T<:Real}
+function invlink(d::PDMatDistribution, Y::AbstractMatrix{T}) where {T<:Real}
   X, dim = copy(Y), size(Y)
   for m in 1:size(X, 1)
     X[m, m] = exp(X[m, m])
   end
-  return X * X'
+  return LowerTriangular(X) * LowerTriangular(X)'
 end
 
 function logpdf_with_trans(d::PDMatDistribution, X::AbstractMatrix{<:Real}, transform::Bool)
@@ -307,10 +307,10 @@ end
 # MatrixDistributions
 using Distributions: MatrixDistribution
 
-link(d::MatrixDistribution, X::AbstractMatrix{<:Real}) = X
+link(d::MatrixDistribution, X::AbstractMatrix{<:Real}) = copy(X)
 link(d::MatrixDistribution, X::AbstractVector{<:AbstractMatrix{<:Real}}) = link.(Ref(d), X)
 
-invlink(d::MatrixDistribution, Y::AbstractMatrix{<:Real}) = Y
+invlink(d::MatrixDistribution, Y::AbstractMatrix{<:Real}) = copy(Y)
 function invlink(d::MatrixDistribution, Y::AbstractVector{<:AbstractMatrix{<:Real}})
   return invlink.(Ref(d), Y)
 end

--- a/test/mh.jl/mh_cons.jl
+++ b/test/mh.jl/mh_cons.jl
@@ -10,7 +10,7 @@ using Test
 end
 
 GaussianKernel(var) = (x) -> Normal(x, sqrt(var))
-N = 500
+N = 1000
 s1 = MH(N, (:s, GaussianKernel(3.0)), (:m, GaussianKernel(3.0)))
 s2 = MH(N, :s, :m)
 s3 = MH(N)

--- a/test/transform.jl/transform.jl
+++ b/test/transform.jl/transform.jl
@@ -4,7 +4,10 @@ using Turing: link, invlink, logpdf_with_trans
 # Standard tests for all distributions involving a single-sample.
 function single_sample_tests(dist)
   x = rand(dist)
-  @test invlink(dist, link(dist, x)) ≈ x atol=1e-9
+  @test invlink(dist, link(dist, copy(x))) ≈ x atol=1e-9
+
+  y = link(dist, x)
+  @test link(dist, invlink(dist, copy(y))) ≈ y atol=1e-9
   logpdf_with_trans(dist, x, true)
   logpdf_with_trans(dist, x, false)
 end
@@ -14,7 +17,9 @@ end
 # univariate distributions, just a vector of identical values. For vector-valued
 # distributions, a matrix whose columns are identical.
 function multi_sample_tests(dist, x, xs, N)
-  @test invlink(dist, link(dist, x)) ≈ x atol=1e-9
+  y = link(dist, copy(x))
+  @test invlink(dist, link(dist, copy(x))) ≈ x atol=1e-9
+  @test link(dist, invlink(dist, copy(y))) ≈ y atol=1e-9
   @test logpdf_with_trans(dist, xs, true) == fill(logpdf_with_trans(dist, x, true), N)
   @test logpdf_with_trans(dist, xs, false) == fill(logpdf_with_trans(dist, x, false), N)
 end

--- a/test/transform.jl/transform.jl
+++ b/test/transform.jl/transform.jl
@@ -10,6 +10,8 @@ function single_sample_tests(dist)
   @test link(dist, invlink(dist, copy(y))) ≈ y atol=1e-9
   logpdf_with_trans(dist, x, true)
   logpdf_with_trans(dist, x, false)
+
+  @test typeof(x) == typeof(y)
 end
 
 # Standard tests for all distributions involving multiple samples. xs should be whatever
@@ -22,6 +24,8 @@ function multi_sample_tests(dist, x, xs, N)
   @test link(dist, invlink(dist, copy(ys))) ≈ ys atol=1e-9
   @test logpdf_with_trans(dist, xs, true) == fill(logpdf_with_trans(dist, x, true), N)
   @test logpdf_with_trans(dist, xs, false) == fill(logpdf_with_trans(dist, x, false), N)
+
+  @test typeof(xs) == typeof(ys)
 end
 
 # Tests with scalar-valued distributions.

--- a/test/transform.jl/transform.jl
+++ b/test/transform.jl/transform.jl
@@ -17,9 +17,9 @@ end
 # univariate distributions, just a vector of identical values. For vector-valued
 # distributions, a matrix whose columns are identical.
 function multi_sample_tests(dist, x, xs, N)
-  y = link(dist, copy(x))
-  @test invlink(dist, link(dist, copy(x))) ≈ x atol=1e-9
-  @test link(dist, invlink(dist, copy(y))) ≈ y atol=1e-9
+  ys = link(dist, copy(xs))
+  @test invlink(dist, link(dist, copy(xs))) ≈ xs atol=1e-9
+  @test link(dist, invlink(dist, copy(ys))) ≈ ys atol=1e-9
   @test logpdf_with_trans(dist, xs, true) == fill(logpdf_with_trans(dist, x, true), N)
   @test logpdf_with_trans(dist, xs, false) == fill(logpdf_with_trans(dist, x, false), N)
 end


### PR DESCRIPTION
This PR contains additional modifications to #485 , so please don't even think about merging this until that branch is merged.

This is a substantial refactoring of transform.jl, including:
- Refactoring of vectorised code to more cleanly separate `link` / `invlink` / `logpdf_with_trans` calls from one another.
- A lot more testing. There were some bugs that had been missed in the 1.0 transition due to poor coverage.
- Proper fallbacks: there are now proper fallbacks for all distributions, which vectorise properly.
- Looser type constraints: all vectors are now `AbstractVector`s and matrices are `AbstractMatrices`.

Questions:
- the global TRANS_CACHE: did anyone do any benchmarking to determine whether or not having this cache provides a substantial reduction in complexity in actual use cases? I've removed the code that depends upon on for now, but will of course reinstate it if necessary.