### PR TITLE
WIP: Refactoring AD

### DIFF
--- a/src/core/ad.jl
+++ b/src/core/ad.jl
@@ -32,7 +32,7 @@ function gradient_forward(
   # Replace old parameters to ensure this function doesn't mutate `vi`.
   vi[spl] = θ_old
 
-  return ∂l∂θ
+  return getlogp(vi), ∂l∂θ
 end
 
 """

--- a/src/core/ad.jl
+++ b/src/core/ad.jl
@@ -47,27 +47,27 @@ Computes the gradient of the log joint of `θ` for the model specified by `(vi, 
 using reverse-mode AD from Flux.jl.
 """
 function gradient_reverse(
-  x::AbstractVector{<:Real},
+  θ::AbstractVector{<:Real},
   vi::Turing.VarInfo,
   model::Function,
   spl::Union{Nothing, Sampler}=nothing,
 )
   # Specify objective function.
-  function f(x)
-    vi[spl] = x
+  function f(θ)
+    vi[spl] = θ
     return -runmodel(model, vi, spl).logp
   end
 
   # Compute forward and reverse passes.
-  l, ȳ = Tracker.forward(f, x)
-  ∂l∂x = ȳ(1)[1]
+  l, ȳ = Tracker.forward(f, θ)
+  ∂l∂θ = ȳ(1)[1]
 
   # Remove tracking info from variables in model (because mutable state).
   vi.logp = Tracker.data(vi.logp)
   vi[spl] .= Tracker.data.(vi[spl])
 
   # Return non-tracked gradient value
-  return Tracker.data(l), Tracker.data(∂l∂x)
+  return Tracker.data(l), Tracker.data(∂l∂θ)
 end
 
 function verifygrad(grad::AbstractVector{<:Real})

--- a/src/core/ad.jl
+++ b/src/core/ad.jl
@@ -14,17 +14,6 @@ function gradient_forward(
   vi::VarInfo,
   model::Function,
   spl::Union{Nothing, Sampler}=nothing,
-  chunk_size::Int=CHUNKSIZE,
-)
-  return _gradient_forward(θ, vi, model, spl, ForwardDiff.Chunk(min(length(θ), chunk_size)))
-end
-
-function _gradient_forward(
-  θ::AbstractVector{<:Real},
-  vi::VarInfo,
-  model::Function,
-  spl::Union{Nothing, Sampler},
-  chunk::ForwardDiff.Chunk,
 )
   # Record old parameters.
   θ_old = vi[spl]
@@ -36,8 +25,7 @@ function _gradient_forward(
   end
 
   # Set chunk size and do ForwardMode.
-  config = ForwardDiff.GradientConfig(f, θ, chunk)
-  ∂l∂θ = ForwardDiff.gradient!(similar(θ), f, θ, config)
+  ∂l∂θ = ForwardDiff.gradient(f, θ)
 
   # Replace old parameters to ensure this function doesn't mutate `vi`.
   vi[spl] = θ_old

--- a/src/core/ad.jl
+++ b/src/core/ad.jl
@@ -14,6 +14,17 @@ function gradient_forward(
   vi::VarInfo,
   model::Function,
   spl::Union{Nothing, Sampler}=nothing,
+  chunk_size::Int=CHUNKSIZE,
+)
+  return _gradient_forward(θ, vi, model, spl, ForwardDiff.Chunk(min(length(θ), chunk_size)))
+end
+
+function _gradient_forward(
+  θ::AbstractVector{<:Real},
+  vi::VarInfo,
+  model::Function,
+  spl::Union{Nothing, Sampler},
+  chunk::ForwardDiff.Chunk,
 )
   # Record old parameters.
   θ_old = vi[spl]
@@ -25,7 +36,6 @@ function gradient_forward(
   end
 
   # Set chunk size and do ForwardMode.
-  chunk = ForwardDiff.Chunk(min(CHUNKSIZE, length(θ)))
   config = ForwardDiff.GradientConfig(f, θ, chunk)
   ∂l∂θ = ForwardDiff.gradient!(similar(θ), f, θ, config)
 

--- a/src/core/ad.jl
+++ b/src/core/ad.jl
@@ -1,127 +1,81 @@
 """
-    gradient(vi::VarInfo, model::Function, spl::Union{Nothing, Sampler})
+gradient_forward(
+    θ::AbstractVector{<:Real},
+    vi::VarInfo,
+    spl::Sampler,
+    model::Function,
+)
 
-Function to generate the gradient dictionary, with each prior map to its derivative of the logjoint probibilioty. This function uses chunk-wise forward AD with a chunk of size $(CHUNKSIZE) as default.
-
-Example:
-
-```julia
-grad = gradient(vi, model, spl)
-end
-```
+Computes the gradient of the log joint of `θ` for the model specified by `(vi, spl, model)`
+using forwards-mode AD from ForwardDiff.jl.
 """
-gradient(vi::VarInfo, model::Function) = gradient(vi, model, nothing)
-gradient(vi::VarInfo, model::Function, spl::Union{Nothing, Sampler}) = begin
+function gradient_forward(
+  θ::AbstractVector{<:Real},
+  vi::VarInfo,
+  model::Function,
+  spl::Union{Nothing, Sampler}=nothing,
+)
+  # Record old parameters.
+  θ_old = vi[spl]
 
-  θ_hash = hash(vi[spl])
-
-  if spl != nothing && haskey(spl.info, :grad_cache)
-    if haskey(spl.info[:grad_cache], θ_hash)
-      return spl.info[:grad_cache][θ_hash]
-    end
+  # Define function to compute log joint.
+  function f(θ)
+      vi[spl] = θ
+      return -runmodel(model, vi, spl).logp
   end
 
-  # Initialisation
-  grad = Vector{Float64}()
+  # Set chunk size and do ForwardMode.
+  chunk = ForwardDiff.Chunk(min(CHUNKSIZE, length(θ)))
+  config = ForwardDiff.GradientConfig(f, θ, chunk)
+  ∂l∂θ = ForwardDiff.gradient!(similar(θ), f, θ, config)
 
-  # Split keys(vi) into chunks,
-  @debug "making chunks..."
-  vn_chunk = Set{VarName}(); vn_chunks = []; chunk_dim = 0;
+  # Replace old parameters to ensure this function doesn't mutate `vi`.
+  vi[spl] = θ_old
 
-  vns = getvns(vi, spl); vn_num = length(vns)
-
-  for i = 1:vn_num
-    l = length(getrange(vi, vns[i]))           # dimension for the current variable
-    if chunk_dim + l > CHUNKSIZE
-      push!(vn_chunks,        # store the previous chunk
-            (vn_chunk, chunk_dim))
-      vn_chunk = []           # initialise a new chunk
-      chunk_dim = 0           # reset dimension counter
-    end
-    push!(vn_chunk, vns[i])       # put the current variable into the current chunk
-    chunk_dim += l            # update dimension counter
-  end
-  push!(vn_chunks,            # push the last chunk
-        (vn_chunk, chunk_dim))
-
-  # Chunk-wise forward AD
-  for (vn_chunk, chunk_dim) in vn_chunks
-    # 1. Set dual part correspondingly
-    @debug "set dual..."
-    dim_count = 1
-    for i = 1:vn_num
-      range = getrange(vi, vns[i])
-      l = length(range)
-      vals = getval(vi, vns[i])
-      if vns[i] in vn_chunk        # for each variable to compute gradient in this round
-        for i = 1:l
-          vi[range[i]] = ForwardDiff.Dual{Nothing, Float64, CHUNKSIZE}(realpart(vals[i]), SEEDS[dim_count])
-          dim_count += 1      # count
-        end
-      else                    # for other varilables (no gradient in this round)
-        for i = 1:l
-          vi[range[i]] = ForwardDiff.Dual{Nothing, Float64, CHUNKSIZE}(realpart(vals[i]))
-        end
-      end
-    end
-    @debug "set dual done"
-
-    # 2. Run model
-    @debug "run model..."
-    vi = runmodel(model, vi, spl)
-
-    # 3. Collect gradient
-    @debug "collect gradients from logp..."
-    append!(grad, collect(dualpart(-getlogp(vi)))[1:chunk_dim])
-  end
-
-  if spl != nothing && haskey(spl.info, :grad_cache)
-    spl.info[:grad_cache][θ_hash] = grad
-  end
-
-  vi.logp = realpart(vi.logp)
-
-  grad
+  return ∂l∂θ
 end
 
-verifygrad(grad::Vector{Float64}) = begin
+"""
+gradient_reverse(
+    θ::AbstractVector{<:Real},
+    vi::VarInfo,
+    spl::Sampler,
+    model::Function,
+)
+
+Computes the gradient of the log joint of `θ` for the model specified by `(vi, spl, model)`
+using reverse-mode AD from Flux.jl.
+"""
+function gradient_reverse(
+  x::AbstractVector{<:Real},
+  vi::Turing.VarInfo,
+  model::Function,
+  spl::Union{Nothing, Sampler}=nothing,
+)
+  # Specify objective function.
+  function f(x)
+    vi[spl] = x
+    return -runmodel(model, vi, spl).logp
+  end
+
+  # Compute forward and reverse passes.
+  l, ȳ = Tracker.forward(f, x)
+  ∂l∂x = ȳ(1)[1]
+
+  # Remove tracking info from variables in model (because mutable state).
+  vi.logp = Tracker.data(vi.logp)
+  vi[spl] .= Tracker.data.(vi[spl])
+
+  # Return non-tracked gradient value
+  return Tracker.data(l), Tracker.data(∂l∂x)
+end
+
+function verifygrad(grad::AbstractVector{<:Real})
   if any(isnan.(grad)) || any(isinf.(grad))
     @warn("Numerical error has been found in gradients.")
     @warn("grad = $(grad)")
-    false
+    return false
   else
-    true
+    return true
   end
 end
-
-# Direct call of ForwardDiff.gradient; this is slow
-gradient_slow(_vi::VarInfo, model::Function, spl::Union{Nothing, Sampler}) = begin
-
-  vi = deepcopy(_vi)
-
-  f(x::Vector) = begin
-    vi[spl] = x
-    -getlogp(runmodel(model, vi, spl))
-  end
-
-  g = x -> ForwardDiff.gradient(f, x::Vector, ForwardDiff.GradientConfig{min(length(x),CHUNKSIZE)}(x::Vector))
-
-  g(vi[spl])
-end
-
-gradient_r(theta::AbstractVector{<:Real}, vi::VarInfo, model::Function) = 
-  gradient_r(theta, vi, model, nothing)
-gradient_r(theta::AbstractVector{<:Real}, vi::Turing.VarInfo, model::Function, spl::Union{Nothing, Sampler}) = begin
-  # Use Flux.Tracker to get gradient
-  grad = Tracker.gradient(x -> (vi[spl] = x; -runmodel(model, vi, spl).logp), theta)
-  # Clean tracked numbers 
-  # Numbers do not need to be tracked between two gradient calls
-  vi.logp = vi.logp.data
-  vi_spl = vi[spl]
-  for i = 1:length(theta)
-    vi_spl[i] = vi_spl[i].data
-  end
-  # Return non-tracked graident value
-  return first(grad).data
-end
-

--- a/src/samplers/sghmc.jl
+++ b/src/samplers/sghmc.jl
@@ -78,7 +78,7 @@ function step(model, spl::Sampler{SGHMC}, vi::VarInfo, is_first::Bool)
     @debug "recording old variables..."
     old_θ = realpart(vi[spl]);
     θ = deepcopy(old_θ)
-    grad = gradient_forward(old_θ, vi, model, spl)
+    _, grad = gradient_forward(old_θ, vi, model, spl)
     old_v = deepcopy(spl.info[:v])
     v = deepcopy(old_v)
 

--- a/src/samplers/sghmc.jl
+++ b/src/samplers/sghmc.jl
@@ -78,7 +78,7 @@ function step(model, spl::Sampler{SGHMC}, vi::VarInfo, is_first::Bool)
     @debug "recording old variables..."
     old_θ = realpart(vi[spl]);
     θ = deepcopy(old_θ)
-    grad = gradient(vi, model, spl)
+    grad = gradient_forward(old_θ, vi, model, spl)
     old_v = deepcopy(spl.info[:v])
     v = deepcopy(old_v)
 

--- a/src/samplers/sgld.jl
+++ b/src/samplers/sgld.jl
@@ -80,7 +80,7 @@ function step(model, spl::Sampler{SGLD}, vi::VarInfo, is_first::Bool)
     @debug "recording old variables..."
     old_θ = realpart(vi[spl])
     θ = deepcopy(old_θ)
-    grad = gradient(vi, model, spl)
+    grad = gradient_forward(old_θ, vi, model, spl)
 
     if verifygrad(grad)
       @debug "update latent variables..."

--- a/src/samplers/sgld.jl
+++ b/src/samplers/sgld.jl
@@ -80,7 +80,7 @@ function step(model, spl::Sampler{SGLD}, vi::VarInfo, is_first::Bool)
     @debug "recording old variables..."
     old_θ = realpart(vi[spl])
     θ = deepcopy(old_θ)
-    grad = gradient_forward(old_θ, vi, model, spl)
+    _, grad = gradient_forward(old_θ, vi, model, spl)
 
     if verifygrad(grad)
       @debug "update latent variables..."

--- a/src/samplers/support/hmc_core.jl
+++ b/src/samplers/support/hmc_core.jl
@@ -3,20 +3,21 @@
 """
   gen_grad_func(vi, spl, model)
 
-Generate a function that takes `θ` and returns log-joint probabilty and gradient at `θ`, using Turing-related variables `vi`, `spl` and `model`.
+Generate a function that takes `θ` and returns log-joint probabilty and gradient at `θ`,
+using Turing-related variables `vi`, `spl` and `model`.
 """
 function gen_grad_func(vi, spl, model)
 
   grad_func(θ::T) where {T<:Union{Vector,SubArray}} = begin
 
     if ADBACKEND == :forward_diff
-      vi[spl] = θ
-      grad = gradient(vi, model, spl)
+      grad = gradient_forward(θ, vi, model, spl)
+      lp = getlogp(vi)
     elseif ADBACKEND == :reverse_diff
-      grad = gradient_r(θ, vi, model, spl)
+      lp, grad = gradient_reverse(θ, vi, model, spl)
     end
 
-    return getlogp(vi), grad
+    return lp, grad
 
   end
 

--- a/src/samplers/support/hmc_core.jl
+++ b/src/samplers/support/hmc_core.jl
@@ -11,8 +11,7 @@ function gen_grad_func(vi, spl, model)
   grad_func(θ::T) where {T<:Union{Vector,SubArray}} = begin
 
     if ADBACKEND == :forward_diff
-      grad = gradient_forward(θ, vi, model, spl)
-      lp = getlogp(vi)
+      lp, grad = gradient_forward(θ, vi, model, spl)
     elseif ADBACKEND == :reverse_diff
       lp, grad = gradient_reverse(θ, vi, model, spl)
     end

--- a/test/ad.jl/ad1.jl
+++ b/test/ad.jl/ad1.jl
@@ -1,6 +1,6 @@
 using Distributions
 using Turing
-using Turing: gradient, invlink, link, getval, realpart
+using Turing: gradient_forward, invlink, link, getval, realpart
 using ForwardDiff
 using ForwardDiff: Dual
 using Test
@@ -22,7 +22,8 @@ svn = collect(Iterators.filter(vn -> vn.sym == :s, keys(vi)))[1]
 mvn = collect(Iterators.filter(vn -> vn.sym == :m, keys(vi)))[1]
 _s = realpart(getval(vi, svn)[1])
 _m = realpart(getval(vi, mvn)[1])
-∇E = gradient(vi, ad_test_f)
+spl = nothing
+∇E = gradient_forward(realpart(vi[spl]), vi, ad_test_f)
 # println(vi.vns)
 # println(∇E)
 grad_Turing = sort(∇E)

--- a/test/ad.jl/ad1.jl
+++ b/test/ad.jl/ad1.jl
@@ -23,7 +23,7 @@ mvn = collect(Iterators.filter(vn -> vn.sym == :m, keys(vi)))[1]
 _s = realpart(getval(vi, svn)[1])
 _m = realpart(getval(vi, mvn)[1])
 spl = nothing
-∇E = gradient_forward(realpart(vi[spl]), vi, ad_test_f)
+_, ∇E = gradient_forward(realpart(vi[spl]), vi, ad_test_f)
 # println(vi.vns)
 # println(∇E)
 grad_Turing = sort(∇E)

--- a/test/ad.jl/ad3.jl
+++ b/test/ad.jl/ad3.jl
@@ -18,7 +18,7 @@ ad_test_3_f = ad_test_3()
 vi = ad_test_3_f()
 vvn = collect(Iterators.filter(vn -> vn.sym == :v, keys(vi)))[1]
 _v = map(d -> realpart(d), vi[vvn])
-grad_Turing = gradient_forward(vi[nothing], vi, ad_test_3_f)
+_, grad_Turing = gradient_forward(vi[nothing], vi, ad_test_3_f)
 
 dist_v = Wishart(7, [1 0.5; 0.5 1])
 

--- a/test/ad.jl/ad3.jl
+++ b/test/ad.jl/ad3.jl
@@ -1,6 +1,6 @@
 using Distributions
 using Turing
-using Turing: gradient, invlink, link, realpart
+using Turing: gradient_forward, invlink, link, realpart
 using ForwardDiff
 using ForwardDiff: Dual
 using Test
@@ -18,7 +18,7 @@ ad_test_3_f = ad_test_3()
 vi = ad_test_3_f()
 vvn = collect(Iterators.filter(vn -> vn.sym == :v, keys(vi)))[1]
 _v = map(d -> realpart(d), vi[vvn])
-grad_Turing = gradient(vi, ad_test_3_f)
+grad_Turing = gradient_forward(vi[nothing], vi, ad_test_3_f)
 
 dist_v = Wishart(7, [1 0.5; 0.5 1])
 

--- a/test/ad.jl/adr.jl
+++ b/test/ad.jl/adr.jl
@@ -1,6 +1,6 @@
 using Distributions
 using Turing
-using Turing: gradient_r, invlink, link, getval, realpart
+using Turing: gradient_reverse, invlink, link, getval, realpart
 using ForwardDiff
 using ForwardDiff: Dual
 using Test
@@ -24,7 +24,7 @@ _s = realpart(getval(vi, svn)[1])
 _m = realpart(getval(vi, mvn)[1])
 
 x = map(_->Float64(_), vi[nothing])
-∇E = gradient_r(x, vi, ad_test_f)
+∇E = gradient_reverse(x, vi, ad_test_f)
 # println(vi.vns)
 # println(∇E)
 grad_Turing = sort(∇E)

--- a/test/hmc_core.jl/unit_test_helper.jl
+++ b/test/hmc_core.jl/unit_test_helper.jl
@@ -10,7 +10,7 @@ function test_grad(turing_model, grad_f; trans=Dict())
     @testset "Gradient using random inputs" begin
         for _ = 1:10000
             theta = rand(d)
-            @test Turing.gradient_r(theta, vi, model_f) == grad_f(theta)[2]
+            @test Turing.gradient_reverse(theta, vi, model_f) == grad_f(theta)[2]
         end
     end
 end


### PR DESCRIPTION
What it says on the tin. Relevant issue is #495 . I decided to refactor the reverse-mode implementation a bit as well to make it consistent with the new forward-mode implementation. I've also renamed `gradient`->`gradient_forward` and `gradient_r`->`gradient_reverse` for the sake of clarity.

Currently `gradient_forward` is reconstructing the `Chunk` on each application, which has a non-trivial effect on the performance of smaller models. It's not clear a priori whether this has a larger effect than the overhead associated with the retrieval of global mutable state, and therefore whether it's worth caching `Chunk` objects for various chunk sizes.

TODO

- [x] Refactor slightly to make `gradient_forward` and `gradient_reverse` have completely consistent interfaces.
- [x] Ascertain whether or not chunk-caching is generally worthwhile by doing some benchmarking.