### PR TITLE
Remove spurious broadcasts (see #507).

### DIFF
--- a/src/core/compiler.jl
+++ b/src/core/compiler.jl
@@ -149,9 +149,9 @@ Example:
 ```julia
 @model gauss() = begin
   s ~ InverseGamma(2,3)
-  m ~ Normal(0,sqrt.(s))
-  1.5 ~ Normal(m, sqrt.(s))
-  2.0 ~ Normal(m, sqrt.(s))
+  m ~ Normal(0, sqrt(s))
+  1.5 ~ Normal(m, sqrt(s))
+  2.0 ~ Normal(m, sqrt(s))
   return(s, m)
 end
 ```

--- a/src/samplers/hmc.jl
+++ b/src/samplers/hmc.jl
@@ -15,9 +15,9 @@ Example:
 # Define a simple Normal model with unknown mean and variance.
 @model gdemo(x) = begin
   s ~ InverseGamma(2,3)
-  m ~ Normal(0,sqrt.(s))
-  x[1] ~ Normal(m, sqrt.(s))
-  x[2] ~ Normal(m, sqrt.(s))
+  m ~ Normal(0, sqrt(s))
+  x[1] ~ Normal(m, sqrt(s))
+  x[2] ~ Normal(m, sqrt(s))
   return s, m
 end
 

--- a/src/samplers/hmcda.jl
+++ b/src/samplers/hmcda.jl
@@ -15,9 +15,9 @@ Example:
 # Define a simple Normal model with unknown mean and variance.
 @model gdemo(x) = begin
   s ~ InverseGamma(2,3)
-  m ~ Normal(0,sqrt.(s))
-  x[1] ~ Normal(m, sqrt.(s))
-  x[2] ~ Normal(m, sqrt.(s))
+  m ~ Normal(0, sqrt(s))
+  x[1] ~ Normal(m, sqrt(s))
+  x[2] ~ Normal(m, sqrt(s))
   return s, m
 end
 

--- a/src/samplers/is.jl
+++ b/src/samplers/is.jl
@@ -17,9 +17,9 @@ Example:
 # Define a simple Normal model with unknown mean and variance.
 @model gdemo(x) = begin
   s ~ InverseGamma(2,3)
-  m ~ Normal(0,sqrt.(s))
-  x[1] ~ Normal(m, sqrt.(s))
-  x[2] ~ Normal(m, sqrt.(s))
+  m ~ Normal(0, sqrt(s))
+  x[1] ~ Normal(m, sqrt(s))
+  x[2] ~ Normal(m, sqrt(s))
   return s, m
 end
 

--- a/src/samplers/nuts.jl
+++ b/src/samplers/nuts.jl
@@ -15,9 +15,9 @@ Example:
 # Define a simple Normal model with unknown mean and variance.
 @model gdemo(x) = begin
   s ~ InverseGamma(2,3)
-  m ~ Normal(0,sqrt.(s))
-  x[1] ~ Normal(m, sqrt.(s))
-  x[2] ~ Normal(m, sqrt.(s))
+  m ~ Normal(0, sqrt(s))
+  x[1] ~ Normal(m, sqrt(s))
+  x[2] ~ Normal(m, sqrt(s))
   return s, m
 end
 

--- a/src/samplers/pgibbs.jl
+++ b/src/samplers/pgibbs.jl
@@ -15,9 +15,9 @@ Example:
 # Define a simple Normal model with unknown mean and variance.
 @model gdemo(x) = begin
   s ~ InverseGamma(2,3)
-  m ~ Normal(0,sqrt.(s))
-  x[1] ~ Normal(m, sqrt.(s))
-  x[2] ~ Normal(m, sqrt.(s))
+  m ~ Normal(0, sqrt(s))
+  x[1] ~ Normal(m, sqrt(s))
+  x[2] ~ Normal(m, sqrt(s))
   return s, m
 end
 

--- a/src/samplers/smc.jl
+++ b/src/samplers/smc.jl
@@ -15,9 +15,9 @@ Example:
 # Define a simple Normal model with unknown mean and variance.
 @model gdemo(x) = begin
   s ~ InverseGamma(2,3)
-  m ~ Normal(0,sqrt.(s))
-  x[1] ~ Normal(m, sqrt.(s))
-  x[2] ~ Normal(m, sqrt.(s))
+  m ~ Normal(0, sqrt(s))
+  x[1] ~ Normal(m, sqrt(s))
+  x[2] ~ Normal(m, sqrt(s))
   return s, m
 end
 

--- a/test/ad.jl/ad1.jl
+++ b/test/ad.jl/ad1.jl
@@ -8,9 +8,9 @@ using Test
 # Define model
 @model ad_test() = begin
   s ~ InverseGamma(2, 3)
-  m ~ Normal(0, sqrt.(s))
-  1.5 ~ Normal(m, sqrt.(s))
-  2.0 ~ Normal(m, sqrt.(s))
+  m ~ Normal(0, sqrt(s))
+  1.5 ~ Normal(m, sqrt(s))
+  2.0 ~ Normal(m, sqrt(s))
   return s, m
 end
 # Turing.TURING[:modelex]
@@ -35,8 +35,8 @@ function logp(x::Vector)
   s = x[2]
   # s = invlink(dist_s, s)
   m = x[1]
-  lik_dist = Normal(m, sqrt.(s))
-  lp = Turing.logpdf_with_trans(dist_s, s, false) + Turing.logpdf_with_trans(Normal(0,sqrt.(s)), m, false)
+  lik_dist = Normal(m, sqrt(s))
+  lp = Turing.logpdf_with_trans(dist_s, s, false) + Turing.logpdf_with_trans(Normal(0,sqrt(s)), m, false)
   lp += logpdf(lik_dist, 1.5) + logpdf(lik_dist, 2.0)
   return lp
 end

--- a/test/ad.jl/ad2.jl
+++ b/test/ad.jl/ad2.jl
@@ -5,9 +5,9 @@ using Test
 # Define model
 @model ad_test2(xs) = begin
   s ~ InverseGamma(2,3)
-  m ~ Normal(0,sqrt.(s))
-  xs[1] ~ Normal(m, sqrt.(s))
-  xs[2] ~ Normal(m, sqrt.(s))
+  m ~ Normal(0, sqrt(s))
+  xs[1] ~ Normal(m, sqrt(s))
+  xs[2] ~ Normal(m, sqrt(s))
   s, m
 end
 

--- a/test/ad.jl/adr.jl
+++ b/test/ad.jl/adr.jl
@@ -36,8 +36,8 @@ function logp(x::Vector)
   s = x[2]
   # s = invlink(dist_s, s)
   m = x[1]
-  lik_dist = Normal(m, sqrt.(s))
-  lp = logpdf(dist_s, s, false) + logpdf(Normal(0,sqrt.(s)), m, false)
+  lik_dist = Normal(m, sqrt(s))
+  lp = logpdf(dist_s, s, false) + logpdf(Normal(0,sqrt(s)), m, false)
   lp += logpdf(lik_dist, 1.5) + logpdf(lik_dist, 2.0)
   lp
 end

--- a/test/compiler.jl/forbid_global.jl
+++ b/test/compiler.jl/forbid_global.jl
@@ -7,13 +7,13 @@ xs = [1.5 2.0]
 
 @model fggibbstest(xs) = begin
   s ~ InverseGamma(2,3)
-  m ~ Normal(0,sqrt.(s))
-  # xx ~ Normal(m, sqrt.(s)) # this is illegal
+  m ~ Normal(0,sqrt(s))
+  # xx ~ Normal(m, sqrt(s)) # this is illegal
 
   for i = 1:length(xs)
-    xs[i] ~ Normal(m, sqrt.(s))
+    xs[i] ~ Normal(m, sqrt(s))
   # for xx in xs
-    # xx ~ Normal(m, sqrt.(s))
+    # xx ~ Normal(m, sqrt(s))
   end
   s, m
 end

--- a/test/compiler.jl/new_grammar.jl
+++ b/test/compiler.jl/new_grammar.jl
@@ -7,9 +7,9 @@ priors = 0
 @model gauss(x) = begin
   priors = TArray{Float64}(2)
   priors[1] ~ InverseGamma(2,3)         # s
-  priors[2] ~ Normal(0,sqrt.(priors[1])) # m
+  priors[2] ~ Normal(0, sqrt(priors[1])) # m
   for i in 1:length(x)
-    x[i] ~ Normal(priors[2], sqrt.(priors[1]))
+    x[i] ~ Normal(priors[2], sqrt(priors[1]))
   end
   priors
 end

--- a/test/compiler.jl/noreturn.jl
+++ b/test/compiler.jl/noreturn.jl
@@ -7,9 +7,9 @@ xnoreturn = [1.5 2.0]
 
 @model noreturn(x) = begin
   s ~ InverseGamma(2,3)
-  m ~ Normal(0,sqrt.(s))
+  m ~ Normal(0, sqrt(s))
   for i in 1:length(x)
-    x[i] ~ Normal(m, sqrt.(s))
+    x[i] ~ Normal(m, sqrt(s))
   end
 end
 

--- a/test/compiler.jl/sample.jl
+++ b/test/compiler.jl/sample.jl
@@ -3,9 +3,9 @@ using Turing
 
 @model gdemo2(x) = begin
   s ~ InverseGamma(2,3)
-  m ~ Normal(0,sqrt.(s))
+  m ~ Normal(0, sqrt(s))
   for i = 1:length(x)
-    x[i] ~ Normal(m, sqrt.(s))
+    x[i] ~ Normal(m, sqrt(s))
   end
   return(s, m, x)
 end

--- a/test/geweke.jl
+++ b/test/geweke.jl
@@ -15,17 +15,17 @@ NSamples = 5000
 
 @model gdemo_fw() = begin
   s ~ InverseGamma(2,3)
-  m ~ Normal(0,sqrt.(s))
-  y ~ MvNormal([m; m; m], [sqrt.(s) 0 0; 0 sqrt.(s) 0; 0 0 sqrt.(s)])
+  m ~ Normal(0, sqrt(s))
+  y ~ MvNormal([m; m; m], [sqrt(s) 0 0; 0 sqrt(s) 0; 0 0 sqrt(s)])
 end
 
 @model gdemo_bk(x) = begin
   # Backward Step 1: theta ~ theta | x
   s ~ InverseGamma(2,3)
-  m ~ Normal(0,sqrt.(s))
-  x ~ MvNormal([m; m; m], [sqrt.(s) 0 0; 0 sqrt.(s) 0; 0 0 sqrt.(s)])
+  m ~ Normal(0,sqrt(s))
+  x ~ MvNormal([m; m; m], [sqrt(s) 0 0; 0 sqrt(s) 0; 0 0 sqrt(s)])
   # Backward Step 2: x ~ x | theta
-  y ~ MvNormal([m; m; m], [sqrt.(s) 0 0; 0 sqrt.(s) 0; 0 0 sqrt.(s)])
+  y ~ MvNormal([m; m; m], [sqrt(s) 0 0; 0 sqrt(s) 0; 0 0 sqrt(s)])
 end
 
 fw = HMCDA(NSamples, 0.9, 0.1)
@@ -41,7 +41,7 @@ x = [s[:y][1]...]
 s_bk = Array{Turing.Chain}(undef, N)
 
 simple_logger = Base.CoreLogging.SimpleLogger(stderr, Base.CoreLogging.Debug)
-with_logger(simple_logger) do 
+with_logger(simple_logger) do
   i = 1
   while i <= N
     try

--- a/test/gibbs.jl/gibbs.jl
+++ b/test/gibbs.jl/gibbs.jl
@@ -9,9 +9,9 @@ x = [1.5 2.0]
 
 @model gibbstest(x) = begin
   s ~ InverseGamma(2,3)
-  m ~ Normal(0,sqrt.(s))
+  m ~ Normal(0, sqrt(s))
   for i in 1:length(x)
-    x[i] ~ Normal(m, sqrt.(s))
+    x[i] ~ Normal(m, sqrt(s))
   end
   s, m
 end

--- a/test/gibbs.jl/gibbs_constructor.jl
+++ b/test/gibbs.jl/gibbs_constructor.jl
@@ -3,9 +3,9 @@ using Test
 
 @model gdemo() = begin
   s ~ InverseGamma(2,3)
-  m ~ Normal(0,sqrt.(s))
-  1.5 ~ Normal(m, sqrt.(s))
-  2.0 ~ Normal(m, sqrt.(s))
+  m ~ Normal(0, sqrt(s))
+  1.5 ~ Normal(m, sqrt(s))
+  2.0 ~ Normal(m, sqrt(s))
   return s, m
 end
 

--- a/test/hmc.jl/multivariate_support.jl
+++ b/test/hmc.jl/multivariate_support.jl
@@ -29,7 +29,7 @@ ts = [ones(M); ones(M); zeros(M); zeros(M)]
 # Define model
 
 alpha = 0.16            # regularizatin term
-var = sqrt.(1.0 / alpha) # variance of the Gaussian prior
+var = sqrt(1.0 / alpha) # variance of the Gaussian prior
 
 @model bnn(ts) = begin
   b1 ~ MvNormal([0 ;0; 0], [var 0 0; 0 var 0; 0 0 var])

--- a/test/hmcda.jl/hmcda.jl
+++ b/test/hmcda.jl/hmcda.jl
@@ -13,9 +13,9 @@ alg3 = Gibbs(1500, PG(30, 10, :s), HMCDA(1, 500, 0.65, 0.005, :m))
 
 @model gdemo(x) = begin
   s ~ InverseGamma(2,3)
-  m ~ Normal(0,sqrt.(s))
-  x[1] ~ Normal(m, sqrt.(s))
-  x[2] ~ Normal(m, sqrt.(s))
+  m ~ Normal(0, sqrt(s))
+  x[1] ~ Normal(m, sqrt(s))
+  x[2] ~ Normal(m, sqrt(s))
   return s, m
 end
 

--- a/test/hmcda.jl/hmcda_geweke.jl
+++ b/test/hmcda.jl/hmcda_geweke.jl
@@ -16,18 +16,18 @@ NSamples = 5000
 @model gdemo_fw() = begin
   # s ~ InverseGamma(2,3)
   s = 1
-  m ~ Normal(0,sqrt.(s))
-  y ~ MvNormal([m; m; m], [sqrt.(s) 0 0; 0 sqrt.(s) 0; 0 0 sqrt.(s)])
+  m ~ Normal(0, sqrt(s))
+  y ~ MvNormal([m; m; m], [sqrt(s) 0 0; 0 sqrt(s) 0; 0 0 sqrt(s)])
 end
 
 @model gdemo_bk(x) = begin
   # Backward Step 1: theta ~ theta | x
   # s ~ InverseGamma(2,3)
   s = 1
-  m ~ Normal(0,sqrt.(s))
-  x ~ MvNormal([m; m; m], [sqrt.(s) 0 0; 0 sqrt.(s) 0; 0 0 sqrt.(s)])
+  m ~ Normal(0,sqrt(s))
+  x ~ MvNormal([m; m; m], [sqrt(s) 0 0; 0 sqrt(s) 0; 0 0 sqrt(s)])
   # Backward Step 2: x ~ x | theta
-  y ~ MvNormal([m; m; m], [sqrt.(s) 0 0; 0 sqrt.(s) 0; 0 0 sqrt.(s)])
+  y ~ MvNormal([m; m; m], [sqrt(s) 0 0; 0 sqrt(s) 0; 0 0 sqrt(s)])
 end
 
 fw = PG(50, NSamples)
@@ -43,7 +43,7 @@ x = [s[:y][1]...]
 s_bk = Array{Turing.Chain}(undef, N)
 
 simple_logger = Base.CoreLogging.SimpleLogger(stderr, Base.CoreLogging.Debug)
-with_logger(simple_logger) do 
+with_logger(simple_logger) do
   i = 1
   while i <= N
     s_bk[i] = sample(gdemo_bk(x), bk);

--- a/test/io.jl/save_resume_chain.jl
+++ b/test/io.jl/save_resume_chain.jl
@@ -13,9 +13,9 @@ alg3 = Gibbs(500, PG(30, 10, :s), HMCDA(1, 500, 0.65, 0.05, :m))
 
 @model gdemo(x) = begin
   s ~ InverseGamma(2,3)
-  m ~ Normal(0,sqrt.(s))
-  x[1] ~ Normal(m, sqrt.(s))
-  x[2] ~ Normal(m, sqrt.(s))
+  m ~ Normal(0, sqrt(s))
+  x[1] ~ Normal(m, sqrt(s))
+  x[2] ~ Normal(m, sqrt(s))
   return s, m
 end
 

--- a/test/nuts.jl/nuts_geweke.jl
+++ b/test/nuts.jl/nuts_geweke.jl
@@ -16,18 +16,18 @@ NSamples = 5000
 @model gdemo_fw() = begin
   s ~ InverseGamma(2,3)
   # s = 1
-  m ~ Normal(0,sqrt.(s))
-  y ~ MvNormal([m; m; m], [sqrt.(s) 0 0; 0 sqrt.(s) 0; 0 0 sqrt.(s)])
+  m ~ Normal(0,sqrt(s))
+  y ~ MvNormal([m; m; m], [sqrt(s) 0 0; 0 sqrt(s) 0; 0 0 sqrt(s)])
 end
 
 @model gdemo_bk(x) = begin
   # Backward Step 1: theta ~ theta | x
   s ~ InverseGamma(2,3)
   # s = 1
-  m ~ Normal(0,sqrt.(s))
-  x ~ MvNormal([m; m; m], [sqrt.(s) 0 0; 0 sqrt.(s) 0; 0 0 sqrt.(s)])
+  m ~ Normal(0,sqrt(s))
+  x ~ MvNormal([m; m; m], [sqrt(s) 0 0; 0 sqrt(s) 0; 0 0 sqrt(s)])
   # Backward Step 2: x ~ x | theta
-  y ~ MvNormal([m; m; m], [sqrt.(s) 0 0; 0 sqrt.(s) 0; 0 0 sqrt.(s)])
+  y ~ MvNormal([m; m; m], [sqrt(s) 0 0; 0 sqrt(s) 0; 0 0 sqrt(s)])
 end
 
 fw = IS(NSamples)
@@ -44,7 +44,7 @@ x = [s[:y][1]...]
 s_bk = Array{Turing.Chain}(undef, N)
 
 simple_logger = Base.CoreLogging.SimpleLogger(stderr, Base.CoreLogging.Debug)
-with_logger(simple_logger) do 
+with_logger(simple_logger) do
   i = 1
   while i <= N
     s_bk[i] = sample(gdemo_bk(x), bk);

--- a/test/pmmh.jl/pmmh.jl
+++ b/test/pmmh.jl/pmmh.jl
@@ -9,9 +9,9 @@ x = [1.5 2.0]
 
 @model pmmhtest(x) = begin
   s ~ InverseGamma(2,3)
-  m ~ Normal(0,sqrt.(s))
+  m ~ Normal(0, sqrt(s))
   for i in 1:length(x)
-    x[i] ~ Normal(m, sqrt.(s))
+    x[i] ~ Normal(m, sqrt(s))
   end
   s, m
 end

--- a/test/pmmh.jl/pmmh_cons.jl
+++ b/test/pmmh.jl/pmmh_cons.jl
@@ -6,14 +6,14 @@ Random.seed!(125)
 
 @model gdemo() = begin
   s ~ InverseGamma(2,3)
-  m ~ Normal(0,sqrt.(s))
-  1.5 ~ Normal(m, sqrt.(s))
-  2.0 ~ Normal(m, sqrt.(s))
+  m ~ Normal(0, sqrt(s))
+  1.5 ~ Normal(m, sqrt(s))
+  2.0 ~ Normal(m, sqrt(s))
   return s, m
 end
 
 N = 500
-s1 = PMMH(N, SMC(10, :s), MH(1,(:m, (s) -> Normal(s, sqrt.(1)))))
+s1 = PMMH(N, SMC(10, :s), MH(1,(:m, (s) -> Normal(s, sqrt(1)))))
 s2 = PMMH(N, SMC(10, :s), MH(1,:m))
 s3 = PIMH(N, SMC(10))
 

--- a/test/sghmc.jl/sghmc.jl
+++ b/test/sghmc.jl/sghmc.jl
@@ -8,9 +8,9 @@ alg = SGHMC(10000, 0.02, 0.5)
 
 @model gdemo(x) = begin
   s ~ InverseGamma(2,3)
-  m ~ Normal(0,sqrt.(s))
-  x[1] ~ Normal(m, sqrt.(s))
-  x[2] ~ Normal(m, sqrt.(s))
+  m ~ Normal(0, sqrt(s))
+  x[1] ~ Normal(m, sqrt(s))
+  x[2] ~ Normal(m, sqrt(s))
   return s, m
 end
 

--- a/test/sgld.jl/sgld.jl
+++ b/test/sgld.jl/sgld.jl
@@ -6,9 +6,9 @@ Random.seed!(125)
 
 @model gdemo(x) = begin
   s ~ InverseGamma(2,3)
-  m ~ Normal(0,sqrt.(s))
-  x[1] ~ Normal(m, sqrt.(s))
-  x[2] ~ Normal(m, sqrt.(s))
+  m ~ Normal(0, sqrt(s))
+  x[1] ~ Normal(m, sqrt(s))
+  x[2] ~ Normal(m, sqrt(s))
   return s, m
 end
 

--- a/test/stan-interface.jl/stan-interface.jl
+++ b/test/stan-interface.jl/stan-interface.jl
@@ -4,9 +4,9 @@
 
   @model gdemo(x) = begin
     s ~ InverseGamma(2,3)
-    m ~ Normal(0,sqrt.(s))
-    x[1] ~ Normal(m, sqrt.(s))
-    x[2] ~ Normal(m, sqrt.(s))
+    m ~ Normal(0, sqrt(s))
+    x[1] ~ Normal(m, sqrt(s))
+    x[2] ~ Normal(m, sqrt(s))
     return s, m
   end
 

--- a/test/varinfo.jl/replay.jl
+++ b/test/varinfo.jl/replay.jl
@@ -10,11 +10,11 @@ xs = rand(Normal(0.5, 1), 100)
 @model priorsinarray(xs) = begin
   priors = Vector{Real}(undef, 2)
   priors[1] ~ InverseGamma(2, 3)
-  priors[2] ~ Normal(0, sqrt.(priors[1]))
+  priors[2] ~ Normal(0, sqrt(priors[1]))
   for i = 1:length(xs)
-    xs[i] ~ Normal(priors[2], sqrt.(priors[1]))
+    xs[i] ~ Normal(priors[2], sqrt(priors[1]))
   # for x in xs
-    # x ~ Normal(priors[2], sqrt.(priors[1]))
+    # x ~ Normal(priors[2], sqrt(priors[1]))
   end
   priors
 end

--- a/test/vectorisation.jl/vec_assume.jl
+++ b/test/vectorisation.jl/vec_assume.jl
@@ -9,7 +9,7 @@ alg = HMC(1000, 0.2, 4)
 @model vdemo() = begin
   x = Vector{Real}(undef, N)
   for i = 1:N
-    x[i] ~ Normal(0, sqrt.(4))
+    x[i] ~ Normal(0, sqrt(4))
   end
 end
 

--- a/test/vectorisation.jl/vectorize_observe.jl
+++ b/test/vectorisation.jl/vectorize_observe.jl
@@ -38,8 +38,8 @@ Random.seed!(129)
 # Test for vectorize UnivariateDistribution
 @model vdemo(x) = begin
   s ~ InverseGamma(2,3)
-  m ~ Normal(0,sqrt.(s))
-  x ~ [Normal(m, sqrt.(s))]
+  m ~ Normal(0, sqrt(s))
+  x ~ [Normal(m, sqrt(s))]
   # for i = 1:length(x)
   #   x[i] ~ Normal(m, sqrt.(s))
   # end


### PR DESCRIPTION
Pretty straightforward change of `sqrt.(scalar)` to `sqrt(scalar)`,
mostly in test code.