### PR TITLE
Compiler cleanup, no functional change

### DIFF
--- a/src/core/compiler.jl
+++ b/src/core/compiler.jl
@@ -5,32 +5,27 @@ using Base.Meta: parse
 #################
 
 # TODO: Replace this macro, see issue #514
-macro VarName(ex::Union{Expr, Symbol})
-  # Usage: @VarName x[1,2][1+5][45][3]
-  #    return: (:x,[1,2],6,45,3)
-    s = string(gensym())
-    if isa(ex, Symbol)
-        ex_str = string(ex)
-        return :(Symbol($ex_str), (), Symbol($s))
-    elseif ex.head == :ref
-        _2 = ex
-        _1 = ""
-        while _2.head == :ref
-            if length(_2.args) > 2
-                _1 = "[" * foldl( (x,y)-> "$x, $y", map(string, _2.args[2:end])) * "], $_1"
-            else
-                _1 = "[" * string(_2.args[2]) * "], $_1"
+"""
+Usage: @VarName x[1,2][1+5][45][3]
+  return: (:x,[1,2],6,45,3)
+"""
+macro VarName(expr::Union{Expr, Symbol})
+    ex = deepcopy(expr)
+    isa(ex, Symbol) && return var_tuple(ex)
+    (ex.head == :ref) || throw("VarName: Mis-formed variable name $(expr)!")
+    inds = :(())
+    while ex.head == :ref
+        if length(ex.args) >= 2
+            pushfirst!(inds.args, Expr(:vect, ex.args[2:end]...))
             end
-            _2 = _2.args[1]
-            isa(_2, Symbol) && (_1 = ":($_2)" * ", ($_1), Symbol(\"$s\")"; break)
+        ex = ex.args[1]
+        isa(ex, Symbol) && return var_tuple(ex, inds)
         end
-        return esc(parse(_1))
-    else
-        @error "VarName: Mis-formed variable name $(ex)!"
-        return :()
-    end
+    throw("VarName: Mis-formed variable name $(expr)!")
 end
-
+function var_tuple(sym::Symbol, inds::Expr=:(()))
+    return esc(:($(QuoteNode(sym)), $inds, $(QuoteNode(gensym()))))
+end
 
 """
     generate_observe(observation, distribution)
@@ -85,7 +80,7 @@ function generate_assume(variable::Expr, distribution)
         quote
             sym, idcs, csym = @VarName $variable
             csym_str = string(Turing._compiler_[:name])*string(csym)
-            indexing = isempty(idcs) ? "" : mapreduce(idx -> string(idx), *, idcs)
+            indexing = mapfoldl(string, *, idcs, init = "")
             varname = Turing.VarName(vi, Symbol(csym_str), sym, indexing)
 
             $(variable), _lp = Turing.assume(
@@ -113,13 +108,17 @@ Example:
 ```
 """
 macro ~(left, right)
+    return tilde(left, right)
+end
+
+function tilde(left, right)
     return generate_observe(left, right)
 end
 
-macro ~(left::Symbol, right)
+function tilde(left::Symbol, right)
     # Check if left-hand side is a observation.
     if left in Turing._compiler_[:args]
-        if ~(left in Turing._compiler_[:dvars])
+        if !(left in Turing._compiler_[:dvars])
             @info " Observe - `$(left)` is an observation"
             push!(Turing._compiler_[:dvars], left)
         end
@@ -127,7 +126,7 @@ macro ~(left::Symbol, right)
         return generate_observe(left, right)
     else
         # Assume it is a parameter.
-        if ~(left in Turing._compiler_[:pvars])
+        if !(left in Turing._compiler_[:pvars])
             msg = " Assume - `$(left)` is a parameter"
             if isdefined(Main, left)
                 msg  *= " (ignoring `$(left)` found in global scope)"
@@ -138,26 +137,26 @@ macro ~(left::Symbol, right)
         end
 
         sym, idcs, csym = @VarName(left)
-        csym = Symbol(string(Turing._compiler_[:name])*string(csym))
+        csym = Symbol(Turing._compiler_[:name], csym)
         syms = Symbol[csym, left]
 
         return generate_assume(left, right, syms)
     end
 end
 
-macro ~(left::Expr, right)
+function tilde(left::Expr, right)
     vsym = getvsym(left)
     @assert isa(vsym, Symbol)
 
     if vsym in Turing._compiler_[:args]
-        if ~(vsym in Turing._compiler_[:dvars])
+        if !(vsym in Turing._compiler_[:dvars])
             @info " Observe - `$(vsym)` is an observation"
             push!(Turing._compiler_[:dvars], vsym)
         end
 
         return generate_observe(left, right)
     else
-        if ~(vsym in Turing._compiler_[:pvars])
+        if !(vsym in Turing._compiler_[:pvars])
             msg = " Assume - `$(vsym)` is a parameter"
             if isdefined(Main, vsym)
                 msg  *= " (ignoring `$(vsym)` found in global scope)"
@@ -219,8 +218,8 @@ macro model(fexpr)
     # extract model name (:name), arguments (:args), (:kwargs) and definition (:body)
     modeldef = MacroTools.splitdef(fexpr)
 
-    lines = length(filter(l -> !isa(l, LineNumberNode), modeldef[:body].args))
-    if lines < 1 # function body of the model is empty
+    # function body of the model is empty
+    if all(l -> isa(l, LineNumberNode), modeldef[:body].args)
         @warn("Model definition seems empty, still continue.")
     end
 
@@ -234,10 +233,6 @@ macro model(fexpr)
         :pvars => Set{Symbol}()
     )
 
-    # Initialise logp in VarInfo.
-    body = modeldef[:body]
-    pushfirst!(body.args, :(vi.logp = zero(Real)))
-
     # Manipulate the function arguments.
     fargs = deepcopy(vcat(modeldef[:args], modeldef[:kwargs]))
     for i in 1:length(fargs)
@@ -246,27 +241,19 @@ macro model(fexpr)
         end
     end
 
-    # Construct user function.
-    fdefn = Dict(
-        :name => compiler[:name],
-        :kwargs => [Expr(:kw, :compiler, compiler)],
-        :args => fargs,
-        :body => Expr(:return, compiler[:closure_name])
-    )
-
-    modelfun = MacroTools.combinedef(fdefn)
-
     # Construct closure.
-    closure_def = Dict(
-        :name => compiler[:closure_name],
-        :kwargs => [],
-        :args => [
-            :(vi::Turing.VarInfo),
-            :(sampler::Turing.AnySampler)
-        ],
-        :body => body
+    closure = MacroTools.combinedef(
+        Dict(
+            :name => compiler[:closure_name],
+            :kwargs => [],
+            :args => [
+                :(vi::Turing.VarInfo),
+                :(sampler::Turing.AnySampler)
+            ],
+            # Initialise logp in VarInfo.
+            :body => Expr(:block, :(vi.logp = zero(Real)), modeldef[:body].args...)
+        )
     )
-    closure = MacroTools.combinedef(closure_def)
 
     # Construct aliases.
     alias1 = MacroTools.combinedef(
@@ -297,58 +284,41 @@ macro model(fexpr)
     )
 
     # Add definitions to the compiler.
-    compiler[:alias3] = alias3
-    compiler[:alias2] = alias2
-    compiler[:alias1] = alias1
     compiler[:closure] = closure
+    compiler[:alias1] = alias1
+    compiler[:alias2] = alias2
+    compiler[:alias3] = alias3
 
-    # Add function definitions.
-    pushfirst!(modelfun.args[2].args, :(Main.eval(alias3)))
-    pushfirst!(modelfun.args[2].args, :(Main.eval(alias2)))
-    pushfirst!(modelfun.args[2].args, :(Main.eval(alias1)))
-    pushfirst!(modelfun.args[2].args, :(Main.eval( Expr(:(=), modelname, closure) )))
-
-    # Insert argument values as kwargs to the closure.
-    for k in fargs
-        if isa(k, Symbol)
-            _k = k
-        elseif k.head == :kw
-            _k = k.args[1]
-        else
-            _k = nothing
-        end
-
-        if _k != nothing
-            _k_str = string(_k)
-            data_insertion = quote
-                if $_k == nothing
-                    # Notify the user if an argument is missing.
-                    @warn("Data `"*$_k_str*"` not provided, treating as parameter instead.")
-                else
-                    if Symbol($_k_str) ∉ Turing._compiler_[:args]
-                        push!(Turing._compiler_[:args], Symbol($_k_str))
-                    end
-                    closure = Turing.setkwargs(closure, Symbol($_k_str), $_k)
-                end
-            end
-            pushfirst!(modelfun.args[2].args, data_insertion)
-        end
-    end
-
-    pushfirst!(
-        modelfun.args[2].args,  # Body of modelfun.
-        quote
-            Turing.eval(:(_compiler_ = deepcopy($compiler)))
-
-            # Copy the expr of function definition and callbacks.
-            alias3 = Turing._compiler_[:alias3]
-            alias2 = Turing._compiler_[:alias2]
-            alias1 = Turing._compiler_[:alias1]
-            closure = Turing._compiler_[:closure]
-            modelname = Turing._compiler_[:closure_name]
-        end
+    # Construct user function.
+    modelfun = MacroTools.combinedef(
+        Dict(
+            :name => compiler[:name],
+            :kwargs => [Expr(:kw, :compiler, compiler)],
+            :args => fargs,
+            :body => Expr(:block, 
+                            quote
+                                Turing.eval(:(_compiler_ = deepcopy($compiler)))
+                                # Copy the expr of function definition and callbacks
+                                closure = Turing._compiler_[:closure]
+                                alias1 = Turing._compiler_[:alias1]
+                                alias2 = Turing._compiler_[:alias2]
+                                alias3 = Turing._compiler_[:alias3]
+                                modelname = Turing._compiler_[:closure_name]
+                            end,
+                            # Insert argument values as kwargs to the closure
+                            map(data_insertion, fargs)...,
+                            # Eval the closure's methods globally and return it
+                            quote
+                                Main.eval(Expr(:(=), modelname, closure))
+                                Main.eval(alias1)
+                                Main.eval(alias2)
+                                Main.eval(alias3)
+                                return $(compiler[:closure_name])
+                            end,
+                        )
+        )
     )
-
+    
     return esc(modelfun)
 end
 
@@ -357,16 +327,35 @@ end
 # Helper functions #
 ####################
 
-function setkwargs(fexpr::Expr, kw::Symbol, value)
+function insertvi(x)
+    return @capture(x, return _) ? Expr(:block, :(vi.logp = _lp), x) : x
+end    
 
+function data_insertion(k)
+        if isa(k, Symbol)
+            _k = k
+        elseif k.head == :kw
+            _k = k.args[1]
+        else
+        return :()
+        end
+
+    return  quote
+                if $_k == nothing
+                    # Notify the user if an argument is missing.
+                    @warn("Data `"*$(string(_k))*"` not provided, treating as parameter instead.")
+                else
+                    if $(QuoteNode(_k)) ∉ Turing._compiler_[:args]
+                        push!(Turing._compiler_[:args], $(QuoteNode(_k)))
+                    end
+                    closure = Turing.setkwargs(closure, $(QuoteNode(_k)), $_k)
+                end
+            end
+end
+
+function setkwargs(fexpr::Expr, kw::Symbol, value)
     # Split up the function definition.
     funcdef = MacroTools.splitdef(fexpr)
-
-    function insertvi(x)
-        return @capture(x, return _) ? Expr(:block, :(vi.logp = _lp), x) : x
-    end
-
-    expr_new = MacroTools.postwalk(x->insertvi(x), funcdef[:body])
 
     # Add the new keyword argument.
     push!(funcdef[:kwargs], Expr(:kw, kw, value))
@@ -378,11 +367,7 @@ end
 getvsym(s::Symbol) = s
 function getvsym(expr::Expr)
     @assert expr.head == :ref "expr needs to be an indexing expression, e.g. :(x[1])"
-    curr = expr
-    while isa(curr, Expr) && curr.head == :ref
-        curr = curr.args[1]
-    end
-    return curr
+    return getvsym(expr.args[1])
 end
 
 translate!(ex::Any) = ex

--- a/src/core/compiler.jl
+++ b/src/core/compiler.jl
@@ -20,7 +20,7 @@ macro VarName(expr::Union{Expr, Symbol})
             end
         ex = ex.args[1]
         isa(ex, Symbol) && return var_tuple(ex, inds)
-        end
+    end
     throw("VarName: Mis-formed variable name $(expr)!")
 end
 function var_tuple(sym::Symbol, inds::Expr=:(()))
@@ -326,10 +326,6 @@ end
 ####################
 # Helper functions #
 ####################
-
-function insertvi(x)
-    return @capture(x, return _) ? Expr(:block, :(vi.logp = _lp), x) : x
-end    
 
 function data_insertion(k)
         if isa(k, Symbol)


### PR DESCRIPTION
Improves the readability of the compiler, especially the `@model` macro and fixes some latent bugs, e.g. `mapreduce` -> `mapfoldl`. Also removes the no-op line https://github.com/TuringLang/Turing.jl/blob/ffb6e982f20dc11920eb051ad0b04fafdb5b91d0/src/core/compiler.jl#L369.
