### PR TITLE
Reexport Stan and automatically download cmdstan when building Turing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ docs/build/
 docs/site/
 docs/build/
 .DS_Store
+
+src/cmdstan_home.jl
+cmdstan/

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -3,7 +3,7 @@ using Pkg
 if !haskey(ENV, "CMDSTAN_HOME") || ENV["CMDSTAN_HOME"] == ""
     # Make the cmdstan home directory
 
-    CMDSTAN = joinpath(@__DIR__, "..", "cmdstan", )
+    CMDSTAN = abspath(joinpath(@__DIR__, "..", "cmdstan", ))
     if !ispath(CMDSTAN)
         mkdir(CMDSTAN)
     end
@@ -30,5 +30,11 @@ if !haskey(ENV, "CMDSTAN_HOME") || ENV["CMDSTAN_HOME"] == ""
 
     # Wrie the src file that sets ENV["CMDSTAN_HOME"]
 
-    write(joinpath("..", "src", "cmdstan_home.jl"), "ENV[\"CMDSTAN_HOME\"] = $cmdstan_home")
+    write(joinpath("..", "src", "cmdstan_home.jl"), "cmdstan_home() = \"$(replace(cmdstan_home, "\\"=>"\\\\"))\"")
+else
+    cmdstan_home_path = joinpath("..", "src", "cmdstan_home.jl")
+    if ispath(cmdstan_home_path)
+        rm(cmdstan_home_path)
+    end
+    write(joinpath("..", "src", "cmdstan_home.jl"), "cmdstan_home() = $(ENV["CMDSTAN_HOME"])")
 end

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,0 +1,34 @@
+using Pkg
+
+if !haskey(ENV, "CMDSTAN_HOME") || ENV["CMDSTAN_HOME"] == ""
+    # Make the cmdstan home directory
+
+    CMDSTAN = joinpath(@__DIR__, "..", "cmdstan", )
+    if !ispath(CMDSTAN)
+        mkdir(CMDSTAN)
+    end
+
+    # Get cmdstan and uncompress it from its url in deps/cmdstan_url.txt
+
+    cmdstan_url = strip(String(read("cmdstan_url.txt")))
+    compressed = splitdir(cmdstan_url)[2]
+    dirname = splitext(compressed)[1]
+    cmdstan_home = joinpath(CMDSTAN, dirname)
+    current_dir = pwd()
+    cd(CMDSTAN)
+    if !ispath(compressed)
+        Pkg.add("HTTP")
+        import HTTP
+        compressedfile = HTTP.get(cmdstan_url)
+        write(compressed, compressedfile.body)
+    end
+    Pkg.add(["ZipFile", "InfoZIP"])
+    import InfoZIP
+    InfoZIP.unzip(compressed, CMDSTAN)
+    cd(current_dir)
+    println("CMDStan is installed at path: $cmdstan_home")
+
+    # Wrie the src file that sets ENV["CMDSTAN_HOME"]
+
+    write(joinpath("..", "src", "cmdstan_home.jl"), "ENV[\"CMDSTAN_HOME\"] = $cmdstan_home")
+end

--- a/deps/cmdstan_url.txt
+++ b/deps/cmdstan_url.txt
@@ -1,0 +1,1 @@
+https://github.com/stan-dev/cmdstan/releases/download/v2.18.0/cmdstan-2.18.0.zip

--- a/src/Turing.jl
+++ b/src/Turing.jl
@@ -22,7 +22,10 @@ using Libtask
 using MacroTools
 
 #  @init @require Stan="682df890-35be-576f-97d0-3d8c8b33a550" begin
-using Stan
+if (!haskey(ENV, "CMDSTAN_HOME") || ENV["CMDSTAN_HOME"] == "") && ispath(joinpath(@__DIR__, "cmdstan_home.jl"))
+    include("cmdstan_home.jl")
+end
+@reexport using Stan
 import Stan: Adapt, Hmc
 #  end
 import Base: ~, convert, promote_rule, rand, getindex, setindex!
@@ -36,31 +39,31 @@ import MCMCChain: AbstractChains, Chains
 ##############################
 
 const ADBACKEND = Ref(:reverse_diff)
-setadbackend(backend_sym) = begin
-  @assert backend_sym == :forward_diff || backend_sym == :reverse_diff
-  backend_sym == :forward_diff && CHUNKSIZE[] == 0 && setchunksize(40)
-  ADBACKEND[] = backend_sym
+function setadbackend(backend_sym)
+    @assert backend_sym == :forward_diff || backend_sym == :reverse_diff
+    backend_sym == :forward_diff && CHUNKSIZE[] == 0 && setchunksize(40)
+    ADBACKEND[] = backend_sym
 end
 
 const ADSAFE = Ref(false)
-setadsafe(switch::Bool) = begin
-  @info("[Turing]: global ADSAFE is set as $switch")
-  ADSAFE[] = switch
+function setadsafe(switch::Bool)
+    @info("[Turing]: global ADSAFE is set as $switch")
+    ADSAFE[] = switch
 end
 
 const CHUNKSIZE = Ref(40) # default chunksize used by AD
 
-setchunksize(chunk_size::Int) = begin
-  if ~(CHUNKSIZE[] == chunk_size)
-    @info("[Turing]: AD chunk size is set as $chunk_size")
-    CHUNKSIZE[] = chunk_size
-  end
+function setchunksize(chunk_size::Int)
+    if ~(CHUNKSIZE[] == chunk_size)
+        @info("[Turing]: AD chunk size is set as $chunk_size")
+        CHUNKSIZE[] = chunk_size
+    end
 end
 
 const PROGRESS = Ref(true)
-turnprogress(switch::Bool) = begin
-  @info("[Turing]: global PROGRESS is set as $switch")
-  PROGRESS[] = switch
+function turnprogress(switch::Bool)
+    @info("[Turing]: global PROGRESS is set as $switch")
+    PROGRESS[] = switch
 end
 
 # Constants for caching
@@ -88,8 +91,8 @@ Turing translates models to chunks that call the modelling functions at specifie
 then include that file at the end of this one.
 """
 mutable struct Sampler{T<:InferenceAlgorithm} <: AbstractSampler
-  alg   ::  T
-  info  ::  Dict{Symbol, Any}         # sampler infomation
+    alg   ::  T
+    info  ::  Dict{Symbol, Any}         # sampler infomation
 end
 
 """
@@ -131,8 +134,6 @@ export consume, produce
 
 # Turing-safe data structures and associated functions
 export TArray, tzeros, localcopy, IArray
-
-export @sym_str
 
 export Flat, FlatPos
 

--- a/src/Turing.jl
+++ b/src/Turing.jl
@@ -11,6 +11,10 @@ module Turing
 using Requires
 using Reexport
 @reexport using Distributions
+#  @init @require Stan="682df890-35be-576f-97d0-3d8c8b33a550" begin
+import Stan: Adapt, Hmc
+@reexport using Stan
+#  end
 @reexport using MCMCChain
 using ForwardDiff
 using StatsFuns
@@ -21,13 +25,6 @@ using Markdown
 using Libtask
 using MacroTools
 
-#  @init @require Stan="682df890-35be-576f-97d0-3d8c8b33a550" begin
-if (!haskey(ENV, "CMDSTAN_HOME") || ENV["CMDSTAN_HOME"] == "") && ispath(joinpath(@__DIR__, "cmdstan_home.jl"))
-    include("cmdstan_home.jl")
-end
-@reexport using Stan
-import Stan: Adapt, Hmc
-#  end
 import Base: ~, convert, promote_rule, rand, getindex, setindex!
 import Distributions: sample
 import ForwardDiff: gradient
@@ -141,6 +138,7 @@ export Flat, FlatPos
 # Inference code #
 ##################
 
+include("cmdstan_home.jl")      # cmdstan home folder
 include("core/compiler.jl")     # compiler
 include("core/container.jl")    # particle container
 include("samplers/sampler.jl")  # samplers


### PR DESCRIPTION
This PR automatically downloads and uncompresses `cmdstan` when Turing is built if `cmdstan`'s path does not exist already in `ENV["CMDSTAN_HOME"]`. It also reexports `Stan`. The function `Turing.cmdstan_home()` returns the path of the internal `cmdstan`. I tried defining it in Stan, but I think it must be defined in Main using `set_cmdstan_home!(Turing.cmdstan_home())`.

We can control which version of `cmdstan` to automatically download by setting the url to the zip file in https://github.com/mohamed82008/Turing.jl/blob/cmdstan/deps/cmdstan_url.txt. On the downside, this will slow down Travis and AppVeyor since `cmdstan` will be downloaded every time. To work around this, I can add `ENV["CMDSTAN_HOME"] = "_"` in the AppVeyor and Travis scripts to avoid setting up `cmdstan` every time.

This script was going to go in `TuringBenchmarks` initially but then I thought `Turing.jl` might be a more suitable place for it. I tried to think of a good reason not to setup cmdstan automatically with fresh installs, but I couldn't find any hence this PR. Please let me know if you think otherwise.