### PR TITLE
Use StatsBase instead of Stats

### DIFF
--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,3 +1,3 @@
 UnicodePlots
-Stats
+StatsBase
 StatsFuns 0.7.0

--- a/test/geweke.jl
+++ b/test/geweke.jl
@@ -1,4 +1,4 @@
-using Stats, Turing
+using StatsBase, Turing
 using Gadfly
 
 # include("ASCIIPlot.jl")

--- a/test/hmcda.jl/hmcda_geweke.jl
+++ b/test/hmcda.jl/hmcda_geweke.jl
@@ -1,4 +1,4 @@
-using Stats, Turing
+using StatsBase, Turing
 using Gadfly
 
 # include("ASCIIPlot.jl")

--- a/test/nuts.jl/nuts_geweke.jl
+++ b/test/nuts.jl/nuts_geweke.jl
@@ -1,4 +1,4 @@
-using Stats, Turing
+using StatsBase, Turing
 using Gadfly
 
 # include("ASCIIPlot.jl")


### PR DESCRIPTION
Stats is a meta-package which in its current form simply reexports StatsBase, 
and which does not support Julia 1.0 for now.

See https://github.com/JuliaStats/Stats.jl/pull/7.