### PR TITLE
Changed using Flux: Tracker to using Flux.Tracker

### DIFF
--- a/src/Turing.jl
+++ b/src/Turing.jl
@@ -29,7 +29,7 @@ end
 import Base: ~, convert, promote_rule, rand, getindex, setindex!
 import Distributions: sample
 import ForwardDiff: gradient
-using Flux: Tracker
+using Flux.Tracker
 import MCMCChain: AbstractChains, Chains
 @init @require DynamicHMC="bbc10e6e-7c05-544b-b16e-64fede858acb" @eval begin
     using DynamicHMC, LogDensityProblems


### PR DESCRIPTION
This is possibly a pull request to fix #583, which appears to be a deprecation problem.

Currently we import `Flux.Tracker` like this:

```julia
using Flux: Tracker
```

When according to [this](https://github.com/JuliaLang/julia/issues/8000) it should be:

```julia
using Flux.Tracker
```

I wanted to open up a pull request here just to make sure I'm correct here. Thoughts?