### PR TITLE
Compiler assertions according to issue #575

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ script:
              else
                 println("Unknown test command.")
              end'
-  - julia -e 'using Pkg; Pkg.add("Documenter")'
+  - julia -e 'using Pkg; Pkg.add("Documenter"), Pkg.add("DocumenterMarkdown")'
   - julia -e 'using Pkg, Turing;
               cd(joinpath(dirname(pathof(Turing)), ".."));
               include(joinpath("docs", "make.jl"))'

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,4 @@
-using Documenter, Turing
+using Documenter, DocumenterMarkdown, Turing
 using LibGit2: clone
 
 # Include the update_homepage function.
@@ -38,6 +38,8 @@ if !in("no-tutorials", ARGS)
     finally
         rm(tmp_path, recursive = true)
     end
+else
+    @info "Skipping tutorial copying."
 end
 
 # Preprocess markdown files.
@@ -48,7 +50,9 @@ yaml_dict = preprocess_markdown(source_path)
 # Build documentation
 try
     makedocs(
-        build = build_relative
+        sitename = "Turing.jl",
+        build = build_relative,
+        format = :markdown
     )
 catch e
     # Put back the original files in the event of an error.
@@ -69,6 +73,8 @@ if !in("no-publish", ARGS)
         "gh-pages",
         "site"
     )
+else
+    @info "Skipping publishing."
 end
 
 # # Deploy documentation.

--- a/test/compiler.jl/model_macro.jl
+++ b/test/compiler.jl/model_macro.jl
@@ -73,3 +73,17 @@ f01_mm = testmodel01()
 end
 f1_mm = testmodel1(1., 10.)
 @test f1_mm() == (1, 10)
+
+# Test for assertions.
+@model brokentestmodel(x1, x2) = begin
+    s ~ InverseGamma(2,3)
+    m ~ Normal(0,sqrt(s))
+
+    x1 ~ Normal(m, sqrt(s))
+    x2 ~ x1 + 2
+
+    return x1, x2
+end
+
+btest = brokentestmodel(1., 2.)
+@test_throws ArgumentError btest()

--- a/test/compiler.jl/model_macro.jl
+++ b/test/compiler.jl/model_macro.jl
@@ -74,8 +74,8 @@ end
 f1_mm = testmodel1(1., 10.)
 @test f1_mm() == (1, 10)
 
-# Test for assertions.
-@model brokentestmodel(x1, x2) = begin
+# Test for assertions in observe statements.
+@model brokentestmodel_observe1(x1, x2) = begin
     s ~ InverseGamma(2,3)
     m ~ Normal(0,sqrt(s))
 
@@ -85,5 +85,45 @@ f1_mm = testmodel1(1., 10.)
     return x1, x2
 end
 
-btest = brokentestmodel(1., 2.)
+btest = brokentestmodel_observe1(1., 2.)
+@test_throws ArgumentError btest()
+
+@model brokentestmodel_observe2(x) = begin
+    s ~ InverseGamma(2,3)
+    m ~ Normal(0,sqrt(s))
+
+    x = Vector{Float64}(undef, 2)
+    x ~ [Normal(m, sqrt(s)), 2.0]
+
+    return x
+end
+
+btest = brokentestmodel_observe2([1., 2.])
+@test_throws ArgumentError btest()
+
+# Test for assertions in assume statements.
+@model brokentestmodel_assume1() = begin
+    s ~ InverseGamma(2,3)
+    m ~ Normal(0,sqrt(s))
+
+    x1 ~ Normal(m, sqrt(s))
+    x2 ~ x1 + 2
+
+    return x1, x2
+end
+
+btest = brokentestmodel_assume1()
+@test_throws ArgumentError btest()
+
+@model brokentestmodel_assume2() = begin
+    s ~ InverseGamma(2,3)
+    m ~ Normal(0,sqrt(s))
+
+    x = Vector{Float64}(undef, 2)
+    x ~ [Normal(m, sqrt(s)), 2.0]
+
+    return x
+end
+
+btest = brokentestmodel_assume2()
 @test_throws ArgumentError btest()


### PR DESCRIPTION
This PR implements some simple assertions to allow for meaningful erroring of the compiler if the right-hand side of a tilde operant is not a Distribution or a Vector of Distributions.