### PR TITLE
Switch to nbviewer and fix broken link

### DIFF
--- a/docs/site/_tutorials/tutorials-index.md
+++ b/docs/site/_tutorials/tutorials-index.md
@@ -10,7 +10,7 @@ A list of all the tutorials available can be found to the right. The [introducti
 
 Tutorials are under continuous development, but there are some older version available at the TuringTutorials within the [`old-notebooks`](https://github.com/TuringLang/TuringTutorialstree/master/old-notebooks/) section. Some of these were built using prior versions of Turing and may not function correctly, but they can assist in the syntax used for common models.
 
-- [Gaussian Mixture Model](https://github.com/TuringLang/TuringTutorials/tree/master/old-notebooks/GMM.ipynb)
-- [Bayesian Hidden Markov Model](https://github.com/TuringLang/TuringTutorials/tree/master/old-notebooks/BayesHmm.ipynb)
-- [Factorical Hidden Markov Model](https://github.com/TuringLang/TuringTutorials/tree/master/old-notebooks/FHMM.ipynb)
-- [Topic Models: LDA and MoC](https://github.com/TuringLang/TuringTutorials/tree/master/old-notebooks/TopicModels.ipynb)
+- [Gaussian Mixture Model](https://nbviewer.jupyter.org/github/TuringLang/TuringTutorials/tree/master/old-notebooks/GMM.ipynb)
+- [Bayesian Hidden Markov Model](https://nbviewer.jupyter.org/github/TuringLang/TuringTutorials/tree/master/old-notebooks/BayesHmm.ipynb)
+- [Factorical Hidden Markov Model](https://nbviewer.jupyter.org/github/TuringLang/TuringTutorials/tree/master/old-notebooks/FHMM.ipynb)
+- [Topic Models: LDA and MoC](https://nbviewer.jupyter.org/github/TuringLang/TuringTutorials/tree/master/old-notebooks/TopicModels.ipynb)

--- a/docs/src/quick-start.md
+++ b/docs/src/quick-start.md
@@ -7,7 +7,7 @@ If you are already well-versed in probabalistic programming and just want to tak
 
 This example can be run on however you have Julia installed (see [Getting Started](get-started.md)), but you will need to install the packages `Turing`, `Distributions`, `MCMCChain`, and `StatPlots` if you have not done so already.
 
-This is an excerpt from a more formal example introducing probabalistic programming which can be found in Jupyter notebook form [here](https://github.com/TuringLang/TuringTutorials/blob/master/0_Introduction.ipynb) or as part of the documentation website [here](0_Introduction.md).
+This is an excerpt from a more formal example introducing probabalistic programming which can be found in Jupyter notebook form [here](https://nbviewer.jupyter.org/github/TuringLang/TuringTutorials/blob/master/0_Introduction.ipynb) or as part of the documentation website [here](../../tutorials/0-introduction/).
 
 ```julia
 # Import libraries.


### PR DESCRIPTION
I think it might be preferable to link to nbviewer.jupyter.org instead of Github (e.g. on my mobile browser Github displays only raw text files of notebooks). Moreover, I discovered a broken link in the documentation.