### PR TITLE
Stan -> CmdStan

### DIFF
--- a/src/Turing.jl
+++ b/src/Turing.jl
@@ -23,9 +23,9 @@ using Libtask
 using MacroTools
 
 function __init__()
-    @require Stan="682df890-35be-576f-97d0-3d8c8b33a550" @eval begin
-        using Stan
-        import Stan: Adapt, Hmc
+    @require CmdStan="593b3428-ca2f-500c-ae53-031589ec8ddd" @eval begin
+        using CmdStan
+        import CmdStan: Adapt, Hmc
     end
 
     @require DynamicHMC="bbc10e6e-7c05-544b-b16e-64fede858acb" @eval begin
@@ -120,7 +120,7 @@ struct SampleFromPrior <: AbstractSampler end
 const AnySampler = Union{Nothing, AbstractSampler}
 
 include("utilities/resample.jl")
-@static if isdefined(Turing, :Stan)
+@static if isdefined(Turing, :CmdStan)
     include("utilities/stan-interface.jl")
 end
 include("utilities/helper.jl")

--- a/src/samplers/hmc.jl
+++ b/src/samplers/hmc.jl
@@ -53,8 +53,8 @@ DEFAULT_ADAPT_CONF_TYPE = Nothing
 STAN_DEFAULT_ADAPT_CONF = nothing
 
 @static if isdefined(Turing, :Stan)
-    DEFAULT_ADAPT_CONF_TYPE = Union{DEFAULT_ADAPT_CONF_TYPE, Stan.Adapt}
-    STAN_DEFAULT_ADAPT_CONF = Stan.Adapt()
+    DEFAULT_ADAPT_CONF_TYPE = Union{DEFAULT_ADAPT_CONF_TYPE, CmdStan.Adapt}
+    STAN_DEFAULT_ADAPT_CONF = CmdStan.Adapt()
 end
 
 # NOTE: the implementation of HMC is removed,

--- a/src/samplers/support/adapt.jl
+++ b/src/samplers/support/adapt.jl
@@ -56,8 +56,8 @@ function init_warm_up_params(vi::VarInfo, spl::Sampler{<:Hamiltonian})
     wum[:δ] = spl.alg.delta
 
     # Initialize by Stan if Stan is installed
-    @static if isdefined(Turing, :Stan)
-        # Stan.Adapt
+    @static if isdefined(Turing, :CmdStan)
+        #CmdStan.Adapt
         adapt_conf = spl.info[:adapt_conf]
 
         # Hyper parameters for dual averaging

--- a/src/utilities/stan-interface.jl
+++ b/src/utilities/stan-interface.jl
@@ -1,36 +1,36 @@
 # NOTE:
 #   Type fields
-#     fieldnames(Stan.Sample)
+#     fieldnames(CmdStan.Sample)
 #       num_samples, num_warmup, save_warmup, thin, adapt, algorithm
 
-#     fieldnames(Stan.Hmc)
+#     fieldnames(CmdStan.Hmc)
 #       engine, metric, stepsize, stepsize_jitter
 
-#     fieldnames(Stan.Adapt)
+#     fieldnames(CmdStan.Adapt)
 #       engaged, gamma, delta, kappa, t0, init_buffer, term_buffer, window
 
 #   Ref
 #     http://goedman.github.io/Stan.jl/latest/index.html#Types-1
-sample(mf::T, ss::Stan.Sample) where {T<:Function} = sample(mf, ss.num_samples, ss.num_warmup, ss.save_warmup, ss.thin, ss.adapt, ss.alg)
-sample(mf::T, num_samples::Int, num_warmup::Int, save_warmup::Bool, thin::Int, ss::Stan.Sample) where{T<:Function} =
+sample(mf::T, ss::CmdStan.Sample) where {T<:Function} = sample(mf, ss.num_samples, ss.num_warmup, ss.save_warmup, ss.thin, ss.adapt, ss.alg)
+sample(mf::T, num_samples::Int, num_warmup::Int, save_warmup::Bool, thin::Int, ss::CmdStan.Sample) where{T<:Function} =
   sample(mf, num_samples, num_warmup, save_warmup, thin, ss.adapt, ss.alg)
 
-sample(mf::T, num_samples::Int, num_warmup::Int, save_warmup::Bool, thin::Int, adapt::Stan.Adapt, alg::Stan.Hmc) where {T<:Function} = begin
+sample(mf::T, num_samples::Int, num_warmup::Int, save_warmup::Bool, thin::Int, adapt::CmdStan.Adapt, alg::CmdStan.Hmc) where {T<:Function} = begin
   if alg.stepsize_jitter != 0
     error("[Turing.sample] Turing does not support adding noise to stepsize yet.")
   end
   if adapt.engaged == false
-    if isa(alg.engine, Stan.Static)   # hmc
+    if isa(alg.engine, CmdStan.Static)   # hmc
       stepnum = Int(round(alg.engine.int_time / alg.stepsize))
       sample(mf, HMC(num_samples, alg.stepsize, stepnum); adapt_conf=adapt)
-    elseif isa(alg.engine, Stan.Nuts) # error
-      error("[Turing.sample] Stan.Nuts cannot be used with adapt.engaged set as false")
+    elseif isa(alg.engine, CmdStan.Nuts) # error
+      error("[Turing.sample] CmdStan.Nuts cannot be used with adapt.engaged set as false")
     end
   else
-    if isa(alg.engine, Stan.Static)   # hmcda
+    if isa(alg.engine, CmdStan.Static)   # hmcda
       sample(mf, HMCDA(num_samples, num_warmup, adapt.delta, alg.engine.int_time); adapt_conf=adapt)
-    elseif isa(alg.engine, Stan.Nuts) # nuts
-      if alg.metric == Stan.dense_e
+    elseif isa(alg.engine, CmdStan.Nuts) # nuts
+      if alg.metric == CmdStan.dense_e
         sample(mf, NUTS(num_samples, num_warmup, adapt.delta); adapt_conf=adapt)
       else
         error("[Turing.sample] Turing does not support full covariance matrix for pre-conditioning yet.")

--- a/test/stan-interface.jl/stan-interface.jl
+++ b/test/stan-interface.jl/stan-interface.jl
@@ -1,4 +1,4 @@
-using Stan, Turing 
+using CmdStan, Turing 
 
 @model gdemo(x) = begin
   s ~ InverseGamma(2,3)
@@ -10,4 +10,4 @@ end
 
 model_f = gdemo([1.5, 2.0])
 
-chn = sample(model_f, 2000, 1000, false, 1, Stan.Adapt(), Stan.Hmc())
+chn = sample(model_f, 2000, 1000, false, 1, CmdStan.Adapt(), CmdStan.Hmc())


### PR DESCRIPTION
Stan.jl has been deprecated in favour of CmdStan.jl. This PR uses CmdStan.jl when available, much like how we used Stan.jl.