### PR TITLE
Update REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.7
+julia 1.0
 
 Requires 0.5.0
 Reexport 0.2.0


### PR DESCRIPTION
https://github.com/JuliaLang/METADATA.jl/pull/19695 failed because it still thinks it should be running on v0.7. This updates the REQUIRE to be v1.0+. The tag should be deleted and re-done with this change.