### PR TITLE
Load Flux and ForwardDiff before Bijectors

### DIFF
--- a/src/Turing.jl
+++ b/src/Turing.jl
@@ -11,9 +11,10 @@ module Turing
 using Requires
 using Reexport
 @reexport using Distributions
+import Flux
+using ForwardDiff
 using Bijectors
 @reexport using MCMCChain
-using ForwardDiff
 using StatsFuns
 using Statistics
 using LinearAlgebra


### PR DESCRIPTION
This PR prepares for Bijectors using Requires.jl to define `_eps` function as explained in  https://github.com/TuringLang/Turing.jl/pull/611. 