### PR TITLE
Enable backprop through poislogpdf

### DIFF
--- a/src/core/ad.jl
+++ b/src/core/ad.jl
@@ -130,7 +130,6 @@ end
 import StatsFuns: poislogpdf
 poislogpdf(v::Tracker.TrackedReal, x::Int) = Tracker.track(poislogpdf, v, x)
 Tracker.@grad function poislogpdf(v::Tracker.TrackedReal, x::Int)
-      println("Called!")
       return poislogpdf(Tracker.data(v), x),
           Δ->(Δ * (x/v - 1), nothing)
 end

--- a/src/core/ad.jl
+++ b/src/core/ad.jl
@@ -125,3 +125,12 @@ Tracker.@grad function binomlogpdf(n::Int, p::Tracker.TrackedReal, x::Int)
     return binomlogpdf(n, Tracker.data(p), x),
         Δ->(nothing, Δ * (x / p - (n - x) / (1 - p)), nothing)
 end
+
+
+import StatsFuns: poislogpdf
+poislogpdf(v::Tracker.TrackedReal, x::Int) = Tracker.track(poislogpdf, v, x)
+Tracker.@grad function poislogpdf(v::Tracker.TrackedReal, x::Int)
+      println("Called!")
+      return poislogpdf(Tracker.data(v), x),
+          Δ->(Δ * (x/v - 1), nothing)
+end

--- a/test/ad.jl/AD_compatibility_with_distributions.jl
+++ b/test/ad.jl/AD_compatibility_with_distributions.jl
@@ -46,3 +46,21 @@ let
         atol=1e-8,
     )
 end
+
+let
+    foo = p->poislogpdf(1, p)
+    @test isapprox(
+        Tracker.gradient(foo, 0.5)[1],
+        central_fdm(5, 1)(foo, 0.5);
+        rtol=1e-8,
+        atol=1e-8,
+    )
+
+    bar = p->logpdf(Poisson(1), 3)
+    @test isapprox(
+        Tracker.gradient(bar, 0.5)[1],
+        central_fdm(5, 1)(bar, 0.5);
+        rtol=1e-8,
+        atol=1e-8,
+    )
+end


### PR DESCRIPTION
Add support for backprop through `poislogpdf`. Please take a look at the tests I've added to make sure they're kosher.