### PR TITLE
Add a DynamicHMC section to the docs

### DIFF
--- a/docs/site/_data/navigation.yml
+++ b/docs/site/_data/navigation.yml
@@ -31,6 +31,8 @@ docs:
         url: /docs/guide/
       - title: "Advanced Usage"
         url: /docs/advanced/
+      - title: "Using DynamicHMC"
+        url: /docs/dynamichmc/
 
   - title: Library
     children:

--- a/docs/src/dynamichmc.md
+++ b/docs/src/dynamichmc.md
@@ -1,0 +1,27 @@
+---
+title: Using DynamicHMC
+permalink: /docs/dynamichmc/
+---
+
+Turing supports the use of [DynamicHMC](https://github.com/tpapp/DynamicHMC.jl) as a sampler through the use of the `DynamicNUTS` function. This is a [faster](https://github.com/TuringLang/Turing.jl/issues/559) version of Turing's native `NUTS` implementation.
+
+To use the `DynamicNUTS` function, you must import the `DynamicHMC` package as well as Turing. Turing does not formally require `DynamicHMC` but will include additional functionality if both packages are present.
+
+Here is a brief example of how to apply `DynamicNUTS`:
+
+```julia
+# Import Turing and DynamicHMC.
+using DynamicHMC, Turing
+
+# Model definition.
+@model gdemo(x, y) = begin
+  s ~ InverseGamma(2,3)
+  m ~ Normal(0,sqrt(s))
+  x ~ Normal(m, sqrt(s))
+  y ~ Normal(m, sqrt(s))
+  return s, m
+end
+
+# Pull 2,000 samples using DynamicNUTS.
+chn = sample(gdemo(1.5, 2.0), DynamicNUTS(2000))
+```

--- a/docs/src/dynamichmc.md
+++ b/docs/src/dynamichmc.md
@@ -5,6 +5,8 @@ permalink: /docs/dynamichmc/
 
 Turing supports the use of [DynamicHMC](https://github.com/tpapp/DynamicHMC.jl) as a sampler through the use of the `DynamicNUTS` function. This is a [faster](https://github.com/TuringLang/Turing.jl/issues/559) version of Turing's native `NUTS` implementation.
 
+`DynamicNUTS` is not appropriate for use in compositional inference. If you intend to use [Gibbs](http://turing.ml/docs/library/#-turinggibbs--type) sampling, you must use Turing's native `NUTS` function.
+
 To use the `DynamicNUTS` function, you must import the `DynamicHMC` package as well as Turing. Turing does not formally require `DynamicHMC` but will include additional functionality if both packages are present.
 
 Here is a brief example of how to apply `DynamicNUTS`:


### PR DESCRIPTION
Given the speed increase you can get from `DynamicNUTS` (see #559), I figured we should let folks know about it a bit more obviously.

This adds a small section to the documentation site about how to use DynamicHMC. If there's any other tips, tricks, or pitfalls that should be added here, let me know and I'll toss them in there.