### PR TITLE
poissonlogpdf Fix for ForwardDiff

### DIFF
--- a/src/core/ad.jl
+++ b/src/core/ad.jl
@@ -133,3 +133,10 @@ Tracker.@grad function poislogpdf(v::Tracker.TrackedReal, x::Int)
       return poislogpdf(Tracker.data(v), x),
           Δ->(Δ * (x/v - 1), nothing)
 end
+
+function poislogpdf(v::ForwardDiff.Dual{T}, x::Int) where {T}
+    FD = ForwardDiff.Dual{T}
+    val = ForwardDiff.value(v)
+    Δ = ForwardDiff.partials(v)
+    return FD(poislogpdf(val, x), Δ * (x/val - 1))
+end


### PR DESCRIPTION
This fixes `poislogpdf` to work with `Dual` numbers. Thanks to @mohamed82008 for doing near everything.