### PR TITLE
Move numerical tests to separate Travis build stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,22 @@ language: julia
 julia: 1.0
 
 jobs:
+  allow_failures:
+    - env: STAGE=numerical
   include:
     - stage: test
       os: linux
       env: STAGE=test
+      script:
+        - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+        - julia --check-bounds=yes -e 'using Pkg;Pkg.update();
+                   Pkg.clone(pwd(), "Turing");
+                   Pkg.build("Turing");
+                   Pkg.test("Turing"; coverage=true)'
+    - stage: numerical
+      allow_failures:
+      os: linux
+      env: STAGE=numerical
       script:
         - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
         - julia --check-bounds=yes -e 'using Pkg;Pkg.update();
@@ -22,7 +34,7 @@ jobs:
         - julia --check-bounds=yes -e 'using Pkg;Pkg.update();
                    Pkg.clone(pwd(), "Turing");
                    Pkg.build("Turing");
-                   Pkg.test("Turing"; coverage=true)'         
+                   Pkg.test("Turing"; coverage=true)'
     - stage: documentation
       if: branch = master
       env: STAGE=documentation

--- a/test/hmc.jl/error_test.jl
+++ b/test/hmc.jl/error_test.jl
@@ -1,4 +1,0 @@
-using Turing
-using Test
-
-@test 1 == 2

--- a/test/hmc.jl/error_test.jl
+++ b/test/hmc.jl/error_test.jl
@@ -1,0 +1,4 @@
+using Turing
+using Test
+
+@test 1 == 2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,7 +11,21 @@ cd(path); include("utility.jl")
 @debug("[runtests.jl] utility.jl loaded")
 @debug("[runtests.jl] testing starts")
 
-# run all tests
-runtests()
+if get(ENV, "TRAVIS", false)
+    # If Travis is testing, separate the tests.
+    numerical_tests = [joinpath("hmc.jl", "matrix_support.jl"),
+                       joinpath("hmc.jl", "error_test.jl")]
+
+    if ENV["STAGE"] == "test"
+        runtests(exclude = numerical_tests)
+    elseif ENV["STAGE"] == "numerical"
+        runtests(specific_tests = numerical_tests)
+    else
+        @warn "Unknown Travis stage, currently set to: $(ENV["STAGE"])"
+    end
+else
+    # Otherwise, test everything.
+    runtests()
+end
 
 @debug("[runtests.jl] all tests finished")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,8 +13,7 @@ cd(path); include("utility.jl")
 
 if get(ENV, "TRAVIS", "false") == "true"
     # If Travis is testing, separate the tests.
-    numerical_tests = [joinpath("hmc.jl", "matrix_support.jl"),
-                       joinpath("hmc.jl", "error_test.jl")]
+    numerical_tests = [joinpath("hmc.jl", "matrix_support.jl")]
 
     if ENV["STAGE"] == "test"
         runtests(exclude = numerical_tests)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,7 +11,7 @@ cd(path); include("utility.jl")
 @debug("[runtests.jl] utility.jl loaded")
 @debug("[runtests.jl] testing starts")
 
-if get(ENV, "TRAVIS", false)
+if get(ENV, "TRAVIS", "false") == "true"
     # If Travis is testing, separate the tests.
     numerical_tests = [joinpath("hmc.jl", "matrix_support.jl"),
                        joinpath("hmc.jl", "error_test.jl")]

--- a/test/utility.jl
+++ b/test/utility.jl
@@ -7,17 +7,17 @@ function check_numerical(
   exact_vals::Vector;
   eps=0.2,
 )
-    for (sym, val) in zip(symbols, exact_vals)
-        E = mean(chain[sym])
-        print("  $sym = $E ≈ $val (eps = $eps) ?")
-        cmp = abs.(sum(mean(chain[sym]) - val)) <= eps
-        if cmp
-            printstyled("./\n", color = :green)
-            printstyled("    $sym = $E, diff = $(abs.(E - val))\n", color = :green)
-        else
-        printstyled(" X\n", color = :red)
-        printstyled("    $sym = $E, diff = $(abs.(E - val))\n", color = :red)
-    end
+	for (sym, val) in zip(symbols, exact_vals)
+		E = mean(chain[sym])
+		print("  $sym = $E ≈ $val (eps = $eps) ?")
+		cmp = abs.(sum(mean(chain[sym]) - val)) <= eps
+		if cmp
+			printstyled("./\n", color = :green)
+			printstyled("    $sym = $E, diff = $(abs.(E - val))\n", color = :green)
+		else
+		printstyled(" X\n", color = :red)
+		printstyled("    $sym = $E, diff = $(abs.(E - val))\n", color = :red)
+	end
   end
 end
 
@@ -28,70 +28,107 @@ Returns a list of files (tests) to skip within a test group.
 """
 function getteststoskip(filepath)
   if isfile(filepath)
-    lines = readlines(filepath)
-    lines = filter(line -> endswith(line, ".jl"), lines)
-    lines = filter(line -> !startswith(line, "#"), lines)
-    lines = filter(line -> length(split(line)) == 1, lines)
-    lines = map(line -> strip(line), lines)
-    return Set{String}(lines)
+	lines = readlines(filepath)
+	lines = filter(line -> endswith(line, ".jl"), lines)
+	lines = filter(line -> !startswith(line, "#"), lines)
+	lines = filter(line -> length(split(line)) == 1, lines)
+	lines = map(line -> strip(line), lines)
+	return Set{String}(lines)
   else
-    return Set{String}()
+	return Set{String}()
   end
 end
 
 function insdelim(c, deli=",")
-    return reduce((e, res) -> append!(e, [res, deli]), c; init = [])[1:end-1]
+	return reduce((e, res) -> append!(e, [res, deli]), c; init = [])[1:end-1]
 end
 
 """
-  runtests(; tests = ["all"])
+  runtests(; test_folders = ["all"], exclude = [])
 
 Run specified Turing tests. By default this function runs all Turing tests.
 The user can specify a list of test sets that she wants to run if necessary.
+Specific files can be excluded by adding paths to the `exclude` argument.
 
 Example:
 ```julia
-runtests(tests = ["util.jl", "trace.jl"])
+runtests(test_folders = ["util.jl", "trace.jl"])
 ```
+
+Excluding a specific file:
+```julia
+runtests(exclude = [joinpath("hmc.jl", "matrix_support.jl"])
+```
+
+Running a specific test:
+```julia
+runtests(specific_tests = [joinpath("hmc.jl", "matrix_support.jl"])
+```
+
+Note that calling `runtests` with a nonzero length `specific_tests` argument
+overwrites all other function arguments.
 """
-function runtests(; tests = ["all"])
+function runtests(; test_folders = ["all"], exclude = [], specific_tests = [])
+	# test groups
+	CORE_TESTS = ["ad.jl", "compiler.jl", "container.jl", "varinfo.jl",
+		# "io.jl",
+		"util.jl"]
+	SAMPLER_TESTS = ["resample.jl", "adapt.jl", "vectorisation.jl", "gibbs.jl", "nuts.jl",
+		"hmcda.jl", "hmc_core.jl", "hmc.jl", "sghmc.jl", "sgld.jl", "is.jl",
+		"mh.jl",
+		# "pmmh.jl", "ipmcmc.jl", "pgibbs.jl", "smc.jl"
+		]
+	TRACE_TESTS = ["trace.jl"]
+	ALL = union(CORE_TESTS, SAMPLER_TESTS, TRACE_TESTS)
 
-  # test groups
-  CORE_TESTS = ["ad.jl", "compiler.jl", "container.jl", "varinfo.jl",
-                # "io.jl",
-                "util.jl"]
-  SAMPLER_TESTS = ["resample.jl", "adapt.jl", "vectorisation.jl", "gibbs.jl", "nuts.jl",
-                   "hmcda.jl", "hmc_core.jl", "hmc.jl", "sghmc.jl", "sgld.jl", "is.jl",
-                   "mh.jl",
-                   # "pmmh.jl", "ipmcmc.jl", "pgibbs.jl", "smc.jl"
-                  ]
-  TRACE_TESTS = ["trace.jl"]
-  ALL = union(CORE_TESTS, SAMPLER_TESTS, TRACE_TESTS)
+	# test groups that should be executed
+	TEST_GROUPS = "all" ∈ test_folders ? ALL : test_folders
 
-  # test groups that should be executed
-  TEST_GROUPS = "all" ∈ tests ? ALL : tests
+	# If we have specific tests, only run those.
+	has_specific_tests = length(specific_tests) > 0
+	if has_specific_tests
+		TEST_GROUPS = []
+		for i in specific_tests
+			push!(TEST_GROUPS, dirname(i))
+		end
+	end
 
-  # Run tests
-  tr = @testset "Turing tests" begin
-    for test_group in TEST_GROUPS
-      teststoskip = getteststoskip(joinpath(test_group, "skip_tests"))
-      @testset "$(test_group)" begin
-        for test in filter(f -> endswith(f, ".jl") && !(f ∈ teststoskip), readdir(test_group))
-          @testset "$(test)" begin
-            include(joinpath(test_group, test))
-          end
-        end
-      end
-    end
-  end
+	# Run tests
+	tr = @testset "Turing tests" begin
+	for test_group in TEST_GROUPS
+		teststoskip = getteststoskip(joinpath(test_group, "skip_tests"))
+			@testset "$(test_group)" begin
+				for test in filter(f -> endswith(f, ".jl")
+					&& !(f ∈ teststoskip), readdir(test_group))
 
-  println()
-  Test.print_test_results(tr)
+					@testset "$(test)" begin
+						test_path = joinpath(test_group, test)
+
+						if has_specific_tests
+							if test_path in specific_tests
+								include(joinpath(test_group, test))
+							end
+						else
+							if test_path in exclude
+								@info "Skipping $test_path."
+							else
+								include(joinpath(test_group, test))
+							end
+						end
+
+					end
+				end
+			end
+		end
+	end
+
+	println()
+	Test.print_test_results(tr)
 end
 
 using Pkg;
 """
-    isinstalled(x::String)
+	isinstalled(x::String)
 Check if a package is installed.
 """
 isinstalled(x::AbstractString) = x ∈ keys(Pkg.installed())

--- a/test/utility.jl
+++ b/test/utility.jl
@@ -89,7 +89,7 @@ function runtests(; test_folders = ["all"], exclude = [], specific_tests = [])
 	if has_specific_tests
 		TEST_GROUPS = []
 		for i in specific_tests
-			TEST_GROUPS = TEST_GROUPS ∪ dirname(i)
+			TEST_GROUPS = TEST_GROUPS ∪ [dirname(i)]
 		end
 	end
 

--- a/test/utility.jl
+++ b/test/utility.jl
@@ -89,7 +89,7 @@ function runtests(; test_folders = ["all"], exclude = [], specific_tests = [])
 	if has_specific_tests
 		TEST_GROUPS = []
 		for i in specific_tests
-			push!(TEST_GROUPS, dirname(i))
+			TEST_GROUPS = TEST_GROUPS ∪ dirname(i)
 		end
 	end
 
@@ -104,10 +104,12 @@ function runtests(; test_folders = ["all"], exclude = [], specific_tests = [])
 					@testset "$(test)" begin
 						test_path = joinpath(test_group, test)
 
+						# If we've got specific tests, examine those.
 						if has_specific_tests
 							if test_path in specific_tests
 								include(joinpath(test_group, test))
 							end
+						# Otherwise look at every file in the folder.
 						else
 							if test_path in exclude
 								@info "Skipping $test_path."


### PR DESCRIPTION
See #631.

The `runtests` function has changed a bit. The keyword `tests` has been changed to `test_folders`, and there are two new keywords:

- `exclude` is an array of specific test files to exclude. 
- `specific_tests` is an array of specific test file to include. This overwrites all the other arguments and only tests the given files.

Currently, the only test treated separately is `hmc.jl/matrix_support.jl`, but this can be quickly updated by changing the `numerical_tests` variable in `runtests.jl`. 