### PR TITLE
Fixed symbol parsing issue

### DIFF
--- a/src/utilities/io.jl
+++ b/src/utilities/io.jl
@@ -45,7 +45,7 @@ function getjuliatype(s::Sample, v::Symbol, cached_syms=nothing)
     # Fill sample
     for i = 1:length(syms)
         # Get indexing
-        idx = Main.eval(parse(idx_comp[i][1]))
+        idx = Main.eval(Meta.parse(idx_comp[i][1]))
         # Determine if nesting
         nested_dim = length(idx_comp[1]) # how many nested layers?
         if nested_dim == 1
@@ -97,12 +97,12 @@ mutable struct Chain{R<:AbstractRange{Int}} <: AbstractChains
 end
 
 function Chain()
-    return Chain{AbstractRange{Int}}( 0.0, 
-                                      Vector{Sample}(), 
-                                      Array{Float64, 3}(undef, 0, 0, 0), 
+    return Chain{AbstractRange{Int}}( 0.0,
+                                      Vector{Sample}(),
+                                      Array{Float64, 3}(undef, 0, 0, 0),
                                       0:0,
-                                      Vector{String}(), 
-                                      Vector{Int}(), 
+                                      Vector{String}(),
+                                      Vector{Int}(),
                                       Dict{Symbol,Any}()
                                     )
 end
@@ -172,7 +172,7 @@ function flatten(names, value :: Array{Float64}, k :: String, v)
     else
         error("Unknown var type: typeof($v)=$(typeof(v))")
     end
-    return 
+    return
 end
 
 function Base.getindex(c::Chain, v::Symbol)

--- a/src/utilities/io.jl
+++ b/src/utilities/io.jl
@@ -13,6 +13,15 @@ end
 
 Base.getindex(s::Sample, v::Symbol) = getjuliatype(s, v)
 
+function parse_inds(inds)
+    p_inds = [parse(Int, m.captures[1]) for m in eachmatch(r"(\d+)", inds)]
+    if length(p_inds) == 1
+        return p_inds[1]
+    else
+        return Tuple(p_inds)
+    end
+end
+
 function getjuliatype(s::Sample, v::Symbol, cached_syms=nothing)
     # NOTE: cached_syms is used to cache the filter entiries in svalue. This is helpful when the dimension of model is huge.
     if cached_syms == nothing
@@ -38,14 +47,14 @@ function getjuliatype(s::Sample, v::Symbol, cached_syms=nothing)
     if dim == 1
         sample = Vector(undef, length(unique(map(c -> c[1], idx_comp))))
     else
-        d = max(map(c -> eval(parse(c[1])), idx_comp)...)
+        d = max(map(c -> parse_inds(c[1]), idx_comp)...)
         sample = Array{Any, length(d)}(undef, d)
     end
 
     # Fill sample
     for i = 1:length(syms)
         # Get indexing
-        idx = Main.eval(Meta.parse(idx_comp[i][1]))
+        idx = parse_inds(idx_comp[i][1])
         # Determine if nesting
         nested_dim = length(idx_comp[1]) # how many nested layers?
         if nested_dim == 1


### PR DESCRIPTION
This fixes a very minor issue noted over in [TuringTutorials](https://github.com/TuringLang/TuringTutorials/issues/20#issuecomment-457509791). The `parse` function was throwing a fit because it was being given a `SubString` to convert into an expression, so I called `Meta.parse` instead. Seems to have done the trick. Anyone see any obvious problems with this fix?

I guess my editor also removed some blank spaces at line endings, so I suppose I've tidied up a bit too.