### PR TITLE
Fix CmdStan adapt dispatch

### DIFF
--- a/src/Turing.jl
+++ b/src/Turing.jl
@@ -92,6 +92,11 @@ using .Inference
         using ..Turing.CmdStan: CmdStan
         DEFAULT_ADAPT_CONF_TYPE = Union{DEFAULT_ADAPT_CONF_TYPE, CmdStan.Adapt}
         STAN_DEFAULT_ADAPT_CONF = CmdStan.Adapt()
+        
+        Sampler(alg::Hamiltonian) =  Sampler(alg, CmdStan.Adapt())
+        function Sampler(alg::Hamiltonian, adapt_conf::CmdStan.Adapt)
+            _sampler(alg::Hamiltonian, adapt_conf)
+        end
         include("inference/adapt/stan.jl")
     end
 end

--- a/src/inference/hmc.jl
+++ b/src/inference/hmc.jl
@@ -81,8 +81,11 @@ end
 DEFAULT_ADAPT_CONF_TYPE = Nothing
 STAN_DEFAULT_ADAPT_CONF = nothing
 
-Sampler(alg::Hamiltonian) =  Sampler(alg, STAN_DEFAULT_ADAPT_CONF::DEFAULT_ADAPT_CONF_TYPE)
-function Sampler(alg::Hamiltonian, adapt_conf::DEFAULT_ADAPT_CONF_TYPE)
+Sampler(alg::Hamiltonian) =  Sampler(alg, nothing)
+function Sampler(alg::Hamiltonian, adapt_conf::Nothing)
+    return _sampler(alg::Hamiltonian, adapt_conf)
+end
+function _sampler(alg::Hamiltonian, adapt_conf)
     info=Dict{Symbol, Any}()
 
     # For state infomation


### PR DESCRIPTION
The dispatch for `Sampler` was not defined properly when `CmdStan` is loaded and was causing StackOverFlow in `TuringBenchmarks`. This solves the problem.