### PR TITLE
Reversed stepsize inequality

### DIFF
--- a/src/inference/adapt/stepsize.jl
+++ b/src/inference/adapt/stepsize.jl
@@ -93,7 +93,7 @@ function adapt_stepsize!(da::DualAveraging, stats::Real)
     if isnan(ϵ) || isinf(ϵ)
         @warn "Incorrect ϵ = $ϵ; ϵ_previous = $(da.state.ϵ) is used instead."
     else
-        ϵ < 5*one(ϵ) && @warn "$ϵ exceeds 5.0; capped to 5.0 for numerical stability"
+        ϵ > 5*one(ϵ) && @warn "$ϵ exceeds 5.0; capped to 5.0 for numerical stability"
         da.state.ϵ = min(5*one(ϵ), ϵ)
     end
     da.state.x_bar = x_bar


### PR DESCRIPTION
I was getting this error running `NUTS(1500, 200, 0.65)` on the [linear regression tutorial model](https://github.com/TuringLang/TuringTutorials/blob/master/5_LinearRegression.ipynb):

```julia
┌ Info: [Turing] looking for good initial eps...
└ @ Turing.Inference /home/cameron/.julia/dev/Turing/src/inference/support/hmc_core.jl:235
[NUTS{Turing.Core.ForwardDiffAD{40},Union{}}] found initial ϵ: 0.1
└ @ Turing.Inference /home/cameron/.julia/dev/Turing/src/inference/support/hmc_core.jl:280
┌ Warning: 1.8285366944616053 exceeds 5.0; capped to 5.0 for numerical stability
└ @ Turing.Inference /home/cameron/.julia/dev/Turing/src/inference/adapt/stepsize.jl:96
┌ Warning: 0.47251339245267954 exceeds 5.0; capped to 5.0 for numerical stability
└ @ Turing.Inference /home/cameron/.julia/dev/Turing/src/inference/adapt/stepsize.jl:96
┌ Warning: 0.07580434088082583 exceeds 5.0; capped to 5.0 for numerical stability
└ @ Turing.Inference /home/cameron/.julia/dev/Turing/src/inference/adapt/stepsize.jl:96
```

According to the error message, it looks like the inequality was just mistyped in the stepsize. I've added the fix in this pull request in the hopes that this is just a quick fix, but could someone sanity check this for me?