### PR TITLE
Fix DiffEqBayes example - wrap model name in QuoteNode for VarName's csym

### DIFF
--- a/src/core/compiler.jl
+++ b/src/core/compiler.jl
@@ -70,14 +70,14 @@ function generate_assume(var::Union{Symbol, Expr}, dist, model_info)
     if var isa Symbol
         varname_expr = quote
             $sym, $idcs, $csym = Turing.@VarName $var
-            $csym = Symbol($(model_info[:name]), $csym)
+            $csym = Symbol($(QuoteNode(model_info[:name])), $csym)
             $syms = Symbol[$csym, $(QuoteNode(var))]
             $varname = Turing.VarName($vi, $syms, "")
         end
     else
         varname_expr = quote
             $sym, $idcs, $csym = Turing.@VarName $var
-            $csym_str = string($(model_info[:name]))*string($csym)
+            $csym_str = string($(QuoteNode(model_info[:name])))*string($csym)
             $indexing = mapfoldl(string, *, $idcs, init = "")
             $varname = Turing.VarName($vi, Symbol($csym_str), $sym, $indexing)
         end


### PR DESCRIPTION
This fixes the following code:

```julia
using RecursiveArrayTools, ParameterizedFunctions, OrdinaryDiffEq, Distributions, Turing

f1 = @ode_def begin
    dx = a*x - x*y
    dy = -3y + x*y
end a
u0 = [1.0,1.0]
tspan = (0.0,10.0)
prob1 = ODEProblem(f1,u0,tspan,[1.5])
sol = solve(prob1,Tsit5())
t = collect(range(1,stop=10,length=10))
randomized = VectorOfArray([(sol(t[i]) + .01randn(2)) for i in 1:length(t)])
data = convert(Array,randomized)
priors = [Normal(1.5,0.01)]

function turing_inference(prob::DiffEqBase.DEProblem,alg,t,data,priors = nothing;
                          num_samples=1000, delta=0.65, kwargs...)

  N = length(priors)
  _theta = Vector{Real}(undef, N)
  @model bif(x) = begin
    for i in 1:length(priors)
      _theta[i] ~ priors[i]
    end
    σ ~ InverseGamma(2, 3)

    theta = convert(Array{typeof(first(_theta))}, _theta)
    p_tmp = remake(prob, u0 = convert.(eltype(theta), (prob.u0)), p = theta) 
    sol_tmp = solve(p_tmp, alg; saveat = t, kwargs...)
    fill_length = length(t) - length(sol_tmp.u)

    for i in 1:fill_length
      if eltype(sol_tmp.u) <: Number
        push!(sol_tmp.u, Inf)
      else
        push!(sol_tmp.u, fill(Inf, size(sol_tmp[1])))
      end
    end
    for i = 1:length(t)
      res = sol_tmp.u[i]
      x[:,i] ~ MvNormal(res, σ*ones(2))
    end
  end

  model = bif(data)
  chn = sample(model, Turing.IS(num_samples))
end

bayesian_result = turing_inference(prob1,Tsit5(),t,data,priors;num_samples=500)
```

CC: @Vaibhavdixit02