### PR TITLE
Added missing values handling.

### DIFF
--- a/src/inference/dynamichmc.jl
+++ b/src/inference/dynamichmc.jl
@@ -70,5 +70,5 @@ function sample(model::Model,
         samples[i].value = Sample(vi, spl).value
     end
 
-    return Chain(0, samples)
+    return Chain(0.0, samples)
 end

--- a/src/inference/gibbs.jl
+++ b/src/inference/gibbs.jl
@@ -180,7 +180,7 @@ function sample(
     if resume_from != nothing   # concat samples
         pushfirst!(samples, resume_from.value2...)
     end
-    c = Chain(0, samples)       # wrap the result by Chain
+    c = Chain(0.0, samples)       # wrap the result by Chain
 
     if save_state               # save state
         save!(c, spl, model, varInfo)

--- a/src/inference/hmc.jl
+++ b/src/inference/hmc.jl
@@ -186,7 +186,7 @@ function sample(model::Model, alg::Hamiltonian;
     if resume_from != nothing   # concat samples
         pushfirst!(samples, resume_from.value2...)
     end
-    c = Chain(0, samples)       # wrap the result by Chain
+    c = Chain(0.0, samples)       # wrap the result by Chain
     if save_state               # save state
         # Convert vi back to X if vi is required to be saved
         if spl.alg.gid == 0 invlink!(vi, spl) end

--- a/src/inference/ipmcmc.jl
+++ b/src/inference/ipmcmc.jl
@@ -148,5 +148,5 @@ function sample(model::Model, alg::IPMCMC)
   println("[IPMCMC] Finished with")
   println("  Running time    = $time_total;")
 
-  Chain(0, samples) # wrap the result by Chain
+  Chain(0.0, samples) # wrap the result by Chain
 end

--- a/src/inference/mh.jl
+++ b/src/inference/mh.jl
@@ -167,7 +167,7 @@ function sample(model::Model, alg::MH;
   if resume_from != nothing   # concat samples
     pushfirst!(samples, resume_from.value2...)
   end
-  c = Chain(0, samples)       # wrap the result by Chain
+  c = Chain(0.0, samples)       # wrap the result by Chain
   if save_state               # save state
     save!(c, spl, model, vi)
   end

--- a/src/inference/pmmh.jl
+++ b/src/inference/pmmh.jl
@@ -172,7 +172,7 @@ function sample(  model::Model,
     if resume_from != nothing   # concat samples
       pushfirst!(samples, resume_from.value2...)
     end
-    c = Chain(0, samples)       # wrap the result by Chain
+    c = Chain(0.0, samples)       # wrap the result by Chain
 
     if save_state               # save state
       save!(c, spl, model, vi)

--- a/src/utilities/Utilities.jl
+++ b/src/utilities/Utilities.jl
@@ -3,7 +3,7 @@ module Utilities
 using ..Turing: Sampler
 using Distributions, Bijectors
 using StatsFuns, SpecialFunctions
-using MCMCChain: AbstractChains, Chains
+using MCMCChain: AbstractChains, Chains, names2inds
 import Distributions: sample
 
 export  resample,

--- a/src/utilities/io.jl
+++ b/src/utilities/io.jl
@@ -182,7 +182,16 @@ function Base.getindex(c::Chain, v::Symbol)
     elseif v==:logweights
         return c[:lp]
     else
-        return getindex(c, string(v))
+        idx = names2inds(c, string(v))
+        if any(idx .== nothing)
+            syms = collect(Iterators.filter(k -> occursin(string(v)*"[", string(k)), c.names))
+            sort!(syms)
+            idx = names2inds(c, syms)
+            @assert all(idx .!= nothing)
+            return c.value[:, idx, :]
+        else
+            return getindex(c, string(v))
+        end
     end
 end
 

--- a/src/utilities/io.jl
+++ b/src/utilities/io.jl
@@ -95,10 +95,9 @@ mean(chain[:mu])      # find the mean of :mu
 mean(chain[:sigma])   # find the mean of :sigma
 ```
 """
-mutable struct Chain{R<:AbstractRange{Int}} <: AbstractChains
+struct Chain{R<:AbstractRange{Int}} <: AbstractChains
     weight  ::  Float64                 # log model evidence
-    value2  ::  Array{Sample}
-    value   ::  Array{Float64, 3}
+    value   ::  Array{Union{Missing, Float64}, 3}
     range   ::  R # TODO: Perhaps change to UnitRange?
     names   ::  Vector{String}
     chains  ::  Vector{Int}
@@ -107,7 +106,6 @@ end
 
 function Chain()
     return Chain{AbstractRange{Int}}( 0.0,
-                                      Vector{Sample}(),
                                       Array{Float64, 3}(undef, 0, 0, 0),
                                       0:0,
                                       Vector{String}(),
@@ -115,33 +113,24 @@ function Chain()
                                       Dict{Symbol,Any}()
                                     )
 end
-function Chain(w::Real, s::Array{Sample})
-    chn = Chain()
-    chn.weight = w
-    chn.value2 = deepcopy(s)
 
-    chn = flatten!(chn)
-    return chn
-end
+function Chain(w::Real, s::AbstractArray{Sample})
 
-function flatten!(chn::Chain)
-    ## Flatten samples into Mamba's chain type.
-    local names = Vector{Array{AbstractString}}()
-    local vals  = Vector{Array}()
-    for s in chn.value2
-        v, n = flatten(s)
-        push!(vals, v)
-        push!(names, n)
-    end
+    samples = flatten.(s)
+    names_ = collect(mapreduce(s -> keys(s), union, samples))
 
-    # Assuming that names[i] == names[j] for all (i,j)
-    vals2 = [v[i] for v in vals, i=1:length(names[1])]
-    vals2 = reshape(vals2, length(vals), length(names[1]), 1)
-    c = Chains(vals2, names = names[1])
-    chn.value = c.value
-    chn.range = c.range
-    chn.names = c.names
-    chn.chains = c.chains
+    values_ = mapreduce(v -> map(k -> haskey(v, k) ? v[k] : missing, names_), hcat, samples)
+    values_ = convert(Array{Union{Missing, Float64}, 2}, values_')
+    c = Chains(reshape(values_, size(values_, 1), size(values_, 2), 1), names = names_)
+
+    chn = Chain(
+                w,
+                c.value,
+                c.range,
+                c.names,
+                c.chains,
+                Dict{Symbol, Any}()
+               )
     return chn
 end
 
@@ -154,8 +143,9 @@ function flatten(s::Sample)
     for (k, v) in s.value
         flatten(names, vals, string(k), v)
     end
-    return vals, names
+    return Dict(names[i] => vals[i] for i in 1:length(vals))
 end
+
 function flatten(names, value :: Array{Float64}, k :: String, v)
     if isa(v, Number)
         name = k
@@ -189,14 +179,17 @@ function Base.getindex(c::Chain, v::Symbol)
     #  Needs some refactoring a better format for storing results is available.
     if v == :logevidence
         return log(c.weight)
-    elseif v==:samples
-        return c.value2
     elseif v==:logweights
         return c[:lp]
     else
-        return map((s)->Base.getindex(s, v), c.value2)
+        return getindex(c, string(v))
     end
 end
+
+function Base.getindex(c::Chain, v::String)
+    return c.value[:, names2inds(c, v), :]
+end
+
 
 function Base.getindex(c::Chain, expr::Expr)
     str = replace(string(expr), r"\(|\)" => "")
@@ -213,8 +206,17 @@ function Base.vcat(c1::Chain, args::Chain...)
     all(c -> c.chains == chains, args) ||
         throw(ArgumentError("sets of chains differ"))
 
-    value2 = cat(c1.value2, map(c -> c.value2, args)..., dims=1)
-    return Chain(0, value2)
+    @assert c1.weight == c2.weight
+    @assert c1.range == c2.range
+
+    chn = Chain(c1.weight,
+                cat(c1.value, c2.value, dims=1),
+                c1.range,
+                c1.names,
+                c1.chains,
+                merge(c1.info, c2.info)
+        )
+    return chn
 end
 
 function save!(c::Chain, spl::Sampler, model, vi)

--- a/test/compiler.jl/assume.jl
+++ b/test/compiler.jl/assume.jl
@@ -14,10 +14,10 @@ pg = PG(10,1000)
 
 res = sample(test_assume(), smc)
 
-@test reduce(&, res[:x]) == 1 # check that x is always 1
+@test all(res[:x] .== 1) # check that x is always 1
 @test mean(res[:y]) ≈ 0.5 atol=0.1 # check that the mean of y is between 0.4 and 0.6
 
 res = sample(test_assume(), pg)
 
-@test reduce(&, res[:x]) == 1 # check that x is always 1
+@test all(res[:x] .== 1) # check that x is always 1
 @test mean(res[:y]) ≈ 0.5 atol=0.1 # check that the mean of y is between 0.4 and 0.6

--- a/test/compiler.jl/observe.jl
+++ b/test/compiler.jl/observe.jl
@@ -17,16 +17,16 @@ pg  = PG(100,10)
 
 res = sample(test(), is)
 
-@test reduce(&, res[:x]) == 1  #c heck that x is always 1
+@test all(res[:x] .== 1)  #c heck that x is always 1
 @test res[:logevidence] ≈ 2 * log(0.5)
 
 res = sample(test(), smc)
 
-@test reduce(&, res[:x]) == 1  #c heck that x is always 1
+@test all(res[:x] .== 1)  #c heck that x is always 1
 @test res[:logevidence] ≈ 2 * log(0.5)
 
 
 res = sample(test(), pg)
 
-@test reduce(&, res[:x]) == 1  # check that x is always 1
+@test all(res[:x] .== 1)  # check that x is always 1
 # PG does not provide logevidence estimate

--- a/test/hmc.jl/constrained_simplex.jl
+++ b/test/hmc.jl/constrained_simplex.jl
@@ -13,4 +13,5 @@ end
 
 chain = sample(constrained_simplex_test(obs12), HMC(1000, 0.75, 2))
 
+check_numerical(chain, ["ps[1]", "ps[2]"], [5/16, 11/16], eps=0.015)
 check_numerical(chain, [:ps], [[5/16; 11/16]], eps=0.015)

--- a/test/hmc.jl/matrix_support.jl
+++ b/test/hmc.jl/matrix_support.jl
@@ -9,9 +9,11 @@ end
 model_f = hmcmatrixsup()
 vs = []
 chain = nothing
+τ = 3000
 for _ in 1:5
-  chain = sample(model_f, HMC(3000, 0.1, 3))
-  push!(vs, mean(chain[:v]))
+    chain = sample(model_f, HMC(τ, 0.1, 3))
+    r = reshape(chain[:v], τ, 2, 2)
+    push!(vs, reshape(mean(r, dims = [1]), 2, 2))
 end
 
 @test mean(vs) ≈ (7 * [1 0.5; 0.5 1]) atol=0.5

--- a/test/io.jl/chain_utility.jl
+++ b/test/io.jl/chain_utility.jl
@@ -1,23 +1,28 @@
 using Turing
+using Turing.Utilities
 using Turing: Chain, Sample
 using Test
 using MCMCChain: describe
 
-c = Chain()
-#@test string(c) == "Empty Chain, weight 0.0"
+# Test getindex function for sample.
+s = Sample(1, Dict(:m => 1.0))
+@test s[:m] == 1
 
-d = Dict{Symbol, Any}()
-d[:m] = [1,2,3]
-sp = Sample(1, d)
+s = Sample(1, Dict(:m => [1, 2, 3]))
+@test s[:m] == [1, 2, 3]
 
-c2 = Chain(1, Vector{Sample}([sp]))
+# Test conversion of multiple samples to a chain type.
+s = map(i -> i > 50 ? Sample(2, Dict(:x => rand(2))) : Sample(1, Dict(:x => rand(), :y => rand())), 1:100)
 
-string(c2)
-samples = c2[:samples]
-@test samples[1][:m] == d[:m]
+c = Chain(1.0, s)
 
-#@test mean(c2, :m, x -> x) == [1.0, 2.0, 3.0]
-
+@test c.weight == 1
+@test ismissing(c["y"][51, 1, 1])
+@test c["y"][50, 1, 1] == s[50][:y]
+@test "x" ∈ c.names
+@test "y" ∈ c.names
+@test "x[1]" ∈ c.names
+@test "x[2]" ∈ c.names
 
 # Tests for MCMC Chain
 

--- a/test/is.jl/importance_sampling.jl
+++ b/test/is.jl/importance_sampling.jl
@@ -52,9 +52,9 @@ let n = 10
     Random.seed!(seed)
     tested = sample(_f, alg)
     for i = 1:n
-      @test exact[:samples][i][:a] == tested[:samples][i][:a]
-      @test exact[:samples][i][:b] == tested[:samples][i][:b]
-      @test exact[:logweights][i]  == tested[:logweights][i]
+        @test exact[:samples][i][:a] == tested[:a][i,1,1]
+        @test exact[:samples][i][:b] == tested[:b][i,1,1]
+        @test exact[:logweights][i]  == tested[:logweights][i]
     end
     @test exact[:logevidence] == tested[:logevidence]
   end

--- a/test/utility.jl
+++ b/test/utility.jl
@@ -3,14 +3,15 @@ using Test
 # Helper function for numerical tests
 function check_numerical(
   chain,
-  symbols::Vector{Symbol},
+  symbols::Vector,
   exact_vals::Vector;
   eps=0.2,
 )
 	for (sym, val) in zip(symbols, exact_vals)
-		E = mean(chain[sym])
+        @info sym, val
+        E = val isa Real ? mean(chain[sym]) : vec(mean(chain[sym], dims=[1]))
 		print("  $sym = $E ≈ $val (eps = $eps) ?")
-		cmp = abs.(sum(mean(chain[sym]) - val)) <= eps
+		cmp = abs.(sum(E - val)) <= eps
 		if cmp
 			printstyled("./\n", color = :green)
 			printstyled("    $sym = $E, diff = $(abs.(E - val))\n", color = :green)


### PR DESCRIPTION
This PR adds missing values handling for the internal `Turing.Chain` object and `Sample` object. This work is required for BNP related models.

Changes:

* Removed `value2` field which contains  redundant information.
* Changed `getindex` function to use `MCMCChain.names2inds`
* `Chain` is now immutable (I hope this doesn't break anything!)
* `value` field supports missing values.
* Refactored constructor and `flatten` functions.
* Added more tests.

Supported indexing:

```julia
@model testmodel() = begin
    x ~ Normal()
    y ~ Dirichlet([0.5, 0.5])
    z ~ Wishart(7, [1 0.5; 0.5 1])
end

...
chain = sample(mf, SMC(100))

chain["x"] # => 100 x 1 x 1 matrix
chain[:x] #  == chain["x"]
chain["y[1]"] #  => 100 x 1 x 1 matrix
chain[["y[1]", "y[2]"]] #  => 100 x 2 x 1 matrix
chain[:y] # == chain[["y[1]", "y[2]"]]
chain["z[1, 1]"] # => 100 x 1 x 1 matrix
chain[:z] # => 100 x 4 x 1 matrix
reshape(mean(chain[:z], dims = [1]), 2, 2) # average z matrix
```