### PR TITLE
Make debug statements optional

### DIFF
--- a/src/Turing.jl
+++ b/src/Turing.jl
@@ -30,6 +30,8 @@ const CACHERESET  = 0b00
 const CACHEIDCS   = 0b10
 const CACHERANGES = 0b01
 
+const DEBUG = Bool(parse(Int, get(ENV, "DEBUG_TURING", "0")))
+
 """
     struct Model{pvars, dvars, F, TData, TDefaults}
         f::F

--- a/src/core/compiler.jl
+++ b/src/core/compiler.jl
@@ -122,7 +122,7 @@ function _tilde(vsym, left, dist, model_info)
 
     if vsym in model_info[:arg_syms]
         if !(vsym in model_info[:tent_dvars_list])
-            @debug " Observe - `$(vsym)` is an observation"
+            Turing.DEBUG && @debug " Observe - `$(vsym)` is an observation"
             push!(model_info[:tent_dvars_list], vsym)
         end
 
@@ -136,7 +136,7 @@ function _tilde(vsym, left, dist, model_info)
     else
         # Assume it is a parameter.
         if !(vsym in model_info[:tent_pvars_list])
-            @debug begin 
+            Turing.DEBUG && @debug begin 
                 msg = " Assume - `$(vsym)` is a parameter"
                 if isdefined(Main, vsym)
                     msg  *= " (ignoring `$(vsym)` found in global scope)"

--- a/src/inference/Inference.jl
+++ b/src/inference/Inference.jl
@@ -5,7 +5,7 @@ using Distributions, Libtask, Bijectors
 using ProgressMeter, LinearAlgebra
 using ..Turing: PROGRESS, CACHERESET, AbstractSampler
 using ..Turing: Sampler, Model, runmodel!, get_pvars, get_dvars
-using ..Turing: in_pvars, in_dvars
+using ..Turing: in_pvars, in_dvars, Turing
 using StatsFuns: logsumexp
 
 import Distributions: sample
@@ -191,8 +191,8 @@ function observe(spl::A,
     vi::VarInfo) where {A<:Union{Nothing, SampleFromPrior, HamiltonianRobustInit}}
 
     vi.num_produce += one(vi.num_produce)
-    @debug "dist = $dist"
-    @debug "value = $value"
+    Turing.DEBUG && @debug "dist = $dist"
+    Turing.DEBUG && @debug "value = $value"
 
     # acclogp!(vi, logpdf(dist, value))
     logpdf(dist, value)

--- a/src/inference/adapt/stepsize.jl
+++ b/src/inference/adapt/stepsize.jl
@@ -69,8 +69,8 @@ end
 
 # Ref: https://github.com/stan-dev/stan/blob/develop/src/stan/mcmc/stepsize_adaptation.hpp
 function adapt_stepsize!(da::DualAveraging, stats::Real)
-    @debug "adapting step size ϵ..."
-    @debug "current α = $(stats)"
+    Turing.DEBUG && @debug "adapting step size ϵ..."
+    Turing.DEBUG && @debug "current α = $(stats)"
     da.state.m += 1
     m = da.state.m
 
@@ -88,7 +88,7 @@ function adapt_stepsize!(da::DualAveraging, stats::Real)
     x_bar = (1.0 - η_x) * x_bar + η_x * x
 
     ϵ = exp(x)
-    @debug "new ϵ = $(ϵ), old ϵ = $(da.state.ϵ)"
+    Turing.DEBUG && @debug "new ϵ = $(ϵ), old ϵ = $(da.state.ϵ)"
 
     if isnan(ϵ) || isinf(ϵ)
         @warn "Incorrect ϵ = $ϵ; ϵ_previous = $(da.state.ϵ) is used instead."

--- a/src/inference/gibbs.jl
+++ b/src/inference/gibbs.jl
@@ -113,7 +113,7 @@ function sample(
     # Gibbs steps
     PROGRESS[] && (spl.info[:progress] = ProgressMeter.Progress(n, 1, "[Gibbs] Sampling...", 0))
     for i = 1:n
-        @debug "Gibbs stepping..."
+        Turing.DEBUG && @debug "Gibbs stepping..."
 
         time_elapsed = zero(Float64)
         lp = nothing; epsilon = nothing; lf_num = nothing; eval_num = nothing
@@ -122,11 +122,11 @@ function sample(
             last_spl = local_spl
       # PROGRESS[] && haskey(spl.info, :progress) && (local_spl.info[:progress] = spl.info[:progress])
 
-            @debug "$(typeof(local_spl)) stepping..."
+            Turing.DEBUG && @debug "$(typeof(local_spl)) stepping..."
 
             if isa(local_spl.alg, GibbsComponent)
                 for _ = 1:local_spl.alg.n_iters
-                    @debug "recording old θ..."
+                    Turing.DEBUG && @debug "recording old θ..."
                     time_elapsed_thin = @elapsed varInfo, is_accept = step(model, local_spl, varInfo, Val(i==1))
 
                     if ~spl.alg.thin

--- a/src/inference/hmc.jl
+++ b/src/inference/hmc.jl
@@ -148,7 +148,7 @@ function sample(model::Model, alg::Hamiltonian;
     accept_his = Bool[]
     PROGRESS[] && (spl.info[:progress] = ProgressMeter.Progress(n, 1, "[$alg_str] Sampling...", 0))
     for i = 1:n
-        @debug "$alg_str stepping..."
+        Turing.DEBUG && @debug "$alg_str stepping..."
 
         time_elapsed = @elapsed vi, is_accept = step(model, spl, vi, Val(i == 1))
         time_total += time_elapsed
@@ -212,13 +212,13 @@ end
 function step(model, spl::Sampler{<:Hamiltonian}, vi::VarInfo, is_first::Val{false})
     # Get step size
     ϵ = getss(spl.info[:wum])
-    @debug "current ϵ: $ϵ"
+    Turing.DEBUG && @debug "current ϵ: $ϵ"
 
     # Reset current counters
     spl.info[:lf_num] = 0
     spl.info[:eval_num] = 0
 
-    @debug "X-> R..."
+    Turing.DEBUG && @debug "X-> R..."
     if spl.alg.gid != 0
         link!(vi, spl)
         runmodel!(model, vi, spl)
@@ -236,7 +236,7 @@ function step(model, spl::Sampler{<:Hamiltonian}, vi::VarInfo, is_first::Val{fal
     θ_new, lj_new, is_accept, α = hmc_step(θ, lj, lj_func, grad_func, H_func, ϵ, spl.alg, momentum_sampler;
                                            rev_func=rev_func, log_func=log_func)
 
-    @debug "decide whether to accept..."
+    Turing.DEBUG && @debug "decide whether to accept..."
     if is_accept
         vi[spl] = θ_new
         setlogp!(vi, lj_new)
@@ -259,21 +259,21 @@ function step(model, spl::Sampler{<:Hamiltonian}, vi::VarInfo, is_first::Val{fal
         adapt!(spl.info[:wum], α, vi[spl], adapt_M=false, adapt_ϵ=true)
     end
 
-    @debug "R -> X..."
+    Turing.DEBUG && @debug "R -> X..."
     spl.alg.gid != 0 && invlink!(vi, spl)
 
     return vi, is_accept
 end
 
 function assume(spl::Sampler{<:Hamiltonian}, dist::Distribution, vn::VarName, vi::VarInfo)
-    @debug "assuming..."
+    Turing.DEBUG && @debug "assuming..."
     updategid!(vi, vn, spl)
     r = vi[vn]
     # acclogp!(vi, logpdf_with_trans(dist, r, istrans(vi, vn)))
     # r
-    @debug "dist = $dist"
-    @debug "vn = $vn"
-    @debug "r = $r" "typeof(r)=$(typeof(r))"
+    Turing.DEBUG && @debug "dist = $dist"
+    Turing.DEBUG && @debug "vn = $vn"
+    Turing.DEBUG && @debug "r = $r" "typeof(r)=$(typeof(r))"
     r, logpdf_with_trans(dist, r, istrans(vi, vn))
 end
 

--- a/src/inference/ipmcmc.jl
+++ b/src/inference/ipmcmc.jl
@@ -131,7 +131,7 @@ function sample(model::Model, alg::IPMCMC)
   # IPMCMC steps
   if PROGRESS[] spl.info[:progress] = ProgressMeter.Progress(n, 1, "[IPMCMC] Sampling...", 0) end
   for i = 1:n
-    @debug "IPMCMC stepping..."
+    Turing.DEBUG && @debug "IPMCMC stepping..."
     time_elapsed = @elapsed VarInfos = step(model, spl, VarInfos, i==1)
 
     # Save each CSMS retained path as a sample

--- a/src/inference/mh.jl
+++ b/src/inference/mh.jl
@@ -86,13 +86,13 @@ function step(model, spl::Sampler{<:MH}, vi::VarInfo, is_first::Val{false})
   old_θ = copy(vi[spl])
   old_logp = getlogp(vi)
 
-  @debug "Propose new parameters from proposals..."
+  Turing.DEBUG && @debug "Propose new parameters from proposals..."
   propose(model, spl, vi)
 
-  @debug "computing accept rate α..."
+  Turing.DEBUG && @debug "computing accept rate α..."
   is_accept, logα = mh_accept(-old_logp, -getlogp(vi), spl.info[:proposal_ratio])
 
-  @debug "decide wether to accept..."
+  Turing.DEBUG && @debug "decide wether to accept..."
   if is_accept && !spl.info[:violating_support]  # accepted
     is_accept = true
   else                      # rejected
@@ -142,7 +142,7 @@ function sample(model::Model, alg::MH;
   accept_his = Bool[]
   PROGRESS[] && (spl.info[:progress] = ProgressMeter.Progress(n, 1, "[$alg_str] Sampling...", 0))
   for i = 1:n
-    @debug "$alg_str stepping..."
+    Turing.DEBUG && @debug "$alg_str stepping..."
 
     time_elapsed = @elapsed vi, is_accept = step(model, spl, vi, Val(i == 1))
     time_total += time_elapsed

--- a/src/inference/nuts.jl
+++ b/src/inference/nuts.jl
@@ -147,7 +147,7 @@ function _nuts_step(θ::T, ϵ::AbstractFloat, lj::Real,
                     lj_func::Function, grad_func::Function, H_func::Function, momentum_sampler::Function;
                     j_max::Int=5) where {T<:Union{AbstractVector,SubArray}}
 
-  @debug "sampling momentums..."
+  Turing.DEBUG && @debug "sampling momentums..."
   θ_dim = length(θ)
   r0 = momentum_sampler()
 

--- a/src/inference/pmmh.jl
+++ b/src/inference/pmmh.jl
@@ -78,9 +78,9 @@ function step(model, spl::Sampler{<:PMMH}, vi::VarInfo, is_first::Bool)
     new_likelihood_estimate = 0.0
     old_θ = copy(vi[spl])
 
-    @debug "Propose new parameters from proposals..."
+    Turing.DEBUG && @debug "Propose new parameters from proposals..."
     for local_spl in spl.info[:samplers][1:end-1]
-        @debug "$(typeof(local_spl)) proposing $(local_spl.alg.space)..."
+        Turing.DEBUG && @debug "$(typeof(local_spl)) proposing $(local_spl.alg.space)..."
         propose(model, local_spl, vi)
         if local_spl.info[:violating_support] violating_support=true; break end
         new_prior_prob += local_spl.info[:prior_prob]
@@ -88,11 +88,11 @@ function step(model, spl::Sampler{<:PMMH}, vi::VarInfo, is_first::Bool)
     end
 
     if !violating_support # do not run SMC if going to refuse anyway
-        @debug "Propose new state with SMC..."
+        Turing.DEBUG && @debug "Propose new state with SMC..."
         vi, _ = step(model, spl.info[:samplers][end], vi)
         new_likelihood_estimate = spl.info[:samplers][end].info[:logevidence][end]
 
-        @debug "computing accept rate α..."
+        Turing.DEBUG && @debug "computing accept rate α..."
         is_accept, logα = mh_accept(
           -(spl.info[:old_likelihood_estimate] + spl.info[:old_prior_prob]),
           -(new_likelihood_estimate + new_prior_prob),
@@ -100,7 +100,7 @@ function step(model, spl::Sampler{<:PMMH}, vi::VarInfo, is_first::Bool)
         )
     end
 
-    @debug "decide whether to accept..."
+    Turing.DEBUG && @debug "decide whether to accept..."
     if !violating_support && is_accept # accepted
         is_accept = true
         spl.info[:old_likelihood_estimate] = new_likelihood_estimate
@@ -148,7 +148,7 @@ function sample(  model::Model,
     accept_his = Bool[]
     PROGRESS[] && (spl.info[:progress] = ProgressMeter.Progress(n, 1, "[$alg_str] Sampling...", 0))
     for i = 1:n
-      @debug "$alg_str stepping..."
+      Turing.DEBUG && @debug "$alg_str stepping..."
       time_elapsed = @elapsed vi, is_accept = step(model, spl, vi, i==1)
 
       if is_accept # accepted => store the new predcits

--- a/src/inference/sghmc.jl
+++ b/src/inference/sghmc.jl
@@ -66,28 +66,28 @@ function step(model, spl::Sampler{<:SGHMC}, vi::VarInfo, is_first::Val{false})
     # Set parameters
     η, α = spl.alg.learning_rate, spl.alg.momentum_decay
 
-    @debug "X-> R..."
+    Turing.DEBUG && @debug "X-> R..."
     if spl.alg.gid != 0
         link!(vi, spl)
         runmodel!(model, vi, spl)
     end
 
-    @debug "recording old variables..."
+    Turing.DEBUG && @debug "recording old variables..."
     θ, v = vi[spl], spl.info[:v]
     _, grad = gradient(θ, vi, model, spl)
     verifygrad(grad)
 
     # Implements the update equations from (15) of Chen et al. (2014).
-    @debug "update latent variables and velocity..."
+    Turing.DEBUG && @debug "update latent variables and velocity..."
     θ .+= v
     v .= (1 - α) .* v .- η .* grad .+ rand.(Normal.(zeros(length(θ)), sqrt(2 * η * α)))
 
-    @debug "saving new latent variables..."
+    Turing.DEBUG && @debug "saving new latent variables..."
     vi[spl] = θ
 
-    @debug "R -> X..."
+    Turing.DEBUG && @debug "R -> X..."
     spl.alg.gid != 0 && invlink!(vi, spl)
 
-    @debug "always accept..."
+    Turing.DEBUG && @debug "always accept..."
     return vi, true
 end

--- a/src/inference/sgld.jl
+++ b/src/inference/sgld.jl
@@ -65,30 +65,30 @@ function step(model, spl::Sampler{<:SGLD}, vi::VarInfo, is_first::Val{false})
     # Update iteration counter
     spl.info[:t] += 1
 
-    @debug "compute current step size..."
+    Turing.DEBUG && @debug "compute current step size..."
     γ = .35
     ϵ_t = spl.alg.epsilon / spl.info[:t]^γ # NOTE: Choose γ=.55 in paper
     mssa = spl.info[:wum].ssa
     mssa.state.ϵ = ϵ_t
 
-    @debug "X-> R..."
+    Turing.DEBUG && @debug "X-> R..."
     if spl.alg.gid != 0
         link!(vi, spl)
         runmodel!(model, vi, spl)
     end
 
-    @debug "recording old variables..."
+    Turing.DEBUG && @debug "recording old variables..."
     θ = vi[spl]
     _, grad = gradient(θ, vi, model, spl)
     verifygrad(grad)
 
-    @debug "update latent variables..."
+    Turing.DEBUG && @debug "update latent variables..."
     θ .-= ϵ_t .* grad ./ 2 .+ rand.(Normal.(zeros(length(θ)), sqrt(ϵ_t)))
 
-    @debug "always accept..."
+    Turing.DEBUG && @debug "always accept..."
     vi[spl] = θ
 
-    @debug "R -> X..."
+    Turing.DEBUG && @debug "R -> X..."
     spl.alg.gid != 0 && invlink!(vi, spl)
 
     return vi, true

--- a/src/inference/support/hmc_core.jl
+++ b/src/inference/support/hmc_core.jl
@@ -183,20 +183,20 @@ function _hmc_step(θ::AbstractVector{<:Real},
                    rev_func=nothing,
                    log_func=nothing,
                    )
-    @debug "sampling momentums..."
+    Turing.DEBUG && @debug "sampling momentums..."
     p = momentum_sampler()
 
-    @debug "recording old values..."
+    Turing.DEBUG && @debug "recording old values..."
     H = H_func(θ, p, lj)
 
-    @debug "leapfrog for $τ steps with step size $ϵ"
+    Turing.DEBUG && @debug "leapfrog for $τ steps with step size $ϵ"
     θ_new, p_new, τ_valid = _leapfrog(θ, p, τ, ϵ, grad_func; rev_func=rev_func, log_func=log_func)
 
-    @debug "computing new H..."
+    Turing.DEBUG && @debug "computing new H..."
     lj_new = lj_func(θ_new)
     H_new = (τ_valid == 0) ? Inf : H_func(θ_new, p_new, lj_new)
 
-    @debug "deciding wether to accept and computing accept rate α..."
+    Turing.DEBUG && @debug "deciding wether to accept and computing accept rate α..."
     is_accept, logα = mh_accept(H, H_new)
 
     if is_accept
@@ -260,7 +260,7 @@ function _find_good_eps(θ, lj_func, grad_func, H_func, momentum_sampler; max_nu
 
         θ_prime, p_prime, τ = _leapfrog(θ, p, 1, ϵ, grad_func)
         h = τ == 0 ? Inf : H_func(θ_prime, p_prime, lj_func(θ_prime))
-        @debug "direction = $direction, h = $h"
+        Turing.DEBUG && @debug "direction = $direction, h = $h"
 
         delta_H = H0 - h
 


### PR DESCRIPTION
This PR makes debug statements optional. An environment variable `ENV["DEBUG_TURING"]` can be set to 1 before running `using Turing` to turn on debugging. `@debug` statements introduce a type instability so this is for performance.