### PR TITLE
Fix #687

### DIFF
--- a/src/core/Core.jl
+++ b/src/core/Core.jl
@@ -37,12 +37,12 @@ export  @model,
         ForwardDiffAD, 
         FluxTrackerAD,
         value,
-        gradient,
+        gradient_logp,
         CHUNKSIZE, 
         ADBACKEND,
         setchunksize,
         verifygrad,
-        gradient_forward,
-        gradient_reverse
+        gradient_logp_forward,
+        gradient_logp_reverse
 
 end # module

--- a/src/core/ad.jl
+++ b/src/core/ad.jl
@@ -57,17 +57,18 @@ getADtype(s::Sampler) = getADtype(typeof(s))
 getADtype(s::Type{<:Sampler{TAlg}}) where {TAlg} = getADtype(TAlg)
 
 """
-gradient(
+gradient_logp(
     θ::AbstractVector{<:Real},
     vi::VarInfo,
     model::Model,
     sampler::Union{Nothing, Sampler}=nothing,
 )
 
-Computes the gradient of the log joint of `θ` for the model specified by
-`(vi, sampler, model)` using whichever automatic differentation tool is currently active.
+Computes the value of the log joint of `θ` and its gradient for the model 
+specified by `(vi, sampler, model)` using whichever automatic differentation 
+tool is currently active.
 """
-function gradient(
+function gradient_logp(
     θ::AbstractVector{<:Real},
     vi::VarInfo,
     model::Model,
@@ -76,24 +77,24 @@ function gradient(
 
     ad_type = getADtype(TS)
     if ad_type <: ForwardDiffAD 
-        return gradient_forward(θ, vi, model, sampler)
+        return gradient_logp_forward(θ, vi, model, sampler)
     else ad_type <: FluxTrackerAD
-        return gradient_reverse(θ, vi, model, sampler)
+        return gradient_logp_reverse(θ, vi, model, sampler)
     end
 end
 
 """
-gradient_forward(
+gradient_logp_forward(
     θ::AbstractVector{<:Real},
     vi::VarInfo,
     model::Model,
     spl::Union{Nothing, Sampler}=nothing,
 )
 
-Computes the gradient of the log joint of `θ` for the model specified by `(vi, spl, model)`
-using forwards-mode AD from ForwardDiff.jl.
+Computes the value of the log joint of `θ` and its gradient for the model 
+specified by `(vi, spl, model)` using forwards-mode AD from ForwardDiff.jl.
 """
-function gradient_forward(
+function gradient_logp_forward(
     θ::AbstractVector{<:Real},
     vi::VarInfo,
     model::Model,
@@ -105,7 +106,7 @@ function gradient_forward(
     # Define function to compute log joint.
     function f(θ)
         vi[sampler] = θ
-        return -runmodel!(model, vi, sampler).logp
+        return runmodel!(model, vi, sampler).logp
     end
 
     chunk_size = getchunksize(sampler)
@@ -113,7 +114,7 @@ function gradient_forward(
     chunk = ForwardDiff.Chunk(min(length(θ), chunk_size))
     config = ForwardDiff.GradientConfig(f, θ, chunk)
     ∂l∂θ = ForwardDiff.gradient!(similar(θ), f, θ, config)
-    l = -vi.logp.value
+    l = vi.logp.value
 
     # Replace old parameters to ensure this function doesn't mutate `vi`.
     vi.vals, vi.logp = vals_old, logp_old
@@ -125,17 +126,17 @@ function gradient_forward(
 end
 
 """
-gradient_reverse(
+gradient_logp_reverse(
     θ::AbstractVector{<:Real},
     vi::VarInfo,
     model::Model,
     sampler::Union{Nothing, Sampler}=nothing,
 )
 
-Computes the gradient of the log joint of `θ` for the model specified by
-`(vi, sampler, model)` using reverse-mode AD from Flux.jl.
+Computes the value of the log joint of `θ` and its gradient for the model 
+specified by `(vi, sampler, model)` using reverse-mode AD from Flux.jl.
 """
-function gradient_reverse(
+function gradient_logp_reverse(
     θ::AbstractVector{<:Real},
     vi::VarInfo,
     model::Model,
@@ -146,7 +147,7 @@ function gradient_reverse(
     # Specify objective function.
     function f(θ)
         vi[sampler] = θ
-        return -runmodel!(model, vi, sampler).logp
+        return runmodel!(model, vi, sampler).logp
     end
 
     # Compute forward and reverse passes.

--- a/src/inference/dynamichmc.jl
+++ b/src/inference/dynamichmc.jl
@@ -59,8 +59,8 @@ function sample(model::Model,
     end
 
     function _lp(x)
-        value, deriv = gradient(x, vi, model, spl)
-        return ValueGradient(-value, -deriv)
+        value, deriv = gradient_logp(x, vi, model, spl)
+        return ValueGradient(value, deriv)
     end
 
     chn_dynamic, _ = NUTS_init_tune_mcmc(FunctionLogDensity(length(vi[spl]), _lp), alg.n_iters)

--- a/src/inference/sghmc.jl
+++ b/src/inference/sghmc.jl
@@ -74,13 +74,13 @@ function step(model, spl::Sampler{<:SGHMC}, vi::VarInfo, is_first::Val{false})
 
     Turing.DEBUG && @debug "recording old variables..."
     θ, v = vi[spl], spl.info[:v]
-    _, grad = gradient(θ, vi, model, spl)
+    _, grad = gradient_logp(θ, vi, model, spl)
     verifygrad(grad)
 
     # Implements the update equations from (15) of Chen et al. (2014).
     Turing.DEBUG && @debug "update latent variables and velocity..."
     θ .+= v
-    v .= (1 - α) .* v .- η .* grad .+ rand.(Normal.(zeros(length(θ)), sqrt(2 * η * α)))
+    v .= (1 - α) .* v .+ η .* grad .+ rand.(Normal.(zeros(length(θ)), sqrt(2 * η * α)))
 
     Turing.DEBUG && @debug "saving new latent variables..."
     vi[spl] = θ

--- a/src/inference/sgld.jl
+++ b/src/inference/sgld.jl
@@ -79,11 +79,11 @@ function step(model, spl::Sampler{<:SGLD}, vi::VarInfo, is_first::Val{false})
 
     Turing.DEBUG && @debug "recording old variables..."
     θ = vi[spl]
-    _, grad = gradient(θ, vi, model, spl)
+    _, grad = gradient_logp(θ, vi, model, spl)
     verifygrad(grad)
 
     Turing.DEBUG && @debug "update latent variables..."
-    θ .-= ϵ_t .* grad ./ 2 .+ rand.(Normal.(zeros(length(θ)), sqrt(ϵ_t)))
+    θ .+= ϵ_t .* grad ./ 2 .- rand.(Normal.(zeros(length(θ)), sqrt(ϵ_t)))
 
     Turing.DEBUG && @debug "always accept..."
     vi[spl] = θ

--- a/src/inference/support/hmc_core.jl
+++ b/src/inference/support/hmc_core.jl
@@ -7,7 +7,7 @@ Generate a function that takes a vector of reals `θ` and compute the logpdf and
 gradient at `θ` for the model specified by `(vi, sampler, model)`.
 """
 function gen_grad_func(vi::VarInfo, sampler::Sampler, model)
-    return θ::AbstractVector{<:Real}->gradient(θ, vi, model, sampler)
+    return θ::AbstractVector{<:Real}->gradient_logp(θ, vi, model, sampler)
 end
 
 """
@@ -147,7 +147,7 @@ function _leapfrog(θ::AbstractVector{<:Real},
 
     p, θ, τ_valid = deepcopy(p), deepcopy(θ), 0
 
-    p .-= ϵ .* grad ./ 2
+    p .+= ϵ .* grad ./ 2
     for t in 1:τ
 
         log_func != nothing && log_func()
@@ -162,12 +162,12 @@ function _leapfrog(θ::AbstractVector{<:Real},
             break
         end
 
-        p .-= ϵ .* grad
+        p .+= ϵ .* grad
         τ_valid += 1
     end
 
     # Undo half a step in the momenta.
-    p .+= ϵ .* grad ./ 2
+    p .-= ϵ .* grad ./ 2
 
     return θ, p, τ_valid
 end

--- a/test/ad.jl/ad.jl
+++ b/test/ad.jl/ad.jl
@@ -1,12 +1,12 @@
 using Test, Turing, Distributions
-using Turing: VarInfo, gradient_forward, gradient_reverse
+using Turing: VarInfo, gradient_logp_forward, gradient_logp_reverse
 
 @model foo_ad() = begin
     x ~ Normal(3, 1)
     y ~ Normal(x, 1)
 end
 
-# Check that gradient_forward doesn't change the RV values or logp of a VarInfo.
+# Check that gradient_logp_forward doesn't change the RV values or logp of a VarInfo.
 let
     # Construct model.
     model, sampler, vi = foo_ad(), nothing, VarInfo()
@@ -16,14 +16,14 @@ let
     θ, logp = deepcopy(vi.vals), deepcopy(vi.logp)
 
     # Compute gradient using ForwardDiff.
-    gradient_forward(deepcopy(θ), vi, model, sampler)
+    gradient_logp_forward(deepcopy(θ), vi, model, sampler)
 
     # Check that θ and logp haven't changed.
     @test θ == vi.vals
     @test logp == vi.logp
 end
 
-# Check that gradient_reverse doesn't change the RV values or logp of a VarInfo.
+# Check that gradient_logp_reverse doesn't change the RV values or logp of a VarInfo.
 let
     # Construct model
     model, sampler, vi = foo_ad(), nothing, VarInfo()
@@ -33,14 +33,14 @@ let
     θ, logp = deepcopy(vi.vals), deepcopy(vi.logp)
 
     # Compute gradient using ForwardDiff.
-    gradient_reverse(deepcopy(θ), vi, model, sampler)
+    gradient_logp_reverse(deepcopy(θ), vi, model, sampler)
 
     # Check that θ and logp haven't changed.
     @test θ == vi.vals
     @test logp == vi.logp
 end
 
-# Check that gradient_forward gives the same result as gradient_reverse.
+# Check that gradient_logp_forward gives the same result as gradient_logp_reverse.
 let
     # Construct model.
     model, sampler, vi = foo_ad(), nothing, VarInfo()
@@ -50,9 +50,9 @@ let
     θ, logp = deepcopy(vi.vals), deepcopy(vi.logp)
 
     # Compute gradient using ForwardDiff.
-    l1, d1 = gradient_forward(deepcopy(θ), vi, model, sampler)
+    l1, d1 = gradient_logp_forward(deepcopy(θ), vi, model, sampler)
     # Compute gradient using Flux.Tracker.
-    l2, d2 = gradient_reverse(deepcopy(θ), vi, model, sampler)
+    l2, d2 = gradient_logp_reverse(deepcopy(θ), vi, model, sampler)
 
     # Check that the values are the same.
     @test l1 == l2

--- a/test/ad.jl/ad1.jl
+++ b/test/ad.jl/ad1.jl
@@ -1,5 +1,5 @@
 using Turing
-using Turing: gradient_forward, invlink, link, getval
+using Turing: gradient_logp_forward, invlink, link, getval
 using ForwardDiff
 using ForwardDiff: Dual
 using Test
@@ -23,7 +23,7 @@ mvn = collect(Iterators.filter(vn -> vn.sym == :m, keys(vi)))[1]
 _s = getval(vi, svn)[1]
 _m = getval(vi, mvn)[1]
 spl = nothing
-_, ∇E = gradient_forward(vi[spl], vi, ad_test_f)
+_, ∇E = gradient_logp_forward(vi[spl], vi, ad_test_f)
 # println(vi.vns)
 # println(∇E)
 grad_Turing = sort(∇E)
@@ -45,7 +45,7 @@ end
 g = x -> ForwardDiff.gradient(logp, x);
 # _s = link(dist_s, _s)
 _x = [_m, _s]
-grad_FWAD = sort(-g(_x))
+grad_FWAD = sort(g(_x))
 
 # Compare result
 @test grad_Turing ≈ grad_FWAD atol=1e-9

--- a/test/ad.jl/ad3.jl
+++ b/test/ad.jl/ad3.jl
@@ -1,5 +1,5 @@
 using Turing
-using Turing: gradient_forward, invlink, link
+using Turing: gradient_logp_forward, invlink, link
 using ForwardDiff
 using ForwardDiff: Dual
 using Test
@@ -20,7 +20,7 @@ ad_test_3_f(vi)
 
 vvn = collect(Iterators.filter(vn -> vn.sym == :v, keys(vi)))[1]
 _v = vi[vvn]
-_, grad_Turing = gradient_forward(vi[nothing], vi, ad_test_3_f)
+_, grad_Turing = gradient_logp_forward(vi[nothing], vi, ad_test_3_f)
 
 dist_v = Wishart(7, [1 0.5; 0.5 1])
 
@@ -34,7 +34,7 @@ end
 # Call ForwardDiff's AD
 g = x -> ForwardDiff.gradient(logp3, vec(x));
 # _s = link(dist_v, _s)
-grad_FWAD = -g(_v)
+grad_FWAD = g(_v)
 
 # Compare result
 @test grad_Turing ≈ grad_FWAD atol=1e-9

--- a/test/ad.jl/adr.jl
+++ b/test/ad.jl/adr.jl
@@ -1,5 +1,5 @@
 using Turing
-using Turing: gradient_reverse, invlink, link, getval
+using Turing: gradient_logp_reverse, invlink, link, getval
 using ForwardDiff
 using ForwardDiff: Dual
 using Test
@@ -24,7 +24,7 @@ _s = getval(vi, svn)[1]
 _m = getval(vi, mvn)[1]
 
 x = map(x->Float64(x), vi[nothing])
-∇E = gradient_reverse(x, vi, ad_test_f)[2]
+∇E = gradient_logp_reverse(x, vi, ad_test_f)[2]
 # println(vi.vns)
 # println(∇E)
 grad_Turing = sort(∇E)
@@ -46,7 +46,7 @@ end
 g = x -> ForwardDiff.gradient(logp, x);
 # _s = link(dist_s, _s)
 _x = [_m, _s]
-grad_FWAD = sort(-g(_x))
+grad_FWAD = sort(g(_x))
 
 # Compare result
 println(grad_Turing)

--- a/test/hmc_core.jl/leapfrog.jl
+++ b/test/hmc_core.jl/leapfrog.jl
@@ -3,7 +3,7 @@ using Turing.Inference: _leapfrog
 
 D = 10
 
-lp_grad_func(x) = nothing, x
+lp_grad_func(x) = nothing, -x
 
 step_size = 0.1
 
@@ -18,9 +18,9 @@ step_size = 0.1
 
         theta_turing, p_turing, _ = _leapfrog(theta, p, 1, step_size, lp_grad_func)
 
-        p -= step_size .* lp_grad_func(theta)[2] / 2
+        p .+= step_size .* lp_grad_func(theta)[2] / 2
         theta += step_size .* p
-        p -= step_size .* lp_grad_func(theta)[2] / 2
+        p .+= step_size .* lp_grad_func(theta)[2] / 2
 
         @test theta ≈ theta_turing
         @test p ≈ p_turing

--- a/test/hmc_core.jl/unit_test_helper.jl
+++ b/test/hmc_core.jl/unit_test_helper.jl
@@ -10,7 +10,7 @@ function test_grad(turing_model, grad_f; trans=Dict())
     @testset "Gradient using random inputs" begin
         for _ = 1:10000
             theta = rand(d)
-            @test Turing.gradient_reverse(theta, vi, model_f) == grad_f(theta)[2]
+            @test Turing.gradient_logp_reverse(theta, vi, model_f) == grad_f(theta)[2]
         end
     end
 end


### PR DESCRIPTION
Fixes #687. This PR does the following:
- [x] compute `logp`,  _not_ `-logp` and
- [x] rename `gradient` -> `gradient_logp`, `gradient_forward`->`gradient_logp_forward`, and `gradient_reverse`->`gradient_logp_reverse` to remove ambiguities
- [x] add doc string that clearly states what the `gradient_logp` function returns, i.e. `logp` and `gradient_logp`

Testing that the backends give the same output was done before in #688, and testing against finite difference is already done for the lower level `logpdf` of distributions. I don't think this is necessary for the whole `gradient_logp`.

CC: @trappmartin @willtebbutt @xukai92 