### PR TITLE
Fix #684

### DIFF
--- a/src/core/compiler.jl
+++ b/src/core/compiler.jl
@@ -12,8 +12,9 @@ macro VarName(expr::Union{Expr, Symbol})
     inds = :(())
     while ex.head == :ref
         if length(ex.args) >= 2
-            pushfirst!(inds.args, Expr(:vect, ex.args[2:end]...))
-            end
+            strs = map(x -> :(string($x)), ex.args[2:end])
+            pushfirst!(inds.args, :("[" * join($(Expr(:vect, strs...)), ", ") * "]"))
+        end
         ex = ex.args[1]
         isa(ex, Symbol) && return var_tuple(ex, inds)
     end
@@ -78,7 +79,7 @@ function generate_assume(var::Union{Symbol, Expr}, dist, model_info)
         varname_expr = quote
             $sym, $idcs, $csym = Turing.@VarName $var
             $csym_str = string($(QuoteNode(model_info[:name])))*string($csym)
-            $indexing = mapfoldl(string, *, $idcs, init = "")
+            $indexing = foldl(*, $idcs, init = "")
             $varname = Turing.VarName($vi, Symbol($csym_str), $sym, $indexing)
         end
     end

--- a/src/utilities/io.jl
+++ b/src/utilities/io.jl
@@ -154,10 +154,11 @@ function flatten(names, value :: Array{Float64}, k :: String, v)
     elseif isa(v, Array)
         for i = eachindex(v)
             if isa(v[i], Number)
-                name = k * string(ind2sub(size(v), i))
+                name = string(ind2sub(size(v), i))
                 name = replace(name, "(" => "[");
                 name = replace(name, ",)" => "]");
                 name = replace(name, ")" => "]");
+                name = k * name
                 isa(v[i], Nothing) && println(v, i, v[i])
                 push!(value, Float64(v[i]))
                 push!(names, name)

--- a/test/util.jl/util.jl
+++ b/test/util.jl/util.jl
@@ -4,7 +4,7 @@ using Test, StatsFuns
 
 i = 1
 @test @VarName(s)[1:end-1] == (:s,())
-@test @VarName(x[1,2][1+5][45][3][i])[1:end-1] == (:x,([1,2],[6],[45],[3],[1]))
+@test @VarName(x[1,2][1+5][45][3][i])[1:end-1] == (:x,("[1, 2]","[6]","[45]","[3]","[1]"))
 @test StatsFuns.logistic(1.1) == 1.0 / (exp.(-1.1) + 1.0)
 @test StatsFuns.logit(0.3) ≈ -0.8472978603872036 atol=1e-9
 @test isnan.(StatsFuns.logit(1.0)) == false


### PR DESCRIPTION
This PR fixes #684 by fixing a naming issue in the variables of chains when using a colon in indexing, e.g. `@VarName x[1,:][1]`.

CC: @xukai92