### PR TITLE
Rename `HamiltonianRobustInit` to `SampleFromUniform`.

### DIFF
--- a/src/Turing.jl
+++ b/src/Turing.jl
@@ -67,7 +67,7 @@ abstract type AbstractSampler end
 """
 Robust initialization method for model parameters in Hamiltonian samplers.
 """
-struct HamiltonianRobustInit <: AbstractSampler end
+struct SampleFromUniform <: AbstractSampler end
 struct SampleFromPrior <: AbstractSampler end
 
 """

--- a/src/inference/Inference.jl
+++ b/src/inference/Inference.jl
@@ -5,7 +5,7 @@ using Distributions, Libtask, Bijectors
 using ProgressMeter, LinearAlgebra
 using ..Turing: PROGRESS, CACHERESET, AbstractSampler
 using ..Turing: Model, runmodel!, get_pvars, get_dvars,
-    Sampler, SampleFromPrior, HamiltonianRobustInit
+    Sampler, SampleFromPrior, SampleFromUniform
 using ..Turing: in_pvars, in_dvars, Turing
 using StatsFuns: logsumexp
 
@@ -19,7 +19,7 @@ export  InferenceAlgorithm,
         GibbsComponent,
         StaticHamiltonian,
         AdaptiveHamiltonian,
-        HamiltonianRobustInit,
+        SampleFromUniform,
         SampleFromPrior,
         MH,
         Gibbs,      # classic sampling
@@ -109,12 +109,12 @@ error("Turing.observe: unmanaged inference algorithm: $(typeof(spl))")
 function assume(spl::A,
     dist::Distribution,
     vn::VarName,
-    vi::VarInfo) where {A<:Union{SampleFromPrior, HamiltonianRobustInit}}
+    vi::VarInfo) where {A<:Union{SampleFromPrior, SampleFromUniform}}
 
     if haskey(vi, vn)
         r = vi[vn]
     else
-        r = isa(spl, HamiltonianRobustInit) ? init(dist) : rand(dist)
+        r = isa(spl, SampleFromUniform) ? init(dist) : rand(dist)
         push!(vi, vn, r, dist, 0)
     end
     # NOTE: The importance weight is not correctly computed here because
@@ -129,7 +129,7 @@ function assume(spl::A,
     dists::Vector{T},
     vn::VarName,
     var::Any,
-    vi::VarInfo) where {T<:Distribution, A<:Union{SampleFromPrior, HamiltonianRobustInit}}
+    vi::VarInfo) where {T<:Distribution, A<:Union{SampleFromPrior, SampleFromUniform}}
 
     @assert length(dists) == 1 "Turing.assume only support vectorizing i.i.d distribution"
     dist = dists[1]
@@ -140,7 +140,7 @@ function assume(spl::A,
     if haskey(vi, vns[1])
         rs = vi[vns]
     else
-        rs = isa(spl, HamiltonianRobustInit) ? init(dist, n) : rand(dist, n)
+        rs = isa(spl, SampleFromUniform) ? init(dist, n) : rand(dist, n)
 
         if isa(dist, UnivariateDistribution) || isa(dist, MatrixDistribution)
             for i = 1:n
@@ -181,7 +181,7 @@ observe(::Nothing,
 function observe(spl::A,
     dist::Distribution,
     value::Any,
-    vi::VarInfo) where {A<:Union{SampleFromPrior, HamiltonianRobustInit}}
+    vi::VarInfo) where {A<:Union{SampleFromPrior, SampleFromUniform}}
 
     vi.num_produce += one(vi.num_produce)
     Turing.DEBUG && @debug "dist = $dist"
@@ -195,7 +195,7 @@ end
 function observe(spl::A,
     dists::Vector{T},
     value::Any,
-    vi::VarInfo) where {T<:Distribution, A<:Union{SampleFromPrior, HamiltonianRobustInit}}
+    vi::VarInfo) where {T<:Distribution, A<:Union{SampleFromPrior, SampleFromUniform}}
 
     @assert length(dists) == 1 "Turing.observe only support vectorizing i.i.d distribution"
     dist = dists[1]

--- a/src/inference/dynamichmc.jl
+++ b/src/inference/dynamichmc.jl
@@ -37,10 +37,10 @@ function Sampler(alg::DynamicNUTS{T}) where T <: Hamiltonian
   return Sampler(alg, Dict{Symbol,Any}())
 end
 
-function sample(model::Model, 
-                alg::DynamicNUTS{AD}, 
+function sample(model::Model,
+                alg::DynamicNUTS{AD},
                 ) where AD
-    
+
     spl = Sampler(alg)
 
     n = alg.n_iters
@@ -51,7 +51,7 @@ function sample(model::Model,
     end
 
     vi = VarInfo()
-    model(vi, HamiltonianRobustInit())
+    model(vi, SampleFromUniform())
 
     if spl.alg.gid == 0
         link!(vi, spl)

--- a/src/inference/gibbs.jl
+++ b/src/inference/gibbs.jl
@@ -102,7 +102,7 @@ function sample(
     # Init parameters
     varInfo = if resume_from == nothing
         vi_ = VarInfo()
-        model(vi_, HamiltonianRobustInit())
+        model(vi_, SampleFromUniform())
         vi_
     else
         resume_from.info[:vi]

--- a/src/inference/hmc.jl
+++ b/src/inference/hmc.jl
@@ -130,7 +130,7 @@ function sample(model::Model, alg::Hamiltonian;
 
     vi = if resume_from == nothing
         vi_ = VarInfo()
-        model(vi_, HamiltonianRobustInit())
+        model(vi_, SampleFromUniform())
         spl.info[:eval_num] += 1
         vi_
     else

--- a/src/inference/mh.jl
+++ b/src/inference/mh.jl
@@ -128,7 +128,7 @@ function sample(model::Model, alg::MH;
 
     vi = if resume_from == nothing
         vi_ = VarInfo()
-        model(vi_, HamiltonianRobustInit())
+        model(vi_, SampleFromUniform())
         vi_
     else
         resume_from.info[:vi]

--- a/src/inference/pmmh.jl
+++ b/src/inference/pmmh.jl
@@ -137,7 +137,7 @@ function sample(  model::Model,
     # Init parameters
     vi = if resume_from == nothing
         vi_ = VarInfo()
-        model(vi_, HamiltonianRobustInit())
+        model(vi_, SampleFromUniform())
         vi_
     else
         resume_from.info[:vi]


### PR DESCRIPTION
No functionality change - renamed one data type name into something less mysterious. 