### PR TITLE
Indexing fixes

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -4,7 +4,7 @@ Requires 0.5.0
 Reexport 0.2.0
 Distributions 0.16.0
 ForwardDiff 0.8.0
-MCMCChains 0.3.0
+MCMCChains 0.3.4
 Libtask 0.2.5
 Flux 0.6.7
 MacroTools

--- a/docs/src/_docs/samplers.jmd
+++ b/docs/src/_docs/samplers.jmd
@@ -53,9 +53,10 @@ end
 
 function plot_sampler(chain)
     # Extract values from chain.
-    ss = link.(Ref(InverseGamma(2,3)), chain[:s])
-    ms = chain[:m]
-    lps = chain[:lp]
+    val = get(chain, [:s, :m, :lp])
+    ss = link.(Ref(InverseGamma(2,3)), val.s)
+    ms = val.m
+    lps = val.lp
 
     # How many surface points to sample.
     granularity = 500

--- a/docs/src/_docs/samplers.md
+++ b/docs/src/_docs/samplers.md
@@ -53,9 +53,10 @@ end
 
 function plot_sampler(chain)
     # Extract values from chain.
-    ss = link.(Ref(InverseGamma(2,3)), chain[:s])
-    ms = chain[:m]
-    lps = chain[:lp]
+    val = get(chain, [:s, :m, :lp])
+    ss = link.(Ref(InverseGamma(2,3)), val.s)
+    ms = val.m
+    lps = val.lp
 
     # How many surface points to sample.
     granularity = 500
@@ -81,7 +82,7 @@ function plot_sampler(chain)
         legend=false, colorbar=false, alpha=0.5)
 
     return p
-end
+end;
 ````
 
 

--- a/test/compiler.jl/assume.jl
+++ b/test/compiler.jl/assume.jl
@@ -14,10 +14,10 @@ pg = PG(10,1000)
 
 res = sample(test_assume(), smc)
 
-@test all(res[:x] .== 1) # check that x is always 1
-@test mean(res[:y]) ≈ 0.5 atol=0.1 # check that the mean of y is between 0.4 and 0.6
+@test all(res[:x].value .== 1) # check that x is always 1
+@test mean(res[:y].value) ≈ 0.5 atol=0.1 # check that the mean of y is between 0.4 and 0.6
 
 res = sample(test_assume(), pg)
 
-@test all(res[:x] .== 1) # check that x is always 1
-@test mean(res[:y]) ≈ 0.5 atol=0.1 # check that the mean of y is between 0.4 and 0.6
+@test all(res[:x].value .== 1) # check that x is always 1
+@test mean(res[:y].value) ≈ 0.5 atol=0.1 # check that the mean of y is between 0.4 and 0.6

--- a/test/compiler.jl/explicit_ret.jl
+++ b/test/compiler.jl/explicit_ret.jl
@@ -14,6 +14,6 @@ mf = test_ex_rt()
 for alg = [HMC(2000, 0.2, 3), PG(20, 2000), SMC(10000), IS(10000), Gibbs(2000, PG(20, 1, :x), HMC(1, 0.2, 3, :y))]
   println("[explicit_ret.jl] testing $alg")
   chn = sample(mf, alg)
-  @test mean(chn[:x]) ≈ 10.0 atol=0.2
-  @test mean(chn[:y]) ≈ 5.0 atol=0.2
+  @test mean(chn[:x].value) ≈ 10.0 atol=0.2
+  @test mean(chn[:y].value) ≈ 5.0 atol=0.2
 end

--- a/test/compiler.jl/observe.jl
+++ b/test/compiler.jl/observe.jl
@@ -17,16 +17,16 @@ pg  = PG(100,10)
 
 res = sample(test(), is)
 
-@test all(res[:x] .== 1)  #c heck that x is always 1
+@test all(res[:x].value .== 1)  #c heck that x is always 1
 @test res.logevidence ≈ 2 * log(0.5)
 
 res = sample(test(), smc)
 
-@test all(res[:x] .== 1)  #c heck that x is always 1
+@test all(res[:x].value .== 1)  #c heck that x is always 1
 @test res.logevidence ≈ 2 * log(0.5)
 
 
 res = sample(test(), pg)
 
-@test all(res[:x] .== 1)  # check that x is always 1
+@test all(res[:x].value .== 1)  # check that x is always 1
 # PG does not provide logevidence estimate

--- a/test/compiler.jl/opt_param_of_dist.jl
+++ b/test/compiler.jl/opt_param_of_dist.jl
@@ -13,6 +13,6 @@ s = SMC(1000)
 
 res = sample(testassume, s)
 
-@test reduce(&, res[:x]) == 1 # check that x is always 1
+@test reduce(&, res[:x].value) == 1 # check that x is always 1
 
-@test mean(res[:y]) ≈ 0.5 atol=0.1 # check that the mean of y is between 0.4 and 0.6
+@test mean(res[:y].value) ≈ 0.5 atol=0.1 # check that the mean of y is between 0.4 and 0.6

--- a/test/compiler.jl/sample.jl
+++ b/test/compiler.jl/sample.jl
@@ -15,6 +15,6 @@ alg = Gibbs(1000, HMC(1, 0.2, 3, :m), PG(10, 1, :s))
 # NOTE: want to translate below to
 #       chn = sample(gdemo, Dict(:x => x), alg)
 chn = sample(gdemo2(x), alg);
-mean(chn[:s])
+mean(chn[:s].value)
 
 # Turing.TURING[:modelex]

--- a/test/dynamichmc-support.jl/dynamic_hmc.jl
+++ b/test/dynamichmc-support.jl/dynamic_hmc.jl
@@ -12,5 +12,5 @@ mf = gdemo(1.5, 2.0)
 
 chn = sample(mf, DynamicNUTS(2000));
 
-@test mean(chn[:s]) ≈ 49/24 atol=0.2
-@test mean(chn[:m]) ≈ 7/6 atol=0.2
+@test mean(chn[:s].value) ≈ 49/24 atol=0.2
+@test mean(chn[:m].value) ≈ 7/6 atol=0.2

--- a/test/gibbs.jl/gibbs.jl
+++ b/test/gibbs.jl/gibbs.jl
@@ -17,11 +17,11 @@ end
 
 alg = Gibbs(3000, CSMC(15, 1, :s), HMC(1, 0.2, 4, :m))
 chain = sample(gibbstest(x), alg)
-@test mean(chain[:s]) ≈ 49/24 atol=0.1
-println("mean(chain[:m]) = $(mean(chain[:m]))")
-@test mean(chain[:m]) ≈ 7/6 atol=0.1
+@test mean(chain[:s].value) ≈ 49/24 atol=0.1
+println("mean(chain[:m]) = $(mean(chain[:m].value))")
+@test mean(chain[:m].value) ≈ 7/6 atol=0.1
 
 alg = CSMC(15, 5000)
 chain = sample(gibbstest(x), alg)
-@test mean(chain[:s]) ≈ 49/24 atol=0.1
-@test mean(chain[:m]) ≈ 7/6 atol=0.1
+@test mean(chain[:s].value) ≈ 49/24 atol=0.1
+@test mean(chain[:m].value) ≈ 7/6 atol=0.1

--- a/test/gibbs.jl/gibbs2.jl
+++ b/test/gibbs.jl/gibbs2.jl
@@ -42,11 +42,11 @@ end
 gibbs = Gibbs(500, PG(10, 1, :z1, :z2, :z3, :z4), HMC(3, 0.15, 3, :mu1, :mu2))
 chain = sample(MoGtest(D), gibbs)
 
-@test mean(chain[:z1]) ≈ 1.0 atol=0.1
-@test mean(chain[:z2]) ≈ 1.0 atol=0.1
-@test mean(chain[:z3]) ≈ 2.0 atol=0.1
-@test mean(chain[:z4]) ≈ 2.0 atol=0.1
-@test mean(chain[:mu1]) ≈ 1.0 atol=0.1
-@test mean(chain[:mu2]) ≈ 4.0 atol=0.1
+@test mean(chain[:z1].value) ≈ 1.0 atol=0.1
+@test mean(chain[:z2].value) ≈ 1.0 atol=0.1
+@test mean(chain[:z3].value) ≈ 2.0 atol=0.1
+@test mean(chain[:z4].value) ≈ 2.0 atol=0.1
+@test mean(chain[:mu1].value) ≈ 1.0 atol=0.1
+@test mean(chain[:mu2].value) ≈ 4.0 atol=0.1
 
 setadsafe(false)

--- a/test/gibbs.jl/gibbs_constructor.jl
+++ b/test/gibbs.jl/gibbs_constructor.jl
@@ -28,7 +28,7 @@ for c in [c1, c2, c3 ,c4, c5]
   check_numerical(c, [:s, :m], [49/24, 7/6], eps=1.0)
 end
 
-@test length(c4[:s]) == N * (3 + 2)
+@test length(c4[:s].value) == N * (3 + 2)
 
 # Test gid of each samplers
 g = Turing.Sampler(s3, gdemo())

--- a/test/hmc.jl/constrained_simplex.jl
+++ b/test/hmc.jl/constrained_simplex.jl
@@ -14,4 +14,3 @@ end
 chain = sample(constrained_simplex_test(obs12), HMC(1000, 0.75, 2))
 
 check_numerical(chain, ["ps[1]", "ps[2]"], [5/16, 11/16], eps=0.015)
-check_numerical(chain, [:ps], [[5/16; 11/16]], eps=0.015)

--- a/test/hmc.jl/hmc_reverse_diff.jl
+++ b/test/hmc.jl/hmc_reverse_diff.jl
@@ -16,7 +16,7 @@ alg = HMC(3000, 0.15, 10)
 
 res = sample(gdemo([1.5, 2.0]), alg)
 
-println(mean(res[:s])," ≈ ", 49/24, "?")
-println(mean(res[:m])," ≈ ", 7/6, "?")
-@test mean(res[:s]) ≈ 49/24 atol=0.2
-@test mean(res[:m]) ≈ 7/6 atol=0.2
+println(mean(res[:s].value)," ≈ ", 49/24, "?")
+println(mean(res[:m].value)," ≈ ", 7/6, "?")
+@test mean(res[:s].value) ≈ 49/24 atol=0.2
+@test mean(res[:m].value) ≈ 7/6 atol=0.2

--- a/test/hmc.jl/matrix_support.jl
+++ b/test/hmc.jl/matrix_support.jl
@@ -12,7 +12,7 @@ chain = nothing
 τ = 3000
 for _ in 1:5
     chain = sample(model_f, HMC(τ, 0.1, 3))
-    r = reshape(chain[:v], τ, 2, 2)
+    r = reshape(chain[:v].value, τ, 2, 2)
     push!(vs, reshape(mean(r, dims = [1]), 2, 2))
 end
 

--- a/test/hmc_core.jl/bayes_lr.jl
+++ b/test/hmc_core.jl/bayes_lr.jl
@@ -25,7 +25,7 @@ println("s=$s, β=$β")
 mf = bayes_lr(xs, ys)
 chn = sample(mf, HMC(2000, 0.005, 3))
 
-println("mean of β: $(mean(chn[:β][1000:end]))")
+println("mean of β: $(mean(chn[1000:end, :β, :].value))")
 
 
 

--- a/test/hmc_core.jl/gdemo_hmc.jl
+++ b/test/hmc_core.jl/gdemo_hmc.jl
@@ -8,8 +8,8 @@ include("gdemo.jl")
 mf = gdemo()
 chn = sample(mf, HMC(2000, 0.05, 5))
 
-println("mean of s: $(mean(chn[:s][1000:end]))")
-println("mean of m: $(mean(chn[:m][1000:end]))")
+println("mean of s: $(mean(chn[1000:end, :s, :].value))")
+println("mean of m: $(mean(chn[1000:end, :m, :].value))")
 
 # Plain Julia
 

--- a/test/hmc_core.jl/simple_gauss_hmc.jl
+++ b/test/hmc_core.jl/simple_gauss_hmc.jl
@@ -8,7 +8,7 @@ include("simple_gauss.jl")
 mf = simple_gauss()
 chn = sample(mf, HMC(10000, 0.05, 10))
 
-println("mean of m: $(mean(chn[:m][1000:end]))")
+println("mean of m: $(mean(chn[1000:end, :m, :].value))")
 
 # Plain Julia
 

--- a/test/hmc_core.jl/sv.jl
+++ b/test/hmc_core.jl/sv.jl
@@ -22,7 +22,7 @@ sv_data = load(TPATH*"/example-models/nips-2017/sv-data.jld.data")["data"]
 mf = sv_model(data=sv_data[1])
 chain_nuts = sample(mf, HMC(2000, 0.05, 10))
 
-println("mean of m: $(mean(chn[:μ][1000:end]))")
+println("mean of m: $(mean(chn[1000:end, :μ, :].value))")
 
 
 

--- a/test/hmcda.jl/hmcda_geweke.jl
+++ b/test/hmcda.jl/hmcda_geweke.jl
@@ -39,7 +39,7 @@ s = sample(gdemo_fw(), fw);
 
 N = div(NSamples, 50)
 
-x = [s[:y][1]...]
+x = [s[1,:y,:].value...]
 s_bk = Array{Turing.Chain}(undef, N)
 
 simple_logger = Base.CoreLogging.SimpleLogger(stderr, Base.CoreLogging.Debug)
@@ -48,7 +48,7 @@ Base.CoreLogging.with_logger(simple_logger) do
   i = 1
   while i <= N
     s_bk[i] = sample(gdemo_bk(x), bk);
-    x = [s_bk[i][:y][end]...];
+    x = [s_bk[i][end, :y, :]...];
     i += 1
   end
 end

--- a/test/ipmcmc.jl/ipmcmc.jl
+++ b/test/ipmcmc.jl/ipmcmc.jl
@@ -17,5 +17,5 @@ end
 
 alg = IPMCMC(30, 500, 4)
 chain = sample(gdemo(x), alg)
-@test mean(chain[:s]) ≈ 49/24 atol=0.1
-@test mean(chain[:m]) ≈ 7/6 atol=0.1
+@test mean(chain[:s].value) ≈ 49/24 atol=0.1
+@test mean(chain[:m].value) ≈ 7/6 atol=0.1

--- a/test/ipmcmc.jl/ipmcmc2.jl
+++ b/test/ipmcmc.jl/ipmcmc2.jl
@@ -39,9 +39,9 @@ end
 gibbs = IPMCMC(15, 100, 10)
 chain = sample(MoGtest(D), gibbs)
 
-@test mean(chain[:z1]) ≈ 1.0 atol=0.1
-@test mean(chain[:z2]) ≈ 1.0 atol=0.1
-@test mean(chain[:z3]) ≈ 2.0 atol=0.1
-@test mean(chain[:z4]) ≈ 2.0 atol=0.1
-@test mean(chain[:mu1]) ≈ 1.0 atol=0.1
-@test mean(chain[:mu2]) ≈ 4.0 atol=0.1
+@test mean(chain[:z1].value) ≈ 1.0 atol=0.1
+@test mean(chain[:z2].value) ≈ 1.0 atol=0.1
+@test mean(chain[:z3].value) ≈ 2.0 atol=0.1
+@test mean(chain[:z4].value) ≈ 2.0 atol=0.1
+@test mean(chain[:mu1].value) ≈ 1.0 atol=0.1
+@test mean(chain[:mu2].value) ≈ 4.0 atol=0.1

--- a/test/ipmcmc.jl/ipmcmc_cons.jl
+++ b/test/ipmcmc.jl/ipmcmc_cons.jl
@@ -21,6 +21,6 @@ c2 = sample(gdemo(), s2)
 
 # Very loose bound, only for testing constructor.
 for c in [c1, c2]
-  @test mean(c[:s]) ≈ 49/24 atol=1.0
-  @test mean(c[:m]) ≈ 7/6 atol=1.0
+  @test mean(c[:s].value) ≈ 49/24 atol=1.0
+  @test mean(c[:m].value) ≈ 7/6 atol=1.0
 end

--- a/test/is.jl/importance_sampling.jl
+++ b/test/is.jl/importance_sampling.jl
@@ -51,11 +51,12 @@ let n = 10
     exact = reference(n)
     Random.seed!(seed)
     tested = sample(_f, alg)
+    t_vals = get(tested, [:a, :b, :lp])
     for i = 1:n
-        @test exact[:samples][i][:a] == tested[:a][i,1,1]
-        @test exact[:samples][i][:b] == tested[:b][i,1,1]
-        @test exact[:lp][i]  == tested[:lp][i]
+        @test exact[:samples][i][:a] == t_vals.a[i]
+        @test exact[:samples][i][:b] == t_vals.b[i]
+        @test exact[:lp][i] == t_vals.lp[i]
     end
-    @test all(exact[:lp] .== tested[:lp])
+    @test all(exact[:lp] .== t_vals.lp)
   end
 end

--- a/test/mh.jl/mh.jl
+++ b/test/mh.jl/mh.jl
@@ -17,18 +17,18 @@ end
 # MH with prior as proposal
 alg = MH(2000)
 chain = sample(mhtest(x), alg)
-@test mean(chain[:s]) ≈ 49/24 atol=0.1
-@test mean(chain[:m]) ≈ 7/6 atol=0.1
+@test mean(chain[:s].value) ≈ 49/24 atol=0.1
+@test mean(chain[:m].value) ≈ 7/6 atol=0.1
 
 # MH with Gaussian proposal
 GKernel(var) = (x) -> Normal(x, sqrt.(var))
 alg = MH(5000, (:s, GKernel(5)), (:m, GKernel(1.0)))
 chain = sample(mhtest(x), alg)
-@test mean(chain[:s]) ≈ 49/24 atol=0.2
-@test mean(chain[:m]) ≈ 7/6 atol=0.1
+@test mean(chain[:s].value) ≈ 49/24 atol=0.2
+@test mean(chain[:m].value) ≈ 7/6 atol=0.1
 
 # MH within Gibbs
 alg = Gibbs(1000, MH(5, :m), MH(5, :s))
 chain = sample(mhtest(x), alg)
-@test mean(chain[:s]) ≈ 49/24 atol=0.1
-@test mean(chain[:m]) ≈ 7/6 atol=0.1
+@test mean(chain[:s].value) ≈ 49/24 atol=0.1
+@test mean(chain[:m].value) ≈ 7/6 atol=0.1

--- a/test/mh.jl/mh2.jl
+++ b/test/mh.jl/mh2.jl
@@ -39,9 +39,9 @@ GKernel(var) = (x) -> Normal(x, sqrt.(var))
 gibbs = Gibbs(1000, CSMC(10, 1, :z1, :z2, :z3, :z4), MH(10, (:mu1,GKernel(1)), (:mu2,GKernel(1))))
 chain = sample(MoGtest(D), gibbs)
 
-@test mean(chain[:z1]) ≈ 1.0 atol=0.1
-@test mean(chain[:z2]) ≈ 1.0 atol=0.1
-@test mean(chain[:z3]) ≈ 2.0 atol=0.1
-@test mean(chain[:z4]) ≈ 2.0 atol=0.1
-@test mean(chain[:mu1]) ≈ 1.0 atol=0.1
-@test mean(chain[:mu2]) ≈ 4.0 atol=0.25
+@test mean(chain[:z1].value) ≈ 1.0 atol=0.1
+@test mean(chain[:z2].value) ≈ 1.0 atol=0.1
+@test mean(chain[:z3].value) ≈ 2.0 atol=0.1
+@test mean(chain[:z4].value) ≈ 2.0 atol=0.1
+@test mean(chain[:mu1].value) ≈ 1.0 atol=0.1
+@test mean(chain[:mu2].value) ≈ 4.0 atol=0.25

--- a/test/mh.jl/mh_cons.jl
+++ b/test/mh.jl/mh_cons.jl
@@ -25,6 +25,6 @@ c4 = sample(gdemo(), s4)
 
 # Very loose bound, only for testing constructor.
 for c in [c1, c2, c3, c4]
-  @test mean(c[:s]) ≈ 49/24 atol=1.0
-  @test mean(c[:m]) ≈ 7/6 atol=1.0
+  @test mean(c[:s].value) ≈ 49/24 atol=1.0
+  @test mean(c[:m].value) ≈ 7/6 atol=1.0
 end

--- a/test/models.jl/single_dist_correctness.jl
+++ b/test/models.jl/single_dist_correctness.jl
@@ -79,7 +79,7 @@ dist_matrix = [Wishart(7, [1 0.5; 0.5 1]),
                     end
                     chn = sample(m(), NUTS(n_samples, 0.8))
 
-                    chn_xs = chn[:x][1:2:end] # thining by halving
+                    chn_xs = chn[1:2:end, :x, :].value # thining by halving
 
                     # Mean
                     dist_mean = mean(dist)

--- a/test/nuts.jl/nuts.jl
+++ b/test/nuts.jl/nuts.jl
@@ -15,7 +15,8 @@ model_f = gdemo([1.5, 2.0])
 alg = NUTS(5000, 1000, 0.65)
 res = sample(model_f, alg)
 
-@info(mean(res[:s][1000:end])," ≈ ", 49/24, "?")
-@info(mean(res[:m][1000:end])," ≈ ", 7/6, "?")
-@test mean(res[:s][1000:end]) ≈ 49/24 atol=0.2
-@test mean(res[:m][1000:end]) ≈ 7/6 atol=0.2
+v = get(res, [:s, :m])
+@info(mean(v.s[1000:end])," ≈ ", 49/24, "?")
+@info(mean(v.m[1000:end])," ≈ ", 7/6, "?")
+@test mean(v.s[1000:end]) ≈ 49/24 atol=0.2
+@test mean(v.m[1000:end]) ≈ 7/6 atol=0.2

--- a/test/nuts.jl/nuts_geweke.jl
+++ b/test/nuts.jl/nuts_geweke.jl
@@ -40,37 +40,37 @@ s = sample(gdemo_fw(), fw);
 
 N = div(NSamples, bk_sample_n)
 
-x = [s[:y][1]...]
-s_bk = Array{Turing.Chain}(undef, N)
+x = [s[1, :y, :].value...]
+s_bk = Array{MCMCChains.Chains}(undef, N)
 
 simple_logger = Base.CoreLogging.SimpleLogger(stderr, Base.CoreLogging.Debug)
 with_logger(simple_logger) do
   i = 1
   while i <= N
     s_bk[i] = sample(gdemo_bk(x), bk);
-    x = [s_bk[i][:y][end]...];
+    x = [s_bk[i][end, :y, :].value...];
     i += 1
   end
 end
 
-s2 = vcat(s_bk...);
+s2 = chainscat(s_bk...);
 # describe(s2)
 
 
 # qqplot(s[:m], s2[:m])
 # qqplot(s[:s], s2[:s])
 
-qqm = qqbuild(s[:m], s2[:m])
+qqm = qqbuild(s[:m].value, s2[:m].value)
 
 using UnicodePlots
 
-qqm = qqbuild(s[:m], s2[:m])
+qqm = qqbuild(s[:m].value, s2[:m].value)
 show(scatterplot(qqm.qx, qqm.qy, title = "QQ plot for m", canvas = DotCanvas))
 show(scatterplot(qqm.qx[51:end-50], qqm.qy[51:end-50], title = "QQ plot for m (removing first and last 50 quantiles):", canvas = DotCanvas))
 show(scatterplot(qqm.qx, qqm.qy, title = "QQ plot for m"))
 show(scatterplot(qqm.qx[51:end-50], qqm.qy[51:end-50], title = "QQ plot for m (removing first and last 50 quantiles):"))
 
-qqs = qqbuild(s[:s], s2[:s])
+qqs = qqbuild(s[:s].value, s2[:s].value)
 show(scatterplot(qqs.qx, qqs.qy, title = "QQ plot for s"))
 show(scatterplot(qqs.qx[51:end-50], qqs.qy[51:end-50], title = "QQ plot for s (removing first and last 50 quantiles):"))
 

--- a/test/pmmh.jl/pmmh.jl
+++ b/test/pmmh.jl/pmmh.jl
@@ -19,17 +19,17 @@ end
 GKernel(var) = (x) -> Normal(x, sqrt.(var))
 alg = PMMH(1000, SMC(20, :m), MH(1,(:s, GKernel(1))))
 chain = sample(pmmhtest(x), alg)
-@test mean(chain[:s]) ≈ 49/24 atol=0.2
-@test mean(chain[:m]) ≈ 7/6 atol=0.1
+@test mean(chain[:s].value) ≈ 49/24 atol=0.2
+@test mean(chain[:m].value) ≈ 7/6 atol=0.1
 
 # PMMH with prior as proposal
 alg = PMMH(1000, SMC(20, :m), MH(1,:s))
 chain = sample(pmmhtest(x), alg)
-@test mean(chain[:s]) ≈ 49/24 atol=0.1
-@test mean(chain[:m]) ≈ 7/6 atol=0.1
+@test mean(chain[:s].value) ≈ 49/24 atol=0.1
+@test mean(chain[:m].value) ≈ 7/6 atol=0.1
 
 # PIMH
 alg = PIMH(1000, SMC(20))
 chain = sample(pmmhtest(x), alg)
-@test mean(chain[:s]) ≈ 49/24 atol=0.15
-@test mean(chain[:m]) ≈ 7/6 atol=0.1
+@test mean(chain[:s].value) ≈ 49/24 atol=0.15
+@test mean(chain[:m].value) ≈ 7/6 atol=0.1

--- a/test/pmmh.jl/pmmh2.jl
+++ b/test/pmmh.jl/pmmh2.jl
@@ -39,9 +39,9 @@ end
 pmmh = PMMH(500, SMC(10, :z1, :z2, :z3, :z4), MH(1, :mu1, :mu2))
 chain = sample(MoGtest(D), pmmh)
 
-@test mean(chain[:z1]) ≈ 1.0 atol=0.1
-@test mean(chain[:z2]) ≈ 1.0 atol=0.1
-@test mean(chain[:z3]) ≈ 2.0 atol=0.1
-@test mean(chain[:z4]) ≈ 2.0 atol=0.1
-@test mean(chain[:mu1]) ≈ 1.0 atol=0.1
-@test mean(chain[:mu2]) ≈ 4.0 atol=0.1
+@test mean(chain[:z1].value) ≈ 1.0 atol=0.1
+@test mean(chain[:z2].value) ≈ 1.0 atol=0.1
+@test mean(chain[:z3].value) ≈ 2.0 atol=0.1
+@test mean(chain[:z4].value) ≈ 2.0 atol=0.1
+@test mean(chain[:mu1].value) ≈ 1.0 atol=0.1
+@test mean(chain[:mu2].value) ≈ 4.0 atol=0.1

--- a/test/pmmh.jl/pmmh_cons.jl
+++ b/test/pmmh.jl/pmmh_cons.jl
@@ -23,6 +23,6 @@ c3 = sample(gdemo(), s3)
 
 # Very loose bound, only for testing constructor.
 for c in [c1, c2, c3]
-  @test mean(c[:s]) ≈ 49/24 atol=1.0
-  @test mean(c[:m]) ≈ 7/6 atol=1.0
+  @test mean(c[:s].value) ≈ 49/24 atol=1.0
+  @test mean(c[:m].value) ≈ 7/6 atol=1.0
 end

--- a/test/sghmc.jl/sghmc.jl
+++ b/test/sghmc.jl/sghmc.jl
@@ -14,5 +14,5 @@ end
 
 chain = sample(gdemo([1.5, 2.0]), alg)
 
-@test mean(chain[:s]) ≈ 49/24 atol=0.1
-@test mean(chain[:m]) ≈ 7/6 atol=0.1
+@test mean(chain[:s].value) ≈ 49/24 atol=0.1
+@test mean(chain[:m].value) ≈ 7/6 atol=0.1

--- a/test/sgld.jl/sgld.jl
+++ b/test/sgld.jl/sgld.jl
@@ -13,7 +13,8 @@ end
 chain = sample(gdemo([1.5, 2.0]), SGLD(10000, 0.5))
 
 # Note: samples are weigthed by step sizes cf 4.2 in paper
-s_res1weightedMean = sum(chain[:lf_eps] .* chain[:s]) / sum(chain[:lf_eps])
-m_res1weightedMean = sum(chain[:lf_eps] .* chain[:m]) / sum(chain[:lf_eps])
+v = get(chain, [:lf_eps, :s, :m])
+s_res1weightedMean = sum(v.lf_eps .* v.s) / sum(v.lf_eps)
+m_res1weightedMean = sum(v.lf_eps .* v.m) / sum(v.lf_eps)
 @test s_res1weightedMean ≈ 49/24 atol=0.2
 @test m_res1weightedMean ≈ 7/6 atol=0.2

--- a/test/utility.jl
+++ b/test/utility.jl
@@ -9,7 +9,7 @@ function check_numerical(
 )
 	for (sym, val) in zip(symbols, exact_vals)
         @info sym, val
-        E = val isa Real ? mean(chain[sym]) : vec(mean(chain[sym], dims=[1]))
+        E = val isa Real ? mean(chain[sym].value) : vec(mean(chain[sym].value, dims=[1]))
 		print("  $sym = $E ≈ $val (eps = $eps) ?")
 		cmp = abs.(sum(E - val)) <= eps
 		if cmp

--- a/test/varinfo.jl/test_varname.jl
+++ b/test/varinfo.jl/test_varname.jl
@@ -71,7 +71,7 @@ v_mat = eval(varname(:((x[1,2][1+5][45][3][i])))[1])
 end
 chain = sample(mat_name_test(), HMC(1000, 0.2, 4))
 
-@test mean(chain[Symbol("p[1, 1]")]) ≈ 0 atol=0.25
+@test mean(chain["p[1, 1]"].value) ≈ 0 atol=0.25
 
 # Multi array
 i, j = 1, 2
@@ -88,5 +88,4 @@ v_arrarr = eval(varname(:(x[i][j]))[1])
   p
 end
 chain = sample(marr_name_test(), HMC(1000, 0.2, 4))
-@test mean(chain[Symbol("p[1][1]")]) ≈ 0 atol=0.25
-
+@test mean(chain["p[1][1]"].value) ≈ 0 atol=0.25


### PR DESCRIPTION
Updates all the tests to use the MCMCChains indexing behavior, since `chn[:param]` now returns a `Chains` object and not an array. I also updated the sampler page to use the correct indexing.