### PR TITLE
Fix a bug in `find_good_eps`

### DIFF
--- a/src/inference/support/hmc_core.jl
+++ b/src/inference/support/hmc_core.jl
@@ -232,9 +232,10 @@ function find_good_eps(model, spl::Sampler{T}, vi::VarInfo) where T
     momentum_sampler = gen_momentum_sampler(vi, spl)
     grad_func = gen_grad_func(vi, spl, model)
     H_func = gen_H_func()
-    θ = vi[spl]
+    θ, lj = vi[spl], vi.logp
     ϵ = _find_good_eps(θ, lj_func, grad_func, H_func, momentum_sampler)
     vi[spl] = θ
+    setlogp!(vi, lj)
     @info "[Turing] found initial ϵ: $ϵ"
     return ϵ
 end

--- a/src/inference/support/hmc_core.jl
+++ b/src/inference/support/hmc_core.jl
@@ -234,6 +234,7 @@ function find_good_eps(model, spl::Sampler{T}, vi::VarInfo) where T
     H_func = gen_H_func()
     θ = vi[spl]
     ϵ = _find_good_eps(θ, lj_func, grad_func, H_func, momentum_sampler)
+    vi[spl] = θ
     @info "[Turing] found initial ϵ: $ϵ"
     return ϵ
 end

--- a/test/inference/hmcda.jl
+++ b/test/inference/hmcda.jl
@@ -4,6 +4,8 @@ using Turing: Sampler
 include("../test_utils/AllUtils.jl")
 
 @testset "hmcda.jl" begin
+    Random.seed!(1234)
+    
     @numerical_testset "hmcda inference" begin
         alg1 = HMCDA(3000, 1000, 0.65, 0.015)
         # alg2 = Gibbs(3000, HMCDA(1, 200, 0.65, 0.35, :m), HMC(1, 0.25, 3, :s))

--- a/test/utilities/io.jl
+++ b/test/utilities/io.jl
@@ -4,7 +4,7 @@ include("../test_utils/AllUtils.jl")
 
 @testset "io.jl" begin
     @testset "chain save/resume" begin
-        Random.seed!(123)
+        Random.seed!(1234)
 
         alg1 = HMCDA(3000, 1000, 0.65, 0.15)
         alg2 = PG(20, 500)


### PR DESCRIPTION
I guess we lost these lines of reverting theta and log-joint during some previous refactoring...