### PR TITLE
Add Julia compatibility

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,3 +19,6 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
+
+[compat]
+julia = ">= 1.0"


### PR DESCRIPTION
[Fredrik suggested](https://github.com/JuliaRegistries/General/pull/304) adding a Julia compat section to the Project.toml file. Could someone look at the second I've added and see if it seems reasonable? Do we want to publish with `julia = ">= 1.0"`?