### PR TITLE
Disallow numerical tests on Appveyor

### DIFF
--- a/src/utilities/distributions.jl
+++ b/src/utilities/distributions.jl
@@ -27,13 +27,13 @@ function Distributions.logpdf(d::FlatPos, x::AbstractVector{<:Real})
 end
 
 # Binomial with logit
-struct BinomialLogit{T<:Real} <: DiscreteUnivariateDistribution
-    n::Int64
+struct BinomialLogit{T<:Real, I<:Integer} <: DiscreteUnivariateDistribution
+    n::I
     logitp::T
 end
 
-struct VecBinomialLogit{T<:Real} <: DiscreteUnivariateDistribution
-    n::Vector{Int64}
+struct VecBinomialLogit{T<:Real, I<:Integer} <: DiscreteUnivariateDistribution
+    n::Vector{I}
     logitp::Vector{T}
 end
 
@@ -42,10 +42,10 @@ function logpdf_binomial_logit(n, logitp, k)
     return logcomb + k * logitp - n * StatsFuns.log1pexp(logitp)
 end
 
-function Distributions.logpdf(d::BinomialLogit{<:Real}, k::Int64)
+function Distributions.logpdf(d::BinomialLogit{<:Real}, k::T) where {T<:Integer}
     return logpdf_binomial_logit(d.n, d.logitp, k)
 end
 
-function Distributions.logpdf(d::VecBinomialLogit{<:Real}, ks::Vector{Int64})
+function Distributions.logpdf(d::VecBinomialLogit{<:Real}, ks::Vector{<:Integer})
     return sum(logpdf_binomial_logit.(d.n, d.logitp, ks))
 end

--- a/test/test_utils/staging.jl
+++ b/test/test_utils/staging.jl
@@ -1,18 +1,19 @@
 function get_stage()
+    # Appveyor uses "True" for non-Ubuntu images.
+    if get(ENV, "APPVEYOR", "") == "True" || get(ENV, "APPVEYOR", "") == "true"
+        return "nonnumeric"
+    end
+
+    # Handle Travis specially.
     if get(ENV, "TRAVIS", "") == "true"
         if "STAGE" in keys(ENV)
             return ENV["STAGE"]
         else
             return "all"
         end
-    else
-        return "all"
     end
 
-    # Appveyor uses "True" for non-Ubuntu images.
-    if get(ENV("APPVEYOR", "")) == "True" || get(ENV("APPVEYOR", "")) == "true"
-        return "appveyor"
-    end
+    return "all"
 end
 
 function do_test(stage_str)
@@ -20,7 +21,7 @@ function do_test(stage_str)
 
     # If the tests are being run by Appveyor, don't run
     # any numerical tests.
-    if stg == "appveyor"
+    if stg == "nonnumeric"
         if stage_str == "numerical"
             return false
         else

--- a/test/test_utils/staging.jl
+++ b/test/test_utils/staging.jl
@@ -10,7 +10,7 @@ function get_stage()
     end
 
     # Appveyor uses "True" for non-Ubuntu images.
-    if get(ENV("APPVEYOR", "")) == "True" or get(ENV("APPVEYOR", "")) == "true"
+    if get(ENV("APPVEYOR", "")) == "True" || get(ENV("APPVEYOR", "")) == "true"
         return "appveyor"
     end
 end

--- a/test/test_utils/staging.jl
+++ b/test/test_utils/staging.jl
@@ -8,10 +8,27 @@ function get_stage()
     else
         return "all"
     end
+
+    # Appveyor uses "True" for non-Ubuntu images.
+    if get(ENV("APPVEYOR", "")) == "True" or get(ENV("APPVEYOR", "")) == "true"
+        return "appveyor"
+    end
 end
 
 function do_test(stage_str)
     stg = get_stage()
+
+    # If the tests are being run by Appveyor, don't run
+    # any numerical tests.
+    if stg == "appveyor"
+        if stage_str == "numerical"
+            return false
+        else
+            return true
+        end
+    end
+
+    # Otherwise run the regular testing procedure.
     if stg == "all" || stg == stage_str
         return true
     end


### PR DESCRIPTION
This cuts around numerical tests for Appveyor by removing it from the regular staging flow. Fixes #776.