### PR TITLE
Discard adaptation samples

### DIFF
--- a/src/inference/hmc.jl
+++ b/src/inference/hmc.jl
@@ -220,6 +220,7 @@ function sample(
     adaptor = AHMCAdaptor(alg),
     init_theta::Union{Nothing,Array{<:Any,1}}=nothing,
     rng::AbstractRNG=GLOBAL_RNG,
+    discard_adapt::Bool=true,
     kwargs...
 )
     # Create sampler
@@ -283,7 +284,9 @@ function sample(
     end
 
     # Wrap the result by Chain
-    c = Chain(0.0, samples)
+    c = typeof(alg) <: AdaptiveHamiltonian && discard_adapt ?
+        Chain(0.0, samples[(alg.n_adapts+1):end]) :
+        Chain(0.0, samples)
 
     # Save state
     if save_state

--- a/test/inference/hmc.jl
+++ b/test/inference/hmc.jl
@@ -165,8 +165,8 @@ include("../test_utils/AllUtils.jl")
     @turing_testset "check discard" begin
         alg = NUTS(500, 100, 0.8)
 
-        c1 = sample(gdemo_default, alg1, discard_adapt = true)
-        c2 = sample(gdemo_default, alg1, discard_adapt = false)
+        c1 = sample(gdemo_default, alg, discard_adapt = true)
+        c2 = sample(gdemo_default, alg, discard_adapt = false)
 
         @test size(c1, 1) == 400
         @test size(c2, 1) == 500

--- a/test/inference/hmc.jl
+++ b/test/inference/hmc.jl
@@ -163,11 +163,10 @@ include("../test_utils/AllUtils.jl")
         sampler = Sampler(alg)
     end
     @turing_testset "check discard" begin
-        alg1 = NUTS(500, 100, 0.8, discard_adapt = true)
-        alg2 = NUTS(500, 100, 0.8, discard_adapt = false)
+        alg = NUTS(500, 100, 0.8)
 
-        c1 = sample(gdemo_default, alg1)
-        c2 = sample(gdemo_default, alg1)
+        c1 = sample(gdemo_default, alg1, discard_adapt = true)
+        c2 = sample(gdemo_default, alg1, discard_adapt = false)
 
         @test size(c1, 1) == 400
         @test size(c2, 1) == 500

--- a/test/inference/hmc.jl
+++ b/test/inference/hmc.jl
@@ -150,7 +150,7 @@ include("../test_utils/AllUtils.jl")
     @numerical_testset "nuts inference" begin
         alg = NUTS(5000, 1000, 0.8)
         res = sample(gdemo_default, alg)
-        check_gdemo(res[1000:end, :, :])
+        check_gdemo(res)
     end
     @turing_testset "nuts constructor" begin
         alg = NUTS(1000, 200, 0.65)
@@ -161,5 +161,15 @@ include("../test_utils/AllUtils.jl")
 
         alg = NUTS(1000, 200, 0.65, :m)
         sampler = Sampler(alg)
+    end
+    @turing_testset "check discard" begin
+        alg1 = NUTS(500, 100, 0.8, discard_adapt = true)
+        alg2 = NUTS(500, 100, 0.8, discard_adapt = false)
+
+        c1 = sample(gdemo_default, alg1)
+        c2 = sample(gdemo_default, alg1)
+
+        @test size(c1, 1) == 400
+        @test size(c2, 1) == 500
     end
 end


### PR DESCRIPTION
This PR modifies the `hmc.jl` file to discard the adaptation samples from `AdaptiveHamiltonian` samplers. I've added a keyword to the `sample` function for `NUTS` and `HMCDA` which is temporary until the sampling API is reworked, but for now you can choose to keep the adaptation samples using 

```julia
c1 = sample(model(. . .), NUTS(1000, 200, 0.65), discard_adapt = true)
c2 = sample(model(. . .), NUTS(1000, 200, 0.65), discard_adapt = false)
```

In the above case, `c1` has length 800, while `c2` has length 1000. `discard_adapt` defaults to true, so you must call `discard_adapt = false` explicitly if you want to hang on to them for some reason.

I also threw in a couple tests just to make sure this was sane.