### PR TITLE
Interface Implementation Part 1

### DIFF
--- a/docs/src/_docs/interface-manual.md
+++ b/docs/src/_docs/interface-manual.md
@@ -1,0 +1,11 @@
+# The Sampling Interface
+
+Turing's sampling interface presents several structures and functions that one needs to overload in order to implement an interface-compatible sampler. Currently it is non-operational, but the intent is to have all of Turing's samplers using the API below.
+
+1. A subtype of `AbstractSampler`, defined as a mutable struct containing state information
+2. A subtype of `AbstractTransition`, which represents a single draw from the sampler
+3. A function `transition_type` which returns the `AbstractTransition` type used by an implementation of an `AbstractSampler`
+4. A function `sample_init!` which performs any necessary set up
+5. A function `step!` which returns an `AbstractTransition`
+6. A function `sample_end!` which handles any sampler wrap-up
+7. A function `MCMCChains.Chains` which accepts an `Array{AbstractTransition, 1}` and returns an `MCMCChains` object

--- a/docs/src/_docs/interface-manual.md
+++ b/docs/src/_docs/interface-manual.md
@@ -4,8 +4,8 @@ Turing's sampling interface presents several structures and functions that one n
 
 1. A subtype of `AbstractSampler`, defined as a mutable struct containing state information
 2. A subtype of `AbstractTransition`, which represents a single draw from the sampler
-3. A function `transition_type` which returns the `AbstractTransition` type used by an implementation of an `AbstractSampler`
+3. A function `transitions_init` which returns a preallocated vector of the `AbstractTransition` type used by an implementation of an `AbstractSampler`
 4. A function `sample_init!` which performs any necessary set up
 5. A function `step!` which returns an `AbstractTransition`
 6. A function `sample_end!` which handles any sampler wrap-up
-7. A function `MCMCChains.Chains` which accepts an `Array{AbstractTransition, 1}` and returns an `MCMCChains` object
+7. A function `MCMCChains.Chains` which accepts the post-sampling vector created by `transitions_init` returns an `MCMCChains` object

--- a/src/interface/Interface.jl
+++ b/src/interface/Interface.jl
@@ -1,0 +1,136 @@
+module Interface
+
+import Distributions: sample, Sampleable
+import Random: GLOBAL_RNG, AbstractRNG
+
+export AbstractSampler,
+       AbstractTransition,
+       sample_init!,
+       sample_end!,
+       sample,
+       step!
+
+"""
+    AbstractSampler
+
+The `AbstractSampler` type is intended to be inherited from when
+implementing a custom sampler. Any persistent state information should be
+saved in a subtype of `AbstractSampler`.
+
+When defining a new sampler, you should also overload the function
+`transition_type`, which tells the `sample` function what type of parameter
+it should expect to receive.
+"""
+abstract type AbstractSampler end
+
+transition_type(s::AbstractSampler) = AbstractTransition
+
+"""
+    AbstractTransition
+
+The `AbstractTransition` type describes the results of a single step
+of a given sampler. As an example, one implementation of an
+`AbstractTransition` might include be a vector of parameters sampled from
+a prior distribution.
+
+Transition types should store a single draw from any sampler, since the
+interface will sample `N` times, and store the results of each step in an
+array of type `Array{Transition<:AbstractTransition, 1}`. If you were
+using a sampler that returned a `NamedTuple` after each step, your
+implementation might look like:
+
+```
+struct MyTransition <: AbstractTransition
+    draw :: NamedTuple
+end
+```
+"""
+abstract type AbstractTransition end
+
+
+"""
+    sample(
+        ℓ::ModelType,
+        s::SamplerType,
+        N::Integer;
+        kwargs...)
+        
+    sample(
+        rng::AbstractRNG,
+        ℓ::ModelType,
+        s::SamplerType,
+        N::Integer;
+        kwargs...)
+
+A generic interface for samplers.
+"""
+function sample(
+    ℓ::ModelType,
+    s::SamplerType,
+    N::Integer;
+    kwargs...
+) where {ModelType<:Sampleable, SamplerType<:AbstractSampler}
+    return sample(GLOBAL_RNG, ℓ, s, N)
+end
+
+function sample(
+    rng::AbstractRNG,
+    ℓ::ModelType,
+    s::SamplerType,
+    N::Integer;
+    kwargs...
+) where {ModelType<:Sampleable, SamplerType<:AbstractSampler}
+    # Perform any necessary setup.
+    sample_init!(rng, ℓ, s, N; kwargs...)
+
+    # Preallocate the TransitionType vector.
+    t = Array{transition_type(s), 1}(undef, N)
+
+    # Step through the sampler.
+    for i=1:N
+        t[i] = step!(rng, ℓ, s, N; kwargs...)
+    end
+
+    # Wrap up the sampler, if necessary.
+    sample_end!(rng, ℓ, s, N; kwargs...)
+
+    return Chains(t)
+end
+
+function sample_init!(
+    rng::AbstractRNG,
+    ℓ::ModelType,
+    s::SamplerType,
+    N::Integer;
+    kwargs...
+) where {ModelType<:Sampleable, SamplerType<:AbstractSampler}
+    # Do nothing.
+    @warn "No sample_init! function has been implemented for objects
+           of types $(typeof(ℓ)) and $(typeof(s))"
+end
+
+function sample_end!(
+    rng::AbstractRNG,
+    ℓ::ModelType,
+    s::SamplerType,
+    N::Integer;
+    kwargs...
+) where {ModelType<:Sampleable, SamplerType<:AbstractSampler}
+    # Do nothing.
+    @warn "No sample_end! function has been implemented for objects
+           of types $(typeof(ℓ)) and $(typeof(s))"
+end
+
+function step!(
+    rng::AbstractRNG,
+    ℓ::ModelType,
+    s::SamplerType,
+    N::Integer;
+    kwargs...
+) where {ModelType<:Sampleable, SamplerType<:AbstractSampler}
+    # Do nothing.
+    @warn "No step! function has been implemented for objects
+           of types $(typeof(ℓ)) and $(typeof(s))"
+end
+
+end # module Interface

--- a/src/interface/Interface.jl
+++ b/src/interface/Interface.jl
@@ -150,7 +150,7 @@ function sample_end!(
     rng::AbstractRNG,
     ℓ::ModelType,
     s::SamplerType,
-    N::Integer
+    N::Integer,
     ts::Vector{TransitionType};
     kwargs...
 ) where {

--- a/src/interface/Interface.jl
+++ b/src/interface/Interface.jl
@@ -86,7 +86,7 @@ function sample(
 
     # Step through the sampler.
     for i=1:N
-        t[i] = step!(rng, ℓ, s, N; kwargs...)
+        t[i] = step!(rng, ℓ, s, N, t[1:(i-1)]; kwargs...)
     end
 
     # Wrap up the sampler, if necessary.
@@ -111,9 +111,13 @@ function sample_end!(
     rng::AbstractRNG,
     ℓ::ModelType,
     s::SamplerType,
-    N::Integer;
+    N::Integer,
+    t::TransitionType;
     kwargs...
-) where {ModelType<:Sampleable, SamplerType<:AbstractSampler}
+) where {ModelType<:Sampleable,
+    SamplerType<:AbstractSampler,
+    TransitionType<:AbstractTransition
+}
     # Do nothing.
     @warn "No sample_end! function has been implemented for objects
            of types $(typeof(ℓ)) and $(typeof(s))"

--- a/src/interface/Interface.jl
+++ b/src/interface/Interface.jl
@@ -23,8 +23,6 @@ it should expect to receive.
 """
 abstract type AbstractSampler end
 
-transition_type(s::AbstractSampler) = AbstractTransition
-
 """
     AbstractTransition
 
@@ -54,7 +52,7 @@ abstract type AbstractTransition end
         s::SamplerType,
         N::Integer;
         kwargs...)
-        
+
     sample(
         rng::AbstractRNG,
         ℓ::ModelType,
@@ -84,7 +82,7 @@ function sample(
     sample_init!(rng, ℓ, s, N; kwargs...)
 
     # Preallocate the TransitionType vector.
-    t = Array{transition_type(s), 1}(undef, N)
+    t = transitions_init(rng, ℓ, s, N; kwargs...)
 
     # Step through the sampler.
     for i=1:N
@@ -131,6 +129,18 @@ function step!(
     # Do nothing.
     @warn "No step! function has been implemented for objects
            of types $(typeof(ℓ)) and $(typeof(s))"
+end
+
+function transitions_init(
+    rng::AbstractRNG,
+    ℓ::ModelType,
+    s::SamplerType,
+    N::Integer;
+    kwargs...
+) where {ModelType<:Sampleable, SamplerType<:AbstractSampler}
+    @warn "No transitions_init function has been implemented
+           for objects of types $(typeof(ℓ)) and $(typeof(s))"
+    return Vector(undef, N)
 end
 
 end # module Interface


### PR DESCRIPTION
This is the first in a series of PRs intended to get Turing's internals working on a common interface. Currently there is **no functional change**, but it is a good idea to have the bones of the interface in the codebase for easier development later. 

Also note that the basic interface (`Interface.jl`) is ultimately intended to move over to MCMCChains, once all of Turing's relevant internals are updated.

In this PR:
1. The basic interface.
2. A document which I'll be updating over time, containing a general guide to interface implementation.
3. A basic hook of Turing into the interface, which basically only moves us from Turing's native `AbstractSampler` type to the `Interface` version.

**EDIT**

I've copied below the beginnings of the design document for the interface, so people don't have to click around for it:

# The Sampling Interface

Turing's sampling interface presents several structures and functions that one needs to overload in order to implement an interface-compatible sampler. Currently it is non-operational, but the intent is to have all of Turing's samplers using the API below.

1. A subtype of `AbstractSampler`, defined as a mutable struct containing state information
2. A subtype of `AbstractTransition`, which represents a single draw from the sampler
3. A function `transitions_init` which returns a preallocated vector of the `AbstractTransition` type used by an implementation of an `AbstractSampler`
4. A function `sample_init!` which performs any necessary set up
5. A function `step!` which returns an `AbstractTransition`
6. A function `sample_end!` which handles any sampler wrap-up
7. A function `MCMCChains.Chains` which accepts the post-sampling vector created by `transitions_init` returns an `MCMCChains` object
