### PR TITLE
Fix AHMC version before #791 is merged

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,7 +26,7 @@ Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
-AdvancedHMC = ">= 0.1.5"
+AdvancedHMC = "<= 0.1.5"
 julia = ">= 1.0"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -26,7 +26,7 @@ Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
-AdvancedHMC = "<= 0.1.5"
+AdvancedHMC = "0.1.5"
 julia = ">= 1.0"
 
 [extras]


### PR DESCRIPTION
There some interface changes haven't been synced between AHMC and Turing. Before #791 is merged Turing shall use AHMC <= 0.1.5