### PR TITLE
TS 3: Hook sample to TypedVarInfo

### DIFF
--- a/src/core/RandomVariables.jl
+++ b/src/core/RandomVariables.jl
@@ -1,7 +1,7 @@
 module RandomVariables
 
 using ...Turing: Turing, CACHERESET, CACHEIDCS, CACHERANGES, Model,
-    AbstractSampler, Sampler, SampleFromPrior,
+    AbstractSampler, Sampler, SampleFromPrior, SampleFromUniform,
     Selector, getspace
 using ...Utilities: vectorize, reconstruct, reconstruct!
 using Bijectors: SimplexDistribution, link, invlink
@@ -176,6 +176,42 @@ struct VarInfo{Tmeta, Tlogp} <: AbstractVarInfo
 end
 const UntypedVarInfo = VarInfo{<:Metadata}
 const TypedVarInfo = VarInfo{<:NamedTuple}
+
+function VarInfo(model::Model)
+    vi = VarInfo()
+    model(vi, SampleFromUniform())
+    return TypedVarInfo(vi)
+end
+
+function VarInfo(old_vi::TypedVarInfo, spl, T)
+    md = newmetadata(old_vi.metadata, spl, T)
+    VarInfo(md, Base.RefValue{T}(old_vi.logp), Ref(old_vi.num_produce))
+end
+function newmetadata(metadata::NamedTuple{names}, spl, ::Type{T}) where {T, names}
+    # Check if the named tuple is empty and end the recursion
+    length(names) === 0 && return ()
+    # Take the first key in the NamedTuple
+    f = names[1]
+    mdf = getfield(metadata, f)
+    syms = getspace(spl)
+    if f ∈ syms || length(syms) == 0
+        idcs = mdf.idcs
+        vns = mdf.vns
+        ranges = mdf.ranges
+        vals = similar(mdf.vals, T)
+        dists = mdf.dists
+        gids = mdf.gids
+        orders = mdf.orders
+        flags = mdf.flags
+        md = Metadata(idcs, vns, ranges, vals, dists, gids, orders, flags)
+	    nt = NamedTuple{(f,)}((md,))
+        return merge(nt, newmetadata(_tail(metadata), spl, T))
+    else
+        md = getfield(vi, f)
+	    nt = NamedTuple{(f,)}((md,))
+        return merge(nt, newmetadata(_tail(metadata), spl, T))
+    end
+end
 
 ####
 #### Internal functions
@@ -643,7 +679,7 @@ Samples from `model` using the sampler `spl` storing the sample and log joint
 probability in `vi`.
 """
 function runmodel!(model::Model, vi::AbstractVarInfo, spl::AbstractSampler = SampleFromPrior())
-    setlogp!(vi, zero(Float64))
+    setlogp!(vi, 0)
     if spl isa Sampler && haskey(spl.info, :eval_num)
         spl.info[:eval_num] += 1
     end

--- a/src/core/RandomVariables.jl
+++ b/src/core/RandomVariables.jl
@@ -207,7 +207,7 @@ function newmetadata(metadata::NamedTuple{names}, spl, ::Type{T}) where {T, name
 	    nt = NamedTuple{(f,)}((md,))
         return merge(nt, newmetadata(_tail(metadata), spl, T))
     else
-        md = getfield(vi, f)
+        md = getfield(metadata, f)
 	    nt = NamedTuple{(f,)}((md,))
         return merge(nt, newmetadata(_tail(metadata), spl, T))
     end
@@ -442,7 +442,7 @@ end
 Returns a tuple of the unique symbols of random variables sampled in `vi`.
 """
 syms(vi::UntypedVarInfo) = Tuple(unique!(map(vn -> vn.sym, vi.vns)))  # get all symbols
-syms(vi::TypedVarInfo) = fieldnames(vi.metadata)
+syms(vi::TypedVarInfo) = keys(vi.metadata)
 
 # Get all indices of variables belonging to SampleFromPrior:
 #   if the gid/selector of a var is an empty Set, then that var is assumed to be assigned to
@@ -1135,7 +1135,7 @@ function push!(
             gidset::Set{Selector}
             ) where sym
 
-    @assert ~(haskey(vi, vn)) "[push!] attempt to add an exisitng variable $(vn.sym) ($(vn)) to TypedVarInfo of syms $(syms(vi)) with dist=$dist, gid=$gid"
+    @assert ~(haskey(vi, vn)) "[push!] attempt to add an exisitng variable $(vn.sym) ($(vn)) to TypedVarInfo of syms $(syms(vi)) with dist=$dist, gid=$gidset"
 
     val = vectorize(dist, r)
 

--- a/src/core/RandomVariables.jl
+++ b/src/core/RandomVariables.jl
@@ -183,6 +183,8 @@ function VarInfo(model::Model)
     return TypedVarInfo(vi)
 end
 
+VarInfo(old_vi::UntypedVarInfo, spl, T) = old_vi
+
 function VarInfo(old_vi::TypedVarInfo, spl, T)
     md = newmetadata(old_vi.metadata, spl, T)
     VarInfo(md, Base.RefValue{T}(old_vi.logp), Ref(old_vi.num_produce))

--- a/src/core/ad.jl
+++ b/src/core/ad.jl
@@ -151,8 +151,12 @@ function gradient_logp_reverse(
 
     # Specify objective function.
     function f(θ)
-        vi[sampler] = θ
-        return runmodel!(model, vi, sampler).logp
+        new_vi = VarInfo(vi, sampler, eltype(θ))
+        new_vi[sampler] = θ
+        logp = runmodel!(model, new_vi, sampler).logp
+        vi[sampler] = Tracker.data.(θ)
+        vi.logp = Tracker.data(logp)
+        return logp
     end
 
     # Compute forward and reverse passes.

--- a/src/core/ad.jl
+++ b/src/core/ad.jl
@@ -101,12 +101,16 @@ function gradient_logp_forward(
     sampler::AbstractSampler=SampleFromPrior(),
 )
     # Record old parameters.
-    vals_old, logp_old = copy(vi.vals), copy(vi.logp)
+    vals_old, logp_old = copy(vi[sampler]), copy(vi.logp)
 
     # Define function to compute log joint.
     function f(θ)
-        vi[sampler] = θ
-        return runmodel!(model, vi, sampler).logp
+        new_vi = VarInfo(vi, sampler, eltype(θ))
+        new_vi[sampler] = θ
+        logp = runmodel!(model, new_vi, sampler).logp
+        vi[sampler] = ForwardDiff.value.(θ)
+        vi.logp = ForwardDiff.value(logp)
+        return logp
     end
 
     chunk_size = getchunksize(sampler)
@@ -114,10 +118,10 @@ function gradient_logp_forward(
     chunk = ForwardDiff.Chunk(min(length(θ), chunk_size))
     config = ForwardDiff.GradientConfig(f, θ, chunk)
     ∂l∂θ = ForwardDiff.gradient!(similar(θ), f, θ, config)
-    l = vi.logp.value
+    l = vi.logp
 
     # Replace old parameters to ensure this function doesn't mutate `vi`.
-    vi.vals .= vals_old
+    vi[sampler] = vals_old
     vi.logp = logp_old
 
     # Strip tracking info from θ to avoid mutating it.
@@ -143,7 +147,7 @@ function gradient_logp_reverse(
     model::Model,
     sampler::AbstractSampler=SampleFromPrior(),
 )
-    vals_old, logp_old = copy(vi.vals), copy(vi.logp)
+    vals_old, logp_old = copy(vi[sampler]), copy(vi.logp)
 
     # Specify objective function.
     function f(θ)
@@ -156,7 +160,7 @@ function gradient_logp_reverse(
     l, ∂l∂θ = Tracker.data(l_tracked), Tracker.data(ȳ(1)[1])
 
     # Remove tracking info from variables in model (because mutable state).
-    vi.vals .= vals_old
+    vi[sampler] .= vals_old
     vi.logp = logp_old
     # Strip tracking info from θ to avoid mutating it.
     θ .= Tracker.data.(θ)

--- a/src/core/container.jl
+++ b/src/core/container.jl
@@ -1,67 +1,74 @@
-mutable struct Trace{T <: AbstractSampler}
-  task  ::  Task
-  vi    ::  VarInfo
-  spl   ::  T
-  Trace{T}() where T <: SampleFromPrior = (res = new(); res.vi = VarInfo(); res.spl = SampleFromPrior(); res)
-  Trace{T}() where T <: Sampler = (res = new(); res.vi = VarInfo(); res)
+mutable struct Trace{Tspl <: AbstractSampler, Tvi <: AbstractVarInfo, Tmodel <: Model}
+    task  ::  Task
+    vi    ::  Tvi
+    spl   ::  Tspl
+    model ::  Tmodel
+    Trace{Tspl, Tvi, Tmodel}() where {Tspl, Tvi, Tmodel} = new()
+    function Trace{SampleFromPrior}(m::Model, spl::AbstractSampler, vi::AbstractVarInfo)
+        res = new{SampleFromPrior, typeof(vi), typeof(m)}()
+        res.vi = vi
+        res.model = m
+        res.spl = SampleFromPrior()
+        return res
+    end
+    function Trace{T}(m::Model, spl::AbstractSampler, vi::AbstractVarInfo) where T <: Sampler
+        res = new{T, typeof(vi), typeof(m)}()
+        res.model = m
+        res.spl = spl
+        res.vi = vi
+        return res
+    end
+end
+function Base.copy(trace::Trace)
+    newtrace = typeof(trace)()
+    newtrace.vi = deepcopy(trace.vi)
+    newtrace.task = Base.copy(trace.task)
+    newtrace.spl = trace.spl
+    newtrace.model = trace.model
+    return newtrace
 end
 
 # NOTE: this function is called by `forkr`
-function Trace{T}(f) where T <: AbstractSampler
-  res = Trace{T}();
-  # CTask(()->f());
-  res.task = CTask( () -> begin res=f(); produce(Val{:done}); res; end )
-  if isa(res.task.storage, Nothing)
-    res.task.storage = IdDict()
-  end
-  res.task.storage[:turing_trace] = res # create a backward reference in task_local_storage
-  res
+function Trace(f::Function, m::Model, spl::T, vi::AbstractVarInfo) where {T <: AbstractSampler}
+    res = Trace{T}(m, spl, deepcopy(vi));
+    # CTask(()->f());
+    res.task = CTask( () -> begin res=f(); produce(Val{:done}); res; end )
+    if isa(res.task.storage, Nothing)
+        res.task.storage = IdDict()
+    end
+    res.task.storage[:turing_trace] = res # create a backward reference in task_local_storage
+    return res
 end
-Trace(f) = Trace{SampleFromPrior}(f)
-
-function Trace{T}(f, spl::Sampler, vi::VarInfo) where T <: Sampler
-  res = Trace{T}();
-  res.spl = spl
-  # CTask(()->f());
-  res.vi = deepcopy(vi)
-  res.vi.num_produce = 0
-  res.task = CTask( () -> begin vi_new=f(vi, spl); produce(Val{:done}); vi_new; end )
-  if isa(res.task.storage, Nothing)
-    res.task.storage = IdDict()
-  end
-  res.task.storage[:turing_trace] = res # create a backward reference in task_local_storage
-  res
+function Trace(m::Model, spl::T, vi::AbstractVarInfo) where {T <: AbstractSampler}
+    res = Trace{T}(m, spl, deepcopy(vi));
+    # CTask(()->f());
+    res.vi.num_produce = 0
+    res.task = CTask( () -> begin vi_new=m(vi, spl); produce(Val{:done}); vi_new; end )
+    if isa(res.task.storage, Nothing)
+        res.task.storage = IdDict()
+    end
+    res.task.storage[:turing_trace] = res # create a backward reference in task_local_storage
+    return res
 end
-Trace(f, spl::Sampler, vi::VarInfo) = Trace{typeof(spl)}(f, spl, vi)
 
 # step to the next observe statement, return log likelihood
 Libtask.consume(t::Trace) = (t.vi.num_produce += 1; consume(t.task))
 
 # Task copying version of fork for Trace.
 function fork(trace :: Trace, is_ref :: Bool = false)
-  newtrace = typeof(trace)()
-  newtrace.task = Base.copy(trace.task)
-  newtrace.spl = trace.spl
-
-  newtrace.vi = deepcopy(trace.vi)
-  if is_ref
-    set_retained_vns_del_by_spl!(newtrace.vi, newtrace.spl)
-  end
-
-  newtrace.task.storage[:turing_trace] = newtrace
-  newtrace
+    newtrace = copy(trace)
+    is_ref && set_retained_vns_del_by_spl!(newtrace.vi, newtrace.spl)
+    newtrace.task.storage[:turing_trace] = newtrace
+    return newtrace
 end
 
 # PG requires keeping all randomness for the reference particle
 # Create new task and copy randomness
 function forkr(trace :: Trace)
-  newtrace = typeof(trace)(trace.task.code)
-  newtrace.spl = trace.spl
-
-  newtrace.vi = deepcopy(trace.vi)
-  newtrace.vi.num_produce = 0
-
-  newtrace
+    newtrace = Trace(trace.task.code, trace.model, trace.spl, deepcopy(trace.vi))
+    newtrace.spl = trace.spl
+    newtrace.vi.num_produce = 0
+    return newtrace
 end
 
 current_trace() = current_task().storage[:turing_trace]
@@ -74,19 +81,19 @@ Data structure for particle filters
 - normalise!(pc::ParticleContainer)
 - consume(pc::ParticleContainer): return incremental likelihood
 """
-mutable struct ParticleContainer{T<:Particle, F}
-  model :: F
-  num_particles :: Int
-  vals  :: Array{T}
-  logWs :: Array{Float64}  # Log weights (Trace) or incremental likelihoods (ParticleContainer)
-  logE  :: Float64           # Log model evidence
-  # conditional :: Union{Nothing,Conditional} # storing parameters, helpful for implementing rejuvenation steps
-  conditional :: Nothing # storing parameters, helpful for implementing rejuvenation steps
-  n_consume :: Int # helpful for rejuvenation steps, e.g. in SMC2
+mutable struct ParticleContainer{T<:Particle, F, Tvals <: Array{T}, TlogW <: Array{Float64}}
+    model :: F
+    num_particles :: Int
+    vals  :: Tvals
+    logWs :: TlogW       # Log weights (Trace) or incremental likelihoods (ParticleContainer)
+    logE  :: Float64     # Log model evidence
+    # conditional :: Union{Nothing,Conditional} # storing parameters, helpful for implementing rejuvenation steps
+    conditional :: Nothing # storing parameters, helpful for implementing rejuvenation steps
+    n_consume :: Int # helpful for rejuvenation steps, e.g. in SMC2
 end
 ParticleContainer{T}(m) where T = ParticleContainer{T}(m, 0)
-function ParticleContainer{T}(m::F, n::Int) where {T, F}
-  ParticleContainer{T, F}(m, n, Vector{T}(), Vector{Float64}(), 0.0, nothing, 0)
+function ParticleContainer{T}(m, n::Int) where {T}
+    ParticleContainer(m, n, Vector{T}(), Vector{Float64}(), 0.0, nothing, 0)
 end
 
 Base.collect(pc :: ParticleContainer) = pc.vals # prev: Dict, now: Array
@@ -98,105 +105,105 @@ Base.getindex(pc :: ParticleContainer, i :: Real) = pc.vals[i]
 
 # registers a new x-particle in the container
 function Base.push!(pc :: ParticleContainer, p :: Particle)
-  pc.num_particles += 1
-  push!(pc.vals, p)
-  push!(pc.logWs, 0)
-  pc
+    pc.num_particles += 1
+    push!(pc.vals, p)
+    push!(pc.logWs, 0)
+    pc
 end
 Base.push!(pc :: ParticleContainer) = Base.push!(pc, eltype(pc.vals)(pc.model))
 
 function Base.push!(pc :: ParticleContainer, n :: Int, spl :: Sampler, varInfo :: VarInfo)
-  vals  = Vector{eltype(pc.vals)}(undef,n)
-  logWs = zeros(eltype(pc.logWs), n)
-  for i=1:n
-    vals[i]  = eltype(pc.vals)(pc.model, spl, varInfo)
-  end
-  append!(pc.vals, vals)
-  append!(pc.logWs, logWs)
-  pc.num_particles += n
-  pc
+    vals  = Vector{eltype(pc.vals)}(undef,n)
+    logWs = zeros(eltype(pc.logWs), n)
+    for i=1:n
+        vals[i]  = Trace(pc.model, spl, varInfo)
+    end
+    append!(pc.vals, vals)
+    append!(pc.logWs, logWs)
+    pc.num_particles += n
+    pc
 end
 
 # clears the container but keep params, logweight etc.
 function Base.empty!(pc :: ParticleContainer)
-  pc.num_particles = 0
-  pc.vals  = Vector{Particle}()
-  pc.logWs = Vector{Float64}()
-  pc
+    pc.num_particles = 0
+    pc.vals  = Vector{Particle}()
+    pc.logWs = Vector{Float64}()
+    pc
 end
 
 # clones a theta-particle
 function Base.copy(pc :: ParticleContainer)
-  particles = collect(pc)
-  newpc     = similar(pc)
-  for p in particles
-    newp = fork(p)
-    push!(newpc, newp)
-  end
-  newpc.logE        = pc.logE
-  newpc.logWs       = deepcopy(pc.logWs)
-  newpc.conditional = deepcopy(pc.conditional)
-  newpc.n_consume   = pc.n_consume
-  newpc
+    particles = collect(pc)
+    newpc     = similar(pc)
+    for p in particles
+        newp = fork(p)
+        push!(newpc, newp)
+    end
+    newpc.logE        = pc.logE
+    newpc.logWs       = deepcopy(pc.logWs)
+    newpc.conditional = deepcopy(pc.conditional)
+    newpc.n_consume   = pc.n_consume
+    newpc
 end
 
 # run particle filter for one step, return incremental likelihood
 function Libtask.consume(pc :: ParticleContainer)
-  @assert pc.num_particles == length(pc)
-  # normalisation factor: 1/N
-  _, z1      = weights(pc)
-  n = length(pc.vals)
+    @assert pc.num_particles == length(pc)
+    # normalisation factor: 1/N
+    _, z1      = weights(pc)
+    n = length(pc.vals)
 
-  particles = collect(pc)
-  num_done = 0
-  for i=1:n
-    p = pc.vals[i]
-    score = Libtask.consume(p)
-    if score isa Real
-      score += getlogp(p.vi)
-      resetlogp!(p.vi)
-      increase_logweight(pc, i, Float64(score))
-    elseif score == Val{:done}
-      num_done += 1
-    else
-      error("[consume]: error in running particle filter.")
+    particles = collect(pc)
+    num_done = 0
+    for i=1:n
+        p = pc.vals[i]
+        score = Libtask.consume(p)
+        if score isa Real
+            score += getlogp(p.vi)
+            resetlogp!(p.vi)
+            increase_logweight(pc, i, Float64(score))
+        elseif score == Val{:done}
+            num_done += 1
+        else
+            error("[consume]: error in running particle filter.")
+        end
     end
-  end
 
-  if num_done == length(pc)
-    res = Val{:done}
-  elseif num_done != 0
-    error("[consume]: mis-aligned execution traces, num_particles= $(n), num_done=$(num_done).")
-  else
-    # update incremental likelihoods
-    _, z2      = weights(pc)
-    res = increase_logevidence(pc, z2 - z1)
-    pc.n_consume += 1
-    # res = increase_loglikelihood(pc, z2 - z1)
-  end
+    if num_done == length(pc)
+        res = Val{:done}
+    elseif num_done != 0
+        error("[consume]: mis-aligned execution traces, num_particles= $(n), num_done=$(num_done).")
+    else
+        # update incremental likelihoods
+        _, z2      = weights(pc)
+        res = increase_logevidence(pc, z2 - z1)
+        pc.n_consume += 1
+        # res = increase_loglikelihood(pc, z2 - z1)
+    end
 
-  res
+    res
 end
 
 function weights(pc :: ParticleContainer)
-  @assert pc.num_particles == length(pc)
-  logWs = pc.logWs
-  Ws = exp.(logWs .- maximum(logWs))
-  logZ = log(sum(Ws)) + maximum(logWs)
-  Ws = Ws ./ sum(Ws)
-  return Ws, logZ
+    @assert pc.num_particles == length(pc)
+    logWs = pc.logWs
+    Ws = exp.(logWs .- maximum(logWs))
+    logZ = log(sum(Ws)) + maximum(logWs)
+    Ws = Ws ./ sum(Ws)
+    return Ws, logZ
 end
 
 function effectiveSampleSize(pc :: ParticleContainer)
-  Ws, _ = weights(pc)
-  ess = 1.0 / sum(Ws .^ 2) # sum(Ws) ^ 2 = 1.0, because weights are normalised
+    Ws, _ = weights(pc)
+    ess = 1.0 / sum(Ws .^ 2) # sum(Ws) ^ 2 = 1.0, because weights are normalised
 end
 
 increase_logweight(pc :: ParticleContainer, t :: Int, logw :: Float64) =
-  (pc.logWs[t]  += logw)
+    (pc.logWs[t]  += logw)
 
 increase_logevidence(pc :: ParticleContainer, logw :: Float64) =
-  (pc.logE += logw)
+    (pc.logE += logw)
 
 
 function resample!(
@@ -204,39 +211,39 @@ function resample!(
     randcat :: Function = Turing.Inference.resample_systematic,
     ref :: Union{Particle, Nothing} = nothing
 )
-  n1, particles = pc.num_particles, collect(pc)
-  @assert n1 == length(particles)
+    n1, particles = pc.num_particles, collect(pc)
+    @assert n1 == length(particles)
 
-  # resample
-  Ws, _ = weights(pc)
+    # resample
+    Ws, _ = weights(pc)
 
-  # check that weights are not NaN
-  @assert !any(isnan.(Ws))
+    # check that weights are not NaN
+    @assert !any(isnan.(Ws))
 
-  n2    = isa(ref, Nothing) ? n1 : n1-1
-  indx  = randcat(Ws, n2)
+    n2    = isa(ref, Nothing) ? n1 : n1-1
+    indx  = randcat(Ws, n2)
 
-  # fork particles
-  empty!(pc)
-  num_children = zeros(Int,n1)
-  map(i->num_children[i]+=1, indx)
-  for i = 1:n1
-    is_ref = particles[i] == ref
-    p = is_ref ? fork(particles[i], is_ref) : particles[i]
-    num_children[i] > 0 && push!(pc, p)
-    for k=1:num_children[i]-1
-      newp = fork(p, is_ref)
-      push!(pc, newp)
+    # fork particles
+    empty!(pc)
+    num_children = zeros(Int,n1)
+    map(i->num_children[i]+=1, indx)
+    for i = 1:n1
+        is_ref = particles[i] == ref
+        p = is_ref ? fork(particles[i], is_ref) : particles[i]
+        num_children[i] > 0 && push!(pc, p)
+        for k=1:num_children[i]-1
+            newp = fork(p, is_ref)
+            push!(pc, newp)
+        end
     end
-  end
 
-  if isa(ref, Particle)
-    # Insert the retained particle. This is based on the replaying trick for efficiency
-    #  reasons. If we implement PG using task copying, we need to store Nx * T particles!
-    push!(pc, ref)
-  end
+    if isa(ref, Particle)
+        # Insert the retained particle. This is based on the replaying trick for efficiency
+        #  reasons. If we implement PG using task copying, we need to store Nx * T particles!
+        push!(pc, ref)
+    end
 
-  pc
+    pc
 end
 
 
@@ -244,15 +251,15 @@ end
 
 # ParticleContainer: particles ==> (weight, results)
 function getsample(pc :: ParticleContainer, i :: Int, w :: Float64 = 0.)
-  p = pc.vals[i]
-  predicts = Sample(p.vi).value
-  predicts[:le] = pc.logE
-  return Sample(w, predicts)
+    p = pc.vals[i]
+    predicts = Sample(p.vi).value
+    predicts[:le] = pc.logE
+    return Sample(w, predicts)
 end
 
 function getsample(pc :: ParticleContainer)
-  w = pc.logE
-  Ws, z = weights(pc)
-  s = map((i)->getsample(pc, i, Ws[i]), 1:length(pc))
-  return exp.(w), s
+    w = pc.logE
+    Ws, z = weights(pc)
+    s = map((i)->getsample(pc, i, Ws[i]), 1:length(pc))
+    return exp.(w), s
 end

--- a/src/inference/AdvancedSMC.jl
+++ b/src/inference/AdvancedSMC.jl
@@ -66,7 +66,7 @@ function sample(model::Model, alg::SMC)
     spl = Sampler(alg)
 
     particles = ParticleContainer{Trace}(model)
-    push!(particles, spl.alg.n_particles, spl, VarInfo())
+    push!(particles, spl.alg.n_particles, spl, empty!(VarInfo(model)))
 
     while consume(particles) != Val{:done}
       ess = effectiveSampleSize(particles)
@@ -174,7 +174,7 @@ function sample(  model::Model,
     time_total = zero(Float64)
 
     vi = resume_from == nothing ?
-        VarInfo() :
+        empty!(VarInfo(model)) :
         resume_from.info[:vi]
 
     pm = nothing
@@ -413,7 +413,7 @@ function sample(  model::Model,
 
     # Init parameters
     vi = if resume_from == nothing
-        vi_ = VarInfo()
+        vi_ = empty!(VarInfo(model))
         model(vi_, SampleFromUniform())
         vi_
     else
@@ -572,7 +572,7 @@ function sample(model::Model, alg::IPMCMC)
   # Init parameters
   VarInfos = Array{VarInfo}(undef, spl.alg.n_nodes)
   for j in 1:spl.alg.n_nodes
-    VarInfos[j] = VarInfo()
+    VarInfos[j] = empty!(VarInfo(model))
   end
   n = spl.alg.n_iters
 

--- a/src/inference/AdvancedSMC.jl
+++ b/src/inference/AdvancedSMC.jl
@@ -413,9 +413,7 @@ function sample(  model::Model,
 
     # Init parameters
     vi = if resume_from == nothing
-        vi_ = empty!(VarInfo(model))
-        model(vi_, SampleFromUniform())
-        vi_
+        vi_ = VarInfo(model)
     else
         resume_from.info[:vi]
     end
@@ -570,9 +568,10 @@ function sample(model::Model, alg::IPMCMC)
   end
 
   # Init parameters
+  vi = empty!(VarInfo(model))
   VarInfos = Array{VarInfo}(undef, spl.alg.n_nodes)
   for j in 1:spl.alg.n_nodes
-    VarInfos[j] = empty!(VarInfo(model))
+    VarInfos[j] = deepcopy(vi)
   end
   n = spl.alg.n_iters
 

--- a/src/inference/AdvancedSMC.jl
+++ b/src/inference/AdvancedSMC.jl
@@ -569,7 +569,6 @@ function sample(model::Model, alg::IPMCMC)
 
   # Init parameters
   vi = empty!(VarInfo(model))
-  @show typeof(vi.metadata.x.vals)
   VarInfos = Array{VarInfo}(undef, spl.alg.n_nodes)
   for j in 1:spl.alg.n_nodes
     VarInfos[j] = deepcopy(vi)

--- a/src/inference/AdvancedSMC.jl
+++ b/src/inference/AdvancedSMC.jl
@@ -120,7 +120,7 @@ end
 step(model, spl::Sampler{<:PG}, vi::VarInfo, _) = step(model, spl, vi)
 
 function step(model, spl::Sampler{<:PG}, vi::VarInfo)
-    particles = ParticleContainer{Trace}(model)
+    particles = ParticleContainer{Trace{typeof(spl), typeof(vi), typeof(model)}}(model)
 
     vi.num_produce = 0;  # Reset num_produce before new sweep\.
     ref_particle = isempty(vi) ?
@@ -569,6 +569,7 @@ function sample(model::Model, alg::IPMCMC)
 
   # Init parameters
   vi = empty!(VarInfo(model))
+  @show typeof(vi.metadata.x.vals)
   VarInfos = Array{VarInfo}(undef, spl.alg.n_nodes)
   for j in 1:spl.alg.n_nodes
     VarInfos[j] = deepcopy(vi)

--- a/src/inference/Inference.jl
+++ b/src/inference/Inference.jl
@@ -210,22 +210,22 @@ end
 # VarInfo to Sample
 Sample(vi::VarInfo) = Sample(0.0, todict(vi))
 function todict(vi::VarInfo)
-    value = todict(vi.metadata)
+    value = todict(vi.metadata, vi)
     value[:lp] = getlogp(vi)
     return value
 end
-function todict(md::Metadata)
+function todict(md::Metadata, vi::VarInfo)
     value = Dict{Symbol, Any}() # value is named here because of Sample has a field called value
     for vn in keys(md.idcs)
-        value[Symbol(vn)] = md.idcs[vn]
+        value[Symbol(vn)] = vi[vn]
     end
     return value
 end
-function todict(metadata::NamedTuple{names}) where {names}
+function todict(metadata::NamedTuple{names}, vi::VarInfo) where {names}
     length(names) === 0 && return Dict{Symbol, Any}()
     f = names[1]
     mdf = getfield(metadata, f)
-    return merge(todict(mdf), todict(_tail(metadata)))
+    return merge(todict(mdf, vi), todict(_tail(metadata), vi))
 end
 
 # VarInfo, combined with spl.info, to Sample

--- a/src/inference/Inference.jl
+++ b/src/inference/Inference.jl
@@ -1,6 +1,7 @@
 module Inference
 
 using ..Core, ..Core.RandomVariables, ..Utilities
+using ..Core.RandomVariables: Metadata, _tail
 using Distributions, Libtask, Bijectors
 using ProgressMeter, LinearAlgebra
 using ..Turing: PROGRESS, CACHERESET, AbstractSampler
@@ -207,14 +208,24 @@ end
 ##############
 
 # VarInfo to Sample
-function Sample(vi::UntypedVarInfo)
-    value = Dict{Symbol, Any}() # value is named here because of Sample has a field called value
-    for vn in keys(vi)
-        value[Symbol(vn)] = vi[vn]
-    end
-    # NOTE: do we need to check if lp is 0?
+Sample(vi::VarInfo) = Sample(0.0, todict(vi))
+function todict(vi::VarInfo)
+    value = todict(vi.metadata)
     value[:lp] = getlogp(vi)
-    return Sample(0.0, value)
+    return value
+end
+function todict(md::Metadata)
+    value = Dict{Symbol, Any}() # value is named here because of Sample has a field called value
+    for vn in keys(md.idcs)
+        value[Symbol(vn)] = md.idcs[vn]
+    end
+    return value
+end
+function todict(metadata::NamedTuple{names}) where {names}
+    length(names) === 0 && return Dict{Symbol, Any}()
+    f = names[1]
+    mdf = getfield(metadata, f)
+    return merge(todict(mdf), todict(_tail(metadata)))
 end
 
 # VarInfo, combined with spl.info, to Sample

--- a/src/inference/dynamichmc.jl
+++ b/src/inference/dynamichmc.jl
@@ -37,7 +37,7 @@ function sample(model::Model,
         samples[i] = Sample(weight, Dict{Symbol, Any}())
     end
 
-    vi = VarInfo()
+    vi = VarInfo(model)
     runmodel!(model, vi, SampleFromUniform())
 
     if spl.selector.tag == :default

--- a/src/inference/gibbs.jl
+++ b/src/inference/gibbs.jl
@@ -113,7 +113,7 @@ function sample(
 
     # Init parameters
     varInfo = if resume_from == nothing
-        vi_ = VarInfo()
+        vi_ = VarInfo(model)
         model(vi_, SampleFromUniform())
         vi_
     else

--- a/src/inference/gibbs.jl
+++ b/src/inference/gibbs.jl
@@ -113,9 +113,7 @@ function sample(
 
     # Init parameters
     varInfo = if resume_from == nothing
-        vi_ = VarInfo(model)
-        model(vi_, SampleFromUniform())
-        vi_
+        VarInfo(model)
     else
         resume_from.info[:vi]
     end

--- a/src/inference/hmc.jl
+++ b/src/inference/hmc.jl
@@ -243,9 +243,7 @@ function sample(
 
     # Create VarInfo
     vi = if resume_from == nothing
-        vi_ = VarInfo()
-        runmodel!(model, vi_, SampleFromUniform())
-        vi_
+        VarInfo(model)
     else
         deepcopy(resume_from.info[:vi])
     end

--- a/src/inference/is.jl
+++ b/src/inference/is.jl
@@ -45,7 +45,7 @@ function sample(model::Model, alg::IS)
     samples = Array{Sample}(undef, alg.n_particles)
 
     n = spl.alg.n_particles
-    vi = empty!(VarInfo(model))
+    vi = VarInfo(model)
     for i = 1:n
         empty!(vi)
         model(vi, spl)

--- a/src/inference/is.jl
+++ b/src/inference/is.jl
@@ -45,8 +45,9 @@ function sample(model::Model, alg::IS)
     samples = Array{Sample}(undef, alg.n_particles)
 
     n = spl.alg.n_particles
+    vi = empty!(VarInfo(model))
     for i = 1:n
-        vi = empty!(VarInfo(model))
+        empty!(vi)
         model(vi, spl)
         samples[i] = Sample(vi)
     end

--- a/src/inference/is.jl
+++ b/src/inference/is.jl
@@ -46,7 +46,7 @@ function sample(model::Model, alg::IS)
 
     n = spl.alg.n_particles
     for i = 1:n
-        vi = VarInfo()
+        vi = VarInfo(model)
         model(vi, spl)
         samples[i] = Sample(vi)
     end

--- a/src/inference/is.jl
+++ b/src/inference/is.jl
@@ -46,7 +46,7 @@ function sample(model::Model, alg::IS)
 
     n = spl.alg.n_particles
     for i = 1:n
-        vi = VarInfo(model)
+        vi = empty!(VarInfo(model))
         model(vi, spl)
         samples[i] = Sample(vi)
     end

--- a/src/inference/mh.jl
+++ b/src/inference/mh.jl
@@ -129,7 +129,7 @@ function sample(model::Model, alg::MH;
   end
 
     vi = if resume_from == nothing
-        vi_ = VarInfo()
+        vi_ = VarInfo(model)
         model(vi_, SampleFromUniform())
         vi_
     else

--- a/src/inference/mh.jl
+++ b/src/inference/mh.jl
@@ -129,9 +129,7 @@ function sample(model::Model, alg::MH;
   end
 
     vi = if resume_from == nothing
-        vi_ = VarInfo(model)
-        model(vi_, SampleFromUniform())
-        vi_
+        VarInfo(model)
     else
         resume_from.info[:vi]
     end

--- a/src/utilities/helper.jl
+++ b/src/utilities/helper.jl
@@ -2,9 +2,9 @@
 # Helper functions for vectorize/reconstruct values #
 #####################################################
 
-vectorize(d::UnivariateDistribution, r::Real) = Vector{Real}([r])
-vectorize(d::MultivariateDistribution, r::AbstractVector{<:Real}) = Vector{Real}(r)
-vectorize(d::MatrixDistribution, r::AbstractMatrix{<:Real}) = Vector{Real}(vec(r))
+vectorize(d::UnivariateDistribution, r::Real) = [r]
+vectorize(d::MultivariateDistribution, r::AbstractVector{<:Real}) = copy(r)
+vectorize(d::MatrixDistribution, r::AbstractMatrix{<:Real}) = copy(vec(r))
 
 # NOTE:
 # We cannot use reconstruct{T} because val is always Vector{Real} then T will be Real.

--- a/test/core/RandomVariables.jl
+++ b/test/core/RandomVariables.jl
@@ -12,7 +12,8 @@ using Test
 
 i, j, k = 1, 2, 3
 
-include("../test_utils/AllUtils.jl")
+dir = splitdir(splitdir(pathof(Turing))[1])[1]
+include(dir*"/test/test_utils/AllUtils.jl")
 
 @testset "RandomVariables.jl" begin
     @turing_testset "TypedVarInfo" begin

--- a/test/core/ad.jl
+++ b/test/core/ad.jl
@@ -1,12 +1,13 @@
 using ForwardDiff, Distributions, FDM, Tracker, Random, LinearAlgebra, PDMats
-using Turing: gradient_logp_reverse, invlink, link, SampleFromPrior
+using Turing: Turing, gradient_logp_reverse, invlink, link, SampleFromPrior
 using Turing.Core.RandomVariables: getval
 using Turing.Core: TuringMvNormal, TuringDiagNormal
 using ForwardDiff: Dual
 using StatsFuns: binomlogpdf, logsumexp
 using Test
 
-include("../test_utils/AllUtils.jl")
+dir = splitdir(splitdir(pathof(Turing))[1])[1]
+include(dir*"/test/test_utils/AllUtils.jl")
 
 _to_cov(B) = B * B' + Matrix(I, size(B)...)
 

--- a/test/core/compiler.jl
+++ b/test/core/compiler.jl
@@ -1,7 +1,8 @@
 using Turing, Random, MacroTools, Distributions, Test
 import Turing.translate_tilde!
 
-include("../test_utils/AllUtils.jl")
+dir = splitdir(splitdir(pathof(Turing))[1])[1]
+include(dir*"/test/test_utils/AllUtils.jl")
 
 Random.seed!(129)
 

--- a/test/core/container.jl
+++ b/test/core/container.jl
@@ -4,7 +4,8 @@ using Turing: ParticleContainer, weights, resample!,
     Sampler, consume, produce, copy, fork
 using Test
 
-include("../test_utils/AllUtils.jl")
+dir = splitdir(splitdir(pathof(Turing))[1])[1]
+include(dir*"/test/test_utils/AllUtils.jl")
 
 @testset "container.jl" begin
     @turing_testset "copy particle container" begin

--- a/test/core/container.jl
+++ b/test/core/container.jl
@@ -39,10 +39,13 @@ include(dir*"/test/test_utils/AllUtils.jl")
         end
 
         pc = ParticleContainer{Trace}(fpc)
-
-        push!(pc, Trace(pc.model))
-        push!(pc, Trace(pc.model))
-        push!(pc, Trace(pc.model))
+        model = Turing.Model{(:x,),()}(fpc, NamedTuple(), NamedTuple())
+        tr = Trace(pc.model, model, spl, Turing.VarInfo())
+        push!(pc, tr)
+        tr = Trace(pc.model, model, spl, Turing.VarInfo())
+        push!(pc, tr)
+        tr = Trace(pc.model, model, spl, Turing.VarInfo())
+        push!(pc, tr)
 
         Base.@assert weights(pc)[1] == [1/3, 1/3, 1/3]
         Base.@assert weights(pc)[2] ≈ log(3)
@@ -82,7 +85,8 @@ include(dir*"/test/test_utils/AllUtils.jl")
         end
 
         # Test task copy version of trace
-        tr = Trace(f2)
+        model = Turing.Model{(:x,),()}(f2, NamedTuple(), NamedTuple())
+        tr = Trace(f2, model, spl, Turing.VarInfo())
 
         consume(tr); consume(tr)
         a = fork(tr);

--- a/test/inference/AdvancedSMC.jl
+++ b/test/inference/AdvancedSMC.jl
@@ -1,6 +1,7 @@
 using Turing, Random, Test
 
-include("../test_utils/AllUtils.jl")
+dir = splitdir(splitdir(pathof(Turing))[1])[1]
+include(dir*"/test/test_utils/AllUtils.jl")
 
 @testset "smc.jl" begin
     # No tests.

--- a/test/inference/dynamichmc.jl
+++ b/test/inference/dynamichmc.jl
@@ -1,6 +1,7 @@
 using Turing, Test
 
-include("../test_utils/AllUtils.jl")
+dir = splitdir(splitdir(pathof(Turing))[1])[1]
+include(dir*"/test/test_utils/AllUtils.jl")
 
 @stage_testset "dynamichmc" "dynamichmc.jl" begin
     import DynamicHMC

--- a/test/inference/gibbs.jl
+++ b/test/inference/gibbs.jl
@@ -1,6 +1,7 @@
 using Random, Turing, Test
 
-include("../test_utils/AllUtils.jl")
+dir = splitdir(splitdir(pathof(Turing))[1])[1]
+include(dir*"/test/test_utils/AllUtils.jl")
 
 @testset "gibbs.jl" begin
     @turing_testset "gibbs constructor" begin

--- a/test/inference/hmc.jl
+++ b/test/inference/hmc.jl
@@ -1,7 +1,8 @@
 using Turing, Random, Test
 using Turing: Sampler, NUTS
 
-include("../test_utils/AllUtils.jl")
+dir = splitdir(splitdir(pathof(Turing))[1])[1]
+include(dir*"/test/test_utils/AllUtils.jl")
 
 @testset "hmc.jl" begin
     @numerical_testset "constrained bounded" begin

--- a/test/inference/is.jl
+++ b/test/inference/is.jl
@@ -1,7 +1,8 @@
 using Turing, Random, Test
 using StatsFuns
 
-include("../test_utils/AllUtils.jl")
+dir = splitdir(splitdir(pathof(Turing))[1])[1]
+include(dir*"/test/test_utils/AllUtils.jl")
 
 @turing_testset "is.jl" begin
     function reference(n :: Int)

--- a/test/inference/is.jl
+++ b/test/inference/is.jl
@@ -46,6 +46,9 @@ include(dir*"/test/test_utils/AllUtils.jl")
       _f = normal();
       for i=1:100
         Random.seed!(seed)
+        # Move the rng twice - equivalent to sampling from prior
+        rand(Normal(4,5))
+        rand(Normal(0,1))
         exact = reference(n)
         Random.seed!(seed)
         tested = sample(_f, alg)

--- a/test/inference/mh.jl
+++ b/test/inference/mh.jl
@@ -1,6 +1,7 @@
 using Turing, Random, Test
 
-include("../test_utils/AllUtils.jl")
+dir = splitdir(splitdir(pathof(Turing))[1])[1]
+include(dir*"/test/test_utils/AllUtils.jl")
 
 @testset "mh.jl" begin
     @turing_testset "mh constructor" begin

--- a/test/inference/sghmc.jl
+++ b/test/inference/sghmc.jl
@@ -1,7 +1,8 @@
 using Turing, Random, Test
 using Turing: Sampler
 
-include("../test_utils/AllUtils.jl")
+dir = splitdir(splitdir(pathof(Turing))[1])[1]
+include(dir*"/test/test_utils/AllUtils.jl")
 
 @testset "sghmc.jl" begin
     @numerical_testset "sghmc inference" begin

--- a/test/stdlib/RandomMeasures.jl
+++ b/test/stdlib/RandomMeasures.jl
@@ -3,7 +3,8 @@ using Turing.RandomMeasures
 using Test
 using Random
 
-include("../test_utils/AllUtils.jl")
+dir = splitdir(splitdir(pathof(Turing))[1])[1]
+include(dir*"/test/test_utils/AllUtils.jl")
 
 @testset "RandomMeasures.jl" begin
     partitions = [

--- a/test/stdlib/distributions.jl
+++ b/test/stdlib/distributions.jl
@@ -3,7 +3,8 @@ using Turing: BinomialLogit, NUTS
 using Distributions: Binomial, logpdf
 using StatsFuns: logistic
 
-include("../test_utils/AllUtils.jl")
+dir = splitdir(splitdir(pathof(Turing))[1])[1]
+include(dir*"/test/test_utils/AllUtils.jl")
 
 @testset "distributions.jl" begin
     @turing_testset "distributions functions" begin

--- a/test/utilities/io.jl
+++ b/test/utilities/io.jl
@@ -1,6 +1,7 @@
 using Turing, Random, Test
 
-include("../test_utils/AllUtils.jl")
+dir = splitdir(splitdir(pathof(Turing))[1])[1]
+include(dir*"/test/test_utils/AllUtils.jl")
 
 @testset "io.jl" begin
     @testset "chain save/resume" begin

--- a/test/utilities/stan-interface.jl
+++ b/test/utilities/stan-interface.jl
@@ -1,6 +1,7 @@
 using Turing, Random, Test
 
-include("../test_utils/AllUtils.jl")
+dir = splitdir(splitdir(pathof(Turing))[1])[1]
+include(dir*"/test/test_utils/AllUtils.jl")
 
 @stage_testset "stan" "stan-interface.jl" begin
     using CmdStan

--- a/test/utilities/util.jl
+++ b/test/utilities/util.jl
@@ -3,7 +3,8 @@ using Turing: @VarName
 using Distributions: Normal
 using StatsFuns
 
-include("../test_utils/AllUtils.jl")
+dir = splitdir(splitdir(pathof(Turing))[1])[1]
+include(dir*"/test/test_utils/AllUtils.jl")
 
 @turing_testset "util.jl" begin
     i = 1


### PR DESCRIPTION
This PR does some small changes to hook `sample` to `TypedVarInfo` for all the samplers of Turing. For this PR to be maximally useful, the following needs to be done possibly in separate PRs:
1. `space` should be part of the type signature of `alg` such that `getspace(alg)` is known at compile time.
2. The construction of `vi::VarInfo` should be separated from the rest of the sampling process by a function barrier. So first construct `vi` using `vi = VarInfo(model)` or `vi = empty!(VarInfo(model))` then pass it to a function to do the sampling. This is relevant to your PR @cpfiffer. Inside the sampling function, you can do `empty!(vi)` to empty the `vi`, or `deepcopy(vi)` if need be; both of these don't hurt the inference.
3. `Sample` should not use `Dict{Symbol, Any}` for its `value` field. The `Any` should be replaced by a concretely typed struct preferably.
4. `spl.info` should be replaced by a concretely typed struct specialized for each sampler.

If all of these changes are completed, Turing should be about as fast as claimed [here](https://github.com/TuringLang/AdvancedHMC.jl/issues/26#issuecomment-475702331) assuming AHMC is type stable and fast.