### PR TITLE
Make AllUtils.jl inclusion copy-paste-friendly

### DIFF
--- a/test/core/RandomVariables.jl
+++ b/test/core/RandomVariables.jl
@@ -12,7 +12,8 @@ using Test
 
 i, j, k = 1, 2, 3
 
-include("../test_utils/AllUtils.jl")
+dir = splitdir(splitdir(pathof(Turing))[1])[1]
+include(dir*"/test/test_utils/AllUtils.jl")
 
 @testset "RandomVariables.jl" begin
     @turing_testset "TypedVarInfo" begin

--- a/test/core/ad.jl
+++ b/test/core/ad.jl
@@ -1,12 +1,13 @@
 using ForwardDiff, Distributions, FDM, Tracker, Random, LinearAlgebra, PDMats
-using Turing: gradient_logp_reverse, invlink, link, SampleFromPrior
+using Turing: Turing, gradient_logp_reverse, invlink, link, SampleFromPrior
 using Turing.Core.RandomVariables: getval
 using Turing.Core: TuringMvNormal, TuringDiagNormal
 using ForwardDiff: Dual
 using StatsFuns: binomlogpdf, logsumexp
 using Test
 
-include("../test_utils/AllUtils.jl")
+dir = splitdir(splitdir(pathof(Turing))[1])[1]
+include(dir*"/test/test_utils/AllUtils.jl")
 
 _to_cov(B) = B * B' + Matrix(I, size(B)...)
 

--- a/test/core/compiler.jl
+++ b/test/core/compiler.jl
@@ -1,7 +1,8 @@
 using Turing, Random, MacroTools, Distributions, Test
 import Turing.translate_tilde!
 
-include("../test_utils/AllUtils.jl")
+dir = splitdir(splitdir(pathof(Turing))[1])[1]
+include(dir*"/test/test_utils/AllUtils.jl")
 
 Random.seed!(129)
 

--- a/test/core/container.jl
+++ b/test/core/container.jl
@@ -4,7 +4,8 @@ using Turing: ParticleContainer, weights, resample!,
     Sampler, consume, produce, copy, fork
 using Test
 
-include("../test_utils/AllUtils.jl")
+dir = splitdir(splitdir(pathof(Turing))[1])[1]
+include(dir*"/test/test_utils/AllUtils.jl")
 
 @testset "container.jl" begin
     @turing_testset "copy particle container" begin

--- a/test/inference/AdvancedSMC.jl
+++ b/test/inference/AdvancedSMC.jl
@@ -1,6 +1,7 @@
 using Turing, Random, Test
 
-include("../test_utils/AllUtils.jl")
+dir = splitdir(splitdir(pathof(Turing))[1])[1]
+include(dir*"/test/test_utils/AllUtils.jl")
 
 @testset "smc.jl" begin
     # No tests.

--- a/test/inference/dynamichmc.jl
+++ b/test/inference/dynamichmc.jl
@@ -1,6 +1,7 @@
 using Turing, Test
 
-include("../test_utils/AllUtils.jl")
+dir = splitdir(splitdir(pathof(Turing))[1])[1]
+include(dir*"/test/test_utils/AllUtils.jl")
 
 @stage_testset "dynamichmc" "dynamichmc.jl" begin
     import DynamicHMC

--- a/test/inference/gibbs.jl
+++ b/test/inference/gibbs.jl
@@ -1,6 +1,7 @@
 using Random, Turing, Test
 
-include("../test_utils/AllUtils.jl")
+dir = splitdir(splitdir(pathof(Turing))[1])[1]
+include(dir*"/test/test_utils/AllUtils.jl")
 
 @testset "gibbs.jl" begin
     @turing_testset "gibbs constructor" begin

--- a/test/inference/hmc.jl
+++ b/test/inference/hmc.jl
@@ -1,7 +1,8 @@
 using Turing, Random, Test
 using Turing: Sampler, NUTS
 
-include("../test_utils/AllUtils.jl")
+dir = splitdir(splitdir(pathof(Turing))[1])[1]
+include(dir*"/test/test_utils/AllUtils.jl")
 
 @testset "hmc.jl" begin
     @numerical_testset "constrained bounded" begin

--- a/test/inference/is.jl
+++ b/test/inference/is.jl
@@ -1,7 +1,8 @@
 using Turing, Random, Test
 using StatsFuns
 
-include("../test_utils/AllUtils.jl")
+dir = splitdir(splitdir(pathof(Turing))[1])[1]
+include(dir*"/test/test_utils/AllUtils.jl")
 
 @turing_testset "is.jl" begin
     function reference(n :: Int)

--- a/test/inference/mh.jl
+++ b/test/inference/mh.jl
@@ -1,6 +1,7 @@
 using Turing, Random, Test
 
-include("../test_utils/AllUtils.jl")
+dir = splitdir(splitdir(pathof(Turing))[1])[1]
+include(dir*"/test/test_utils/AllUtils.jl")
 
 @testset "mh.jl" begin
     @turing_testset "mh constructor" begin

--- a/test/inference/sghmc.jl
+++ b/test/inference/sghmc.jl
@@ -1,7 +1,8 @@
 using Turing, Random, Test
 using Turing: Sampler
 
-include("../test_utils/AllUtils.jl")
+dir = splitdir(splitdir(pathof(Turing))[1])[1]
+include(dir*"/test/test_utils/AllUtils.jl")
 
 @testset "sghmc.jl" begin
     @numerical_testset "sghmc inference" begin

--- a/test/stdlib/RandomMeasures.jl
+++ b/test/stdlib/RandomMeasures.jl
@@ -3,7 +3,8 @@ using Turing.RandomMeasures
 using Test
 using Random
 
-include("../test_utils/AllUtils.jl")
+dir = splitdir(splitdir(pathof(Turing))[1])[1]
+include(dir*"/test/test_utils/AllUtils.jl")
 
 @testset "RandomMeasures.jl" begin
     partitions = [

--- a/test/stdlib/distributions.jl
+++ b/test/stdlib/distributions.jl
@@ -3,7 +3,8 @@ using Turing: BinomialLogit, NUTS
 using Distributions: Binomial, logpdf
 using StatsFuns: logistic
 
-include("../test_utils/AllUtils.jl")
+dir = splitdir(splitdir(pathof(Turing))[1])[1]
+include(dir*"/test/test_utils/AllUtils.jl")
 
 @testset "distributions.jl" begin
     @turing_testset "distributions functions" begin

--- a/test/utilities/io.jl
+++ b/test/utilities/io.jl
@@ -1,6 +1,7 @@
 using Turing, Random, Test
 
-include("../test_utils/AllUtils.jl")
+dir = splitdir(splitdir(pathof(Turing))[1])[1]
+include(dir*"/test/test_utils/AllUtils.jl")
 
 @testset "io.jl" begin
     @testset "chain save/resume" begin

--- a/test/utilities/stan-interface.jl
+++ b/test/utilities/stan-interface.jl
@@ -1,6 +1,7 @@
 using Turing, Random, Test
 
-include("../test_utils/AllUtils.jl")
+dir = splitdir(splitdir(pathof(Turing))[1])[1]
+include(dir*"/test/test_utils/AllUtils.jl")
 
 @stage_testset "stan" "stan-interface.jl" begin
     using CmdStan

--- a/test/utilities/util.jl
+++ b/test/utilities/util.jl
@@ -3,7 +3,8 @@ using Turing: @VarName
 using Distributions: Normal
 using StatsFuns
 
-include("../test_utils/AllUtils.jl")
+dir = splitdir(splitdir(pathof(Turing))[1])[1]
+include(dir*"/test/test_utils/AllUtils.jl")
 
 @turing_testset "util.jl" begin
     i = 1


### PR DESCRIPTION
This PR makes the inclusion of the file AllUtils.jl copy-paste friendly on the REPL, since relative paths can be different. If tests pass, this will be ready to merge.