### PR TITLE
[WIP] Heterogeneous vector priors

### DIFF
--- a/src/core/RandomVariables.jl
+++ b/src/core/RandomVariables.jl
@@ -975,10 +975,12 @@ function getindex(vi::AbstractVarInfo, vn::VarName)
 end
 function getindex(vi::AbstractVarInfo, vns::Vector{<:VarName})
     @assert haskey(vi, vns[1]) "[Turing] attempted to replay unexisting variables in VarInfo"
-    dist = getdist(vi, vns[1])
-    return copy(istrans(vi, vns[1]) ?
-        invlink(dist, reconstruct(dist, getval(vi, vns), length(vns))) :
-        reconstruct(dist, getval(vi, vns), length(vns)))
+    n = length(vns)
+    return map(1:n) do i
+        dist = getdist(vi, vns[i])
+        val = reconstruct(dist, getval(vi, vns[i]))
+        istrans(vi, vns[i]) ? invlink(dist, val) : val
+    end
 end
 
 """

--- a/src/core/compiler.jl
+++ b/src/core/compiler.jl
@@ -96,11 +96,7 @@ function generate_assume(var::Union{Symbol, Expr}, dist, model_info)
         end
         @assert isdist @error($(wrong_dist_errormsg(@__LINE__)))
 
-        ($var, $lp) = if isa($dist, AbstractVector)
-            Turing.assume($sampler, $dist, $varname, $var, $vi)
-        else
-            Turing.assume($sampler, $dist, $varname, $vi)
-        end
+        ($var, $lp) = Turing.assume($sampler, $dist, $varname, $vi)
         $vi.logp += $lp
     end
 end

--- a/src/inference/AdvancedSMC.jl
+++ b/src/inference/AdvancedSMC.jl
@@ -248,7 +248,6 @@ end
 function assume(  spl::Sampler{A},
                   dists::Vector{D},
                   vn::VarName,
-                  var::Any,
                   vi::VarInfo
                 ) where {A<:Union{PG,SMC},D<:Distribution}
     error("[Turing] PG and SMC doesn't support vectorizing assume statement")

--- a/src/inference/Inference.jl
+++ b/src/inference/Inference.jl
@@ -118,7 +118,7 @@ function assume(spl::A,
 end
 
 function assume(spl::Union{SampleFromPrior, SampleFromUniform},
-    dists::Vector{<:Distribution},
+    dists::AbstractVector{<:Distribution},
     vn::VarName,
     vi::VarInfo)
 

--- a/src/inference/Inference.jl
+++ b/src/inference/Inference.jl
@@ -117,15 +117,12 @@ function assume(spl::A,
 
 end
 
-function assume(spl::A,
-    dists::Vector{T},
+function assume(spl::Union{SampleFromPrior, SampleFromUniform},
+    dists::Vector{<:Distribution},
     vn::VarName,
-    var::Any,
-    vi::VarInfo) where {T<:Distribution, A<:Union{SampleFromPrior, SampleFromUniform}}
+    vi::VarInfo)
 
-    @assert isa(var, Vector) "Turing.assume: unsupported variable container."
-
-    n = length(var)
+    n = length(dists)
     vns = map(i -> VarName(vn, "[$i]"), 1:n)
 
     if haskey(vi, vns[1])
@@ -144,7 +141,7 @@ function assume(spl::A,
         var = rs
     end
 
-    @assert length(var) == length(rs) "Turing.assume: variable and random number dimension unmatched"
+    @assert n == length(rs) "Turing.assume: variable and random number dimension unmatched"
 
     # acclogp!(vi, logp)
     logp = sum(1:n) do i 

--- a/src/inference/hmc.jl
+++ b/src/inference/hmc.jl
@@ -599,7 +599,7 @@ function assume(spl::Sampler{<:Hamiltonian},
 end
 
 function assume(spl::Sampler{<:Hamiltonian},
-    dists::Vector{<:Distribution},
+    dists::AbstractVector{<:Distribution},
     vn::VarName,
     vi::VarInfo,
 ) 
@@ -622,7 +622,7 @@ observe(spl::Sampler{<:Hamiltonian},
     vi::VarInfo) = observe(nothing, d, value, vi)
 
 observe(spl::Sampler{<:Hamiltonian},
-    ds::Vector{<:Distribution},
+    ds::AbstractVector{<:Distribution},
     value::Any,
     vi::VarInfo) = observe(nothing, ds, value, vi)
 

--- a/src/inference/hmc.jl
+++ b/src/inference/hmc.jl
@@ -601,16 +601,13 @@ end
 function assume(spl::Sampler{<:Hamiltonian},
     dists::Vector{<:Distribution},
     vn::VarName,
-    var::Any,
-    vi::VarInfo
-)
-    @assert isa(var, Vector) "Turing.assume: unsupported variable container."
-    n = length(var)
-
+    vi::VarInfo,
+) 
+    n = length(dists)
     vns = map(i -> VarName(vn, "[$i]"), 1:n)
     rs = vi[vns]  # NOTE: inside Turing the Julia conversion should be sticked to
 
-    @assert length(var) == length(rs) "Turing.assume: variable and random number dimension unmatched"
+    @assert n == length(rs) "Turing.assume: variable and random number dimension unmatched"
 
     logp = sum(1:n) do i
         dist = length(dists) == 1 ? dists[1] : dists[i]


### PR DESCRIPTION
This PR adds support for heterogeneous vectors of prior distributions. The following works as expected:
```julia
using Turing

@model demo() = begin
    a ~ [Normal(), Beta()]
end
model = demo();
alg = HMC(10000, 0.1, 5)
chain = sample(model, alg)
```
This is only supported for parameters so far, but observations can be supported in a similar fashion.

CC: @ChrisRackauckas please try this branch