### PR TITLE
Fix #665, #802 and #829

### DIFF
--- a/src/Turing.jl
+++ b/src/Turing.jl
@@ -89,6 +89,9 @@ Robust initialization method for model parameters in Hamiltonian samplers.
 struct SampleFromUniform <: AbstractSampler end
 struct SampleFromPrior <: AbstractSampler end
 
+getspace(::SampleFromPrior) = ()
+getspace(::SampleFromUniform) = ()
+
 """
     Sampler{T}
 

--- a/src/Turing.jl
+++ b/src/Turing.jl
@@ -72,7 +72,7 @@ end
 end
 (model::Model)(args...; kwargs...) = model.f(args..., model; kwargs...)
 function runmodel! end
-getspace(alg) = Tuple(alg.space)
+function getspace end
 
 struct Selector
     gid :: UInt64

--- a/src/core/RandomVariables.jl
+++ b/src/core/RandomVariables.jl
@@ -330,7 +330,7 @@ end
 Returns all the indices of `vns` in `vi.metadata.vals`.
 """
 function getranges(vi::AbstractVarInfo, vns::Vector{<:VarName})
-    return union(map(vn -> getrange(vi, vn), vns)...)
+    return mapreduce(vn -> getrange(vi, vn), vcat, vns, init=Int[])
 end
 
 """
@@ -549,7 +549,7 @@ end
     __getranges(vi, _getidcs(vi, s, space))
 end
 @inline function __getranges(vi::UntypedVarInfo, idcs)
-    union(map(i -> vi.ranges[i], idcs)...)
+    mapreduce(i -> vi.ranges[i], vcat, idcs, init=Int[])
 end
 @inline __getranges(vi::TypedVarInfo, idcs) = __getranges(vi.metadata, idcs)
 @inline function __getranges(metadata::NamedTuple{names}, idcs) where {names}
@@ -558,7 +558,7 @@ end
     # Take the first symbol
     f = names[1]
     # Collect the index ranges of all the vns with symbol `f`
-    v = union(map(i -> getfield(metadata, f).ranges[i], getfield(idcs, f))..., Int[])
+    v = mapreduce(i -> getfield(metadata, f).ranges[i], vcat, getfield(idcs, f), init=Int[])
     # Make a single-pair NamedTuple to merge with the result of the recursion
     nt = NamedTuple{(f,)}((v,))
     # Recurse using the remaining of `metadata`

--- a/src/core/RandomVariables.jl
+++ b/src/core/RandomVariables.jl
@@ -192,7 +192,7 @@ function VarInfo(old_vi::TypedVarInfo, spl, x::AbstractVector)
     md = newmetadata(old_vi.metadata, spl, x, 0)
     VarInfo(md, Base.RefValue{eltype(x)}(old_vi.logp), Ref(old_vi.num_produce))
 end
-function newmetadata(metadata::NamedTuple{names}, spl, x, offset) where {names}
+@inline function newmetadata(metadata::NamedTuple{names}, spl, x, offset) where {names}
     # Check if the named tuple is empty and end the recursion
     length(names) === 0 && return ()
     # Take the first key in the NamedTuple

--- a/src/core/RandomVariables.jl
+++ b/src/core/RandomVariables.jl
@@ -1046,6 +1046,10 @@ end
     return _setindex!(_tail(metadata), val, ranges, start)
 end
 
+function Base.eltype(vi::AbstractVarInfo, spl::Union{AbstractSampler, SampleFromPrior})
+    return eltype(Core.Compiler.return_type(getindex, Tuple{typeof(vi), typeof(spl)}))
+end
+
 """
 `haskey(vi::VarInfo, vn::VarName)`
 

--- a/src/core/RandomVariables.jl
+++ b/src/core/RandomVariables.jl
@@ -183,8 +183,11 @@ function VarInfo(model::Model)
     return TypedVarInfo(vi)
 end
 
-VarInfo(old_vi::UntypedVarInfo, spl, x::AbstractVector) = old_vi
-
+function VarInfo(old_vi::UntypedVarInfo, spl, x::AbstractVector)
+    new_vi = deepcopy(old_vi)
+    new_vi[spl] = x 
+    return new_vi
+end
 function VarInfo(old_vi::TypedVarInfo, spl, x::AbstractVector)
     md = newmetadata(old_vi.metadata, spl, x, 0)
     VarInfo(md, Base.RefValue{eltype(x)}(old_vi.logp), Ref(old_vi.num_produce))

--- a/src/core/RandomVariables.jl
+++ b/src/core/RandomVariables.jl
@@ -454,9 +454,9 @@ function _getidcs(vi::UntypedVarInfo, ::SampleFromPrior)
 end
 # Get a NamedTuple of all the indices belonging to SampleFromPrior, one for each symbol
 function _getidcs(vi::TypedVarInfo, ::SampleFromPrior)
-    return __getidcs(vi.metadata)
+    return _getidcs(vi.metadata)
 end
-@inline function __getidcs(metadata::NamedTuple{names}) where {names}
+@inline function _getidcs(metadata::NamedTuple{names}) where {names}
     # Check if the `metadata` is empty to end the recursion
     length(names) === 0 && return NamedTuple()
     # Take the first key/symbol
@@ -468,7 +468,7 @@ end
     # Make a single-pair NamedTuple to merge with the result of the recursion
     nt = NamedTuple{(f,)}((v,))
     # Recurse using the remaining of metadata
-    return merge(nt, __getidcs(_tail(metadata)))
+    return merge(nt, _getidcs(_tail(metadata)))
 end
 
 # Get all indices of variables belonging to a given sampler
@@ -491,10 +491,10 @@ function _getidcs(vi::UntypedVarInfo, s::Selector, space::Tuple)
         (isempty(space) || in(vi.vns[i], space)), 1:length(vi.gids))
 end
 function _getidcs(vi::TypedVarInfo, s::Selector, space::Tuple)
-    return __getidcs(vi.metadata, s, space)
+    return _getidcs(vi.metadata, s, space)
 end
 # Get a NamedTuple for all the indices belonging to a given selector for each symbol
-@inline function __getidcs(metadata::NamedTuple{names}, s::Selector, space::Tuple) where {names}
+@inline function _getidcs(metadata::NamedTuple{names}, s::Selector, space::Tuple) where {names}
     # Check if `metadata` is empty to end the recursion
     length(names) === 0 && return NamedTuple()
     # Take the first sybmol
@@ -507,7 +507,7 @@ end
     # Make a single-pair NamedTuple to merge with the result of the recursion
     nt = NamedTuple{(f,)}((v,))
     # Recurse using the remaining of metadata
-    return merge(nt, __getidcs(_tail(metadata), s, space))
+    return merge(nt, _getidcs(_tail(metadata), s, space))
 end
 
 # Get all vns of variables belonging to spl
@@ -515,10 +515,10 @@ _getvns(vi::UntypedVarInfo, spl::AbstractSampler) = view(vi.vns, _getidcs(vi, sp
 function _getvns(vi::TypedVarInfo, spl::AbstractSampler)
     # Get a NamedTuple of the indices of variables belonging to `spl`, one entry for each symbol
     idcs = _getidcs(vi, spl)
-    return __getvns(vi.metadata, idcs)
+    return _getvns(vi.metadata, idcs)
 end
 # Get a NamedTuple for all the `vns` of indices `idcs`, one entry for each symbol
-@inline function __getvns(metadata::NamedTuple{names}, idcs) where {names}
+@inline function _getvns(metadata::NamedTuple{names}, idcs) where {names}
     # Check if `metadata` is empty to end the recursion
     length(names) === 0 && return NamedTuple()
     # Take the first symbol
@@ -528,7 +528,7 @@ end
     # Make a single-pair NamedTuple to merge with the result of the recursion
     nt = NamedTuple{(f,)}((v,))
     # Recurse using the remaining of `metadata`
-    return merge(nt, __getvns(_tail(metadata), idcs))
+    return merge(nt, _getvns(_tail(metadata), idcs))
 end
 
 # Get the index (in vals) ranges of all the vns of variables belonging to spl
@@ -546,13 +546,13 @@ end
 end
 # Get the index (in vals) ranges of all the vns of variables belonging to selector `s` in `space`
 @inline function _getranges(vi::AbstractVarInfo, s::Selector, space::Tuple=())
-    __getranges(vi, _getidcs(vi, s, space))
+    _getranges(vi, _getidcs(vi, s, space))
 end
-@inline function __getranges(vi::UntypedVarInfo, idcs)
+@inline function _getranges(vi::UntypedVarInfo, idcs::Vector{Int})
     mapreduce(i -> vi.ranges[i], vcat, idcs, init=Int[])
 end
-@inline __getranges(vi::TypedVarInfo, idcs) = __getranges(vi.metadata, idcs)
-@inline function __getranges(metadata::NamedTuple{names}, idcs) where {names}
+@inline _getranges(vi::TypedVarInfo, idcs::NamedTuple) = _getranges(vi.metadata, idcs)
+@inline function _getranges(metadata::NamedTuple{names}, idcs::NamedTuple) where {names}
     # Check if `metadata` is empty to end the recursion
     length(names) === 0 && return NamedTuple()
     # Take the first symbol
@@ -562,7 +562,7 @@ end
     # Make a single-pair NamedTuple to merge with the result of the recursion
     nt = NamedTuple{(f,)}((v,))
     # Recurse using the remaining of `metadata`
-    return merge(nt, __getranges(_tail(metadata), idcs))
+    return merge(nt, _getranges(_tail(metadata), idcs))
 end
 
 """

--- a/src/core/ad.jl
+++ b/src/core/ad.jl
@@ -287,7 +287,12 @@ end
 
 # Tracker's implementation of ldiv isn't good. We'll use Zygote's instead.
 const TrackedVecOrMat = Union{Tracker.TrackedVector, Tracker.TrackedMatrix}
-zygote_ldiv(A::AbstractMatrix, B::AbstractVecOrMat) = A \ B
+function zygote_ldiv(A::AbstractMatrix, B::AbstractVecOrMat)
+    T = typeof((zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))/one(eltype(A)))
+    BB = similar(B, T)
+    copyto!(BB, B)
+    ldiv!(A, BB)
+end
 function zygote_ldiv(A::Tracker.TrackedMatrix, B::TrackedVecOrMat)
     return Tracker.track(zygote_ldiv, A, B)
 end

--- a/src/core/ad.jl
+++ b/src/core/ad.jl
@@ -104,9 +104,6 @@ function gradient_logp_forward(
     logp_old = vi.logp
     function f(θ)
         new_vi = VarInfo(vi, sampler, θ)
-        if vi isa UntypedVarInfo
-            new_vi[sampler] = θ
-        end
         logp = runmodel!(model, new_vi, sampler).logp
         vi.logp = ForwardDiff.value(logp)
         return logp
@@ -145,9 +142,6 @@ function gradient_logp_reverse(
     # Specify objective function.
     function f(θ)
         new_vi = VarInfo(vi, sampler, θ)
-        if vi isa UntypedVarInfo
-            new_vi[sampler] = θ
-        end
         logp = runmodel!(model, new_vi, sampler).logp
         vi.logp = Tracker.data(logp)
         return logp

--- a/src/core/ad.jl
+++ b/src/core/ad.jl
@@ -104,6 +104,9 @@ function gradient_logp_forward(
     logp_old = vi.logp
     function f(θ)
         new_vi = VarInfo(vi, sampler, θ)
+        if vi isa UntypedVarInfo
+            new_vi[sampler] = θ
+        end
         logp = runmodel!(model, new_vi, sampler).logp
         vi.logp = ForwardDiff.value(logp)
         return logp
@@ -142,6 +145,9 @@ function gradient_logp_reverse(
     # Specify objective function.
     function f(θ)
         new_vi = VarInfo(vi, sampler, θ)
+        if vi isa UntypedVarInfo
+            new_vi[sampler] = θ
+        end
         logp = runmodel!(model, new_vi, sampler).logp
         vi.logp = Tracker.data(logp)
         return logp

--- a/src/core/ad.jl
+++ b/src/core/ad.jl
@@ -344,8 +344,12 @@ function Distributions.logpdf(d::TuringMvNormal, x::AbstractVector)
 end
 
 function Distributions.logpdf(d::MvNormal, x::Union{Tracker.TrackedVector, Tracker.TrackedMatrix})
-    logpdf(TuringMvNormal(d.μ, d.Σ.chol), x)
+    logpdf(TuringMvNormal(d.μ, getchol(d.Σ)), x)
 end
+
+getchol(m::PDMats.AbstractPDMat) = m.chol
+getchol(m::PDMats.PDiagMat) = cholesky(Diagonal(m.diag))
+getchol(m::PDMats.ScalMat) = cholesky(Diagonal(fill(m.value, m.dim)))
 
 # Deal with ambiguities.
 function Base.:*(

--- a/src/core/compiler.jl
+++ b/src/core/compiler.jl
@@ -72,15 +72,14 @@ function generate_assume(var::Union{Symbol, Expr}, dist, model_info)
         varname_expr = quote
             $sym, $idcs, $csym = Turing.@VarName $var
             $csym = Symbol($(QuoteNode(model_info[:name])), $csym)
-            $syms = Symbol[$csym, $(QuoteNode(var))]
-            $varname = Turing.VarName($syms, "")
+            $varname = Turing.VarName{$sym}($csym, "")
         end
     else
         varname_expr = quote
             $sym, $idcs, $csym = Turing.@VarName $var
             $csym_str = string($(QuoteNode(model_info[:name])))*string($csym)
             $indexing = foldl(*, $idcs, init = "")
-            $varname = Turing.VarName(Symbol($csym_str), $sym, $indexing)
+            $varname = Turing.VarName{$sym}(Symbol($csym_str), $indexing)
         end
     end
 
@@ -435,7 +434,8 @@ function build_output(model_info)
     end)
 end
 
-@inline get_type(t) = t isa Type ? Type{t} : typeof(t)
+get_type(::Type{T}) where {T} = Type{T}
+get_type(t) = typeof(t)
 
 # Replaces the default for `Vector{Missing}` inputs by `Vector{Real}` of the same length as the input.
 @generated function get_default_values(tent_dvars_nt::Tdvars, tent_arg_defaults_nt::Tdefaults) where {Tdvars <: NamedTuple, Tdefaults <: NamedTuple}

--- a/src/core/compiler.jl
+++ b/src/core/compiler.jl
@@ -122,10 +122,7 @@ function _tilde(vsym, left, dist, model_info)
 
     model_info[:tent_dvars_list] = copy(model_info[:arg_syms])
     if vsym in model_info[:arg_syms]
-        if !(vsym in model_info[:tent_dvars_list])
-            Turing.DEBUG && @debug " Observe - `$(vsym)` is an observation"
-        end
-
+        Turing.DEBUG && @debug " Observe - `$(vsym)` is an observation"
         return quote
             if Turing.in_pvars($(Val(vsym)), $model_name)
                 $(generate_assume(left, dist, model_info))
@@ -135,8 +132,6 @@ function _tilde(vsym, left, dist, model_info)
         end
     else
         # Assume it is a parameter.
-        vind = findfirst(x -> x == vsym, model_info[:tent_dvars_list])
-        vind == nothing || deleteat!(model_info[:tent_dvars_list], vind)
         if !(vsym in model_info[:tent_pvars_list])
             Turing.DEBUG && @debug begin
                 msg = " Assume - `$(vsym)` is a parameter"

--- a/src/core/compiler.jl
+++ b/src/core/compiler.jl
@@ -192,7 +192,7 @@ function model_generator(x = nothing, y = nothing)
     function inner_function(vi::Turing.VarInfo, sampler::Turing.AbstractSampler, model)
         local x
         if isdefined(model.data, :x)
-            if model.data.x isa Type{<:AbstractFloat} || model.data.x isa Type{<:AbstractArray}
+            if model.data.x isa Type && (model.data.x <: AbstractFloat || model.data.x <: AbstractArray)
                 x = Turing.Core.get_matching_type(sampler, vi, model.data.x)
             else
                 x = model.data.x
@@ -202,7 +202,7 @@ function model_generator(x = nothing, y = nothing)
         end
         local y
         if isdefined(model.data, :y)
-            if model.data.y isa Type{<:AbstractFloat} || model.data.y isa Type{<:AbstractArray}
+            if model.data.y isa Type && (model.data.y <: AbstractFloat || model.data.y <: AbstractArray)
                 y = Turing.Core.get_matching_type(sampler, vi, model.data.y)
             else
                 y = model.data.y
@@ -390,7 +390,7 @@ function build_output(model_info)
                 # So if the value is indeed correct, i.e. a type then it should just work
                 # If the value is not a type, i.e. `::Type{T} = 1` and the user doesn't pass it something for this argument, then it will give an error when constructing the model, which is a correct Julia error.
                 # This means that we don't need an expression for the default value of the `Type{T}` arguments in `model.defaults`.
-                if $model_name.data.$var isa Type{<:AbstractFloat} || $model_name.data.$var isa Type{<:AbstractArray}
+                if $model_name.data.$var isa Type && ($model_name.data.$var <: AbstractFloat || $model_name.data.$var <: AbstractArray)
                     $var = Turing.Core.get_matching_type($sampler_name, $vi_name, $model_name.data.$var)
                 else
                     $var = $model_name.data.$var

--- a/src/core/compiler.jl
+++ b/src/core/compiler.jl
@@ -232,13 +232,19 @@ function build_model_info(input_expr)
     warn_empty(modeldef[:body])
     # Construct model_info dictionary
 
+    # Extracting the argument symbols from the model definition
     arg_syms = map(modeldef[:args]) do arg
+        # @model demo(x)
         if (arg isa Symbol)
             arg
-        elseif MacroTools.@capture(arg, ::Type{T_} = TVal_)
+        # @model demo(::Type{T}) where {T}
+        elseif MacroTools.@capture(arg, ::Type{T_} = Tval_)
             T
+        # @model demo(x = 1)
+        elseif MacroTools.@capture(arg, x_ = val_)
+            x
         else
-            arg.args[1]
+            throw(ArgumentError("Unsupported argument $arg to the `@model` macro."))
         end
     end
     args = map(modeldef[:args]) do arg

--- a/src/core/compiler.jl
+++ b/src/core/compiler.jl
@@ -246,7 +246,7 @@ function build_model_info(input_expr)
                 S = :Any
             else
                 ind = findfirst(x -> MacroTools.@capture(x, T1_ <: S_) && T1 == T, modeldef[:whereparams])
-                @assert ind != nothing "Please make sure type parameters are properly used. Every `Type{T}` argument need to have `T` in the a `where` clause"
+                ind != nothing || throw(ArgumentError("Please make sure type parameters are properly used. Every `Type{T}` argument need to have `T` in the a `where` clause"))
             end
             Expr(:kw, :($T::Type{<:$S}), Tval)
         else

--- a/src/inference/AdvancedSMC.jl
+++ b/src/inference/AdvancedSMC.jl
@@ -20,16 +20,17 @@ Usage:
 SMC(1000)
 ```
 """
-mutable struct SMC{T, F} <: InferenceAlgorithm
+mutable struct SMC{space, F} <: InferenceAlgorithm
     n_particles           ::  Int
     resampler             ::  F
     resampler_threshold   ::  Float64
-    space                 ::  Set{T}
 end
-SMC(n) = SMC(n, resample_systematic, 0.5, Set())
+function SMC(n_particles::Int, resampler::F, resampler_threshold::Float64, space::Tuple) where {F}
+    return SMC{space, F}(n_particles, resampler, resampler_threshold)
+end
+SMC(n) = SMC(n, resample_systematic, 0.5, ())
 function SMC(n_particles::Int, space...)
-    _space = isa(space, Symbol) ? Set([space]) : Set(space)
-    SMC(n_particles, resample_systematic, 0.5, _space)
+    SMC(n_particles, resample_systematic, 0.5, space)
 end
 
 function Sampler(alg::SMC, s::Selector)
@@ -97,16 +98,17 @@ Usage:
 PG(100, 100)
 ```
 """
-mutable struct PG{T, F} <: InferenceAlgorithm
+mutable struct PG{space, F} <: InferenceAlgorithm
   n_particles           ::    Int         # number of particles used
   n_iters               ::    Int         # number of iterations
   resampler             ::    F           # function to resample
-  space                 ::    Set{T}      # sampling space, emtpy means all
 end
-PG(n1::Int, n2::Int) = PG(n1, n2, resample_systematic, Set())
+function PG(n_particles::Int, n_iters::Int, resampler::F, space::Tuple) where F
+    return PG{space, F}(n_particles, n_iters, resampler)
+end
+PG(n1::Int, n2::Int) = PG(n1, n2, resample_systematic, ())
 function PG(n1::Int, n2::Int, space...)
-  _space = isa(space, Symbol) ? Set([space]) : Set(space)
-  PG(n1, n2, resample_systematic, _space)
+    PG(n1, n2, resample_systematic, space)
 end
 
 const CSMC = PG # type alias of PG as Conditional SMC
@@ -219,7 +221,7 @@ function assume(  spl::Sampler{T},
                 ) where T<:Union{PG,SMC}
 
     vi = current_trace().vi
-    if isempty(spl.alg.space) || vn.sym in spl.alg.space
+    if isempty(getspace(spl.alg)) || vn.sym in getspace(spl.alg)
         if ~haskey(vi, vn)
             r = rand(dist)
             push!(vi, vn, r, dist, spl)
@@ -295,16 +297,18 @@ Arguments:
 - `parameters_algs::Tuple{MH}` : An [`MH`](@ref) algorithm, which includes a
 sample space specification.
 """
-mutable struct PMMH{T, A<:Tuple} <: InferenceAlgorithm
+mutable struct PMMH{space, A<:Tuple} <: InferenceAlgorithm
     n_iters               ::    Int               # number of iterations
     algs                  ::    A                 # Proposals for state & parameters
-    space                 ::    Set{T}            # sampling space, emtpy means all
+end
+function PMMH(n_iters::Int, algs::A, space::Tuple) where {A <: Tuple}
+    return PMMH{space, A}(n_iters, algs)
 end
 function PMMH(n_iters::Int, smc_alg::SMC, parameter_algs...)
-    return PMMH(n_iters, tuple(parameter_algs..., smc_alg), Set())
+    return PMMH(n_iters, tuple(parameter_algs..., smc_alg), ())
 end
 
-PIMH(n_iters::Int, smc_alg::SMC) = PMMH(n_iters, tuple(smc_alg), Set())
+PIMH(n_iters::Int, smc_alg::SMC) = PMMH(n_iters, tuple(smc_alg), ())
 
 function Sampler(alg::PMMH, model::Model, s::Selector)
     info = Dict{Symbol, Any}()
@@ -324,17 +328,17 @@ function Sampler(alg::PMMH, model::Model, s::Selector)
             error("[$alg_str] unsupport base sampling algorithm $alg")
         end
         if typeof(sub_alg) == MH && sub_alg.n_iters != 1
-            warn("[$alg_str] number of iterations greater than 1 is useless for MH since it is only used for its proposal")
+            @warn("[$alg_str] number of iterations greater than 1 is useless for MH since it is only used for its proposal")
         end
-        space = union(space, sub_alg.space)
+        space = (space..., getspace(sub_alg)...)
     end
 
     # Sanity check for space
     if !isempty(space)
-        @assert issubset(Set(get_pvars(model)), space) "[$alg_str] symbols specified to samplers ($space) doesn't cover the model parameters ($(Set(get_pvars(model))))"
+        @assert issubset(get_pvars(model), space) "[$alg_str] symbols specified to samplers ($space) doesn't cover the model parameters ($(get_pvars(model)))"
 
-        if Set(get_pvars(model)) != space
-            warn("[$alg_str] extra parameters specified by samplers don't exist in model: $(setdiff(space, Set(get_pvars(model))))")
+        if !(issetequal(get_pvars(model), space))
+            @warn("[$alg_str] extra parameters specified by samplers don't exist in model: $(setdiff(space, get_pvars(model)))")
         end
     end
 
@@ -354,7 +358,7 @@ function step(model, spl::Sampler{<:PMMH}, vi::VarInfo, is_first::Bool)
 
     Turing.DEBUG && @debug "Propose new parameters from proposals..."
     for local_spl in spl.info[:samplers][1:end-1]
-        Turing.DEBUG && @debug "$(typeof(local_spl)) proposing $(local_spl.alg.space)..."
+        Turing.DEBUG && @debug "$(typeof(local_spl)) proposing $(getspace(local_spl.alg))..."
         propose(model, local_spl, vi)
         if local_spl.info[:violating_support] violating_support=true; break end
         new_prior_prob += local_spl.info[:prior_prob]
@@ -485,20 +489,21 @@ Arguments:
 
 A paper on this can be found [here](https://arxiv.org/abs/1602.05128).
 """
-mutable struct IPMCMC{T, F} <: InferenceAlgorithm
+mutable struct IPMCMC{space, F} <: InferenceAlgorithm
   n_particles           ::    Int         # number of particles used
   n_iters               ::    Int         # number of iterations
   n_nodes               ::    Int         # number of nodes running SMC and CSMC
   n_csmc_nodes          ::    Int         # number of nodes CSMC
   resampler             ::    F           # function to resample
-  space                 ::    Set{T}      # sampling space, emtpy means all
 end
-IPMCMC(n1::Int, n2::Int) = IPMCMC(n1, n2, 32, 16, resample_systematic, Set())
-IPMCMC(n1::Int, n2::Int, n3::Int) = IPMCMC(n1, n2, n3, Int(ceil(n3/2)), resample_systematic, Set())
-IPMCMC(n1::Int, n2::Int, n3::Int, n4::Int) = IPMCMC(n1, n2, n3, n4, resample_systematic, Set())
+function IPMCMC(n_particles::Int, n_iters::Int, n_nodes::Int, n_csmc_nodes::Int, resampler::F, space::Tuple) where {F}
+    return IPMCMC{space, F}(n_particles, n_iters, n_nodes, n_csmc_nodes, resampler)
+end
+IPMCMC(n1::Int, n2::Int) = IPMCMC(n1, n2, 32, 16, resample_systematic, ())
+IPMCMC(n1::Int, n2::Int, n3::Int) = IPMCMC(n1, n2, n3, Int(ceil(n3/2)), resample_systematic, ())
+IPMCMC(n1::Int, n2::Int, n3::Int, n4::Int) = IPMCMC(n1, n2, n3, n4, resample_systematic, ())
 function IPMCMC(n1::Int, n2::Int, n3::Int, n4::Int, space...)
-  _space = isa(space, Symbol) ? Set([space]) : Set(space)
-  IPMCMC(n1, n2, n3, n4, resample_systematic, _space)
+  IPMCMC(n1, n2, n3, n4, resample_systematic, space)
 end
 
 function Sampler(alg::IPMCMC, s::Selector)
@@ -507,8 +512,8 @@ function Sampler(alg::IPMCMC, s::Selector)
   # Create SMC and CSMC nodes
   samplers = Array{Sampler}(undef, alg.n_nodes)
   # Use resampler_threshold=1.0 for SMC since adaptive resampling is invalid in this setting
-  default_CSMC = CSMC(alg.n_particles, 1, alg.resampler, alg.space)
-  default_SMC = SMC(alg.n_particles, alg.resampler, 1.0, false, alg.space)
+  default_CSMC = CSMC(alg.n_particles, 1, alg.resampler, getspace(alg))
+  default_SMC = SMC(alg.n_particles, alg.resampler, 1.0, false, getspace(alg))
 
   for i in 1:alg.n_csmc_nodes
     samplers[i] = Sampler(default_CSMC, Selector(Symbol(typeof(default_CSMC))))

--- a/src/inference/AdvancedSMC.jl
+++ b/src/inference/AdvancedSMC.jl
@@ -29,7 +29,8 @@ function SMC(n_particles::Int, resampler::F, resampler_threshold::Float64, space
     return SMC{space, F}(n_particles, resampler, resampler_threshold)
 end
 SMC(n) = SMC(n, resample_systematic, 0.5, ())
-function SMC(n_particles::Int, space...)
+SMC(n_particles::Int, ::Tuple{}) = SMC(n_particles)
+function SMC(n_particles::Int, space::Symbol...)
     SMC(n_particles, resample_systematic, 0.5, space)
 end
 
@@ -106,8 +107,8 @@ end
 function PG(n_particles::Int, n_iters::Int, resampler::F, space::Tuple) where F
     return PG{space, F}(n_particles, n_iters, resampler)
 end
-PG(n1::Int, n2::Int) = PG(n1, n2, resample_systematic, ())
-function PG(n1::Int, n2::Int, space...)
+PG(n1::Int, n2::Int, ::Tuple{}) = PG(n1, n2)
+function PG(n1::Int, n2::Int, space::Symbol...)
     PG(n1, n2, resample_systematic, space)
 end
 
@@ -499,10 +500,10 @@ end
 function IPMCMC(n_particles::Int, n_iters::Int, n_nodes::Int, n_csmc_nodes::Int, resampler::F, space::Tuple) where {F}
     return IPMCMC{space, F}(n_particles, n_iters, n_nodes, n_csmc_nodes, resampler)
 end
-IPMCMC(n1::Int, n2::Int) = IPMCMC(n1, n2, 32, 16, resample_systematic, ())
-IPMCMC(n1::Int, n2::Int, n3::Int) = IPMCMC(n1, n2, n3, Int(ceil(n3/2)), resample_systematic, ())
-IPMCMC(n1::Int, n2::Int, n3::Int, n4::Int) = IPMCMC(n1, n2, n3, n4, resample_systematic, ())
-function IPMCMC(n1::Int, n2::Int, n3::Int, n4::Int, space...)
+IPMCMC(n1::Int, n2::Int) = IPMCMC(n1, n2, 32, 16)
+IPMCMC(n1::Int, n2::Int, n3::Int) = IPMCMC(n1, n2, n3, Int(ceil(n3/2)))
+IPMCMC(n1::Int, n2::Int, n3::Int, n4::Int, ::Tuple{}) = IPMCMC(n1, n2, n3, n4)
+function IPMCMC(n1::Int, n2::Int, n3::Int, n4::Int, space::Symbol...)
   IPMCMC(n1, n2, n3, n4, resample_systematic, space)
 end
 
@@ -513,7 +514,7 @@ function Sampler(alg::IPMCMC, s::Selector)
   samplers = Array{Sampler}(undef, alg.n_nodes)
   # Use resampler_threshold=1.0 for SMC since adaptive resampling is invalid in this setting
   default_CSMC = CSMC(alg.n_particles, 1, alg.resampler, getspace(alg))
-  default_SMC = SMC(alg.n_particles, alg.resampler, 1.0, false, getspace(alg))
+  default_SMC = SMC(alg.n_particles, alg.resampler, 1.0, getspace(alg))
 
   for i in 1:alg.n_csmc_nodes
     samplers[i] = Sampler(default_CSMC, Selector(Symbol(typeof(default_CSMC))))

--- a/src/inference/Inference.jl
+++ b/src/inference/Inference.jl
@@ -94,7 +94,7 @@ end
 
 @inline floatof(::Type{T}) where {T <: Real} = typeof(one(T)/one(T))
 @inline floatof(::Type) = Real
-# Make eltype(vi[spl]) lazy
+
 @inline Turing.Core.get_matching_type(spl::Turing.Sampler, vi::Turing.RandomVariables.VarInfo, ::Type{T}) where {T <: AbstractFloat} = floatof(eltype(vi, spl))
 @inline Turing.Core.get_matching_type(spl::Turing.Sampler{<:Hamiltonian}, vi::Turing.RandomVariables.VarInfo, ::Type{TV}) where {T, N, TV <: Array{T, N}} = Array{Turing.Core.get_matching_type(spl, vi, T), N}
 @inline Turing.Core.get_matching_type(spl::Turing.Sampler{<:Union{PG, SMC}}, vi::Turing.RandomVariables.VarInfo, ::Type{TV}) where {T, N, TV <: Array{T, N}} = TArray{T, N}

--- a/src/inference/Inference.jl
+++ b/src/inference/Inference.jl
@@ -85,10 +85,16 @@ include("is.jl")
 include("AdvancedSMC.jl")
 include("gibbs.jl")
 
+for alg in (:SMC, :PG, :PMMH, :IPMCMC, :MH)
+    @eval getspace(::$alg{space}) where {space} = space
+end
+for alg in (:HMC, :HMCDA, :NUTS, :SGLD, :SGHMC)
+    @eval getspace(::$alg{<:Any, space}) where {space} = space
+end
+
 @inline floatof(::Type{T}) where {T <: Real} = typeof(one(T)/one(T))
 @inline floatof(::Type) = Real
 # Make eltype(vi[spl]) lazy
-@inline Turing.Core.get_matching_type(spl::Turing.Sampler, vi::Turing.RandomVariables.VarInfo, ::Type{T}) where {T <: AbstractFloat} = floatof(eltype(vi, spl))
 @inline Turing.Core.get_matching_type(spl::Turing.Sampler, vi::Turing.RandomVariables.VarInfo, ::Type{T}) where {T <: AbstractFloat} = floatof(eltype(vi, spl))
 @inline Turing.Core.get_matching_type(spl::Turing.Sampler{<:Hamiltonian}, vi::Turing.RandomVariables.VarInfo, ::Type{TV}) where {T, N, TV <: Array{T, N}} = Array{Turing.Core.get_matching_type(spl, vi, T), N}
 @inline Turing.Core.get_matching_type(spl::Turing.Sampler{<:Union{PG, SMC}}, vi::Turing.RandomVariables.VarInfo, ::Type{TV}) where {T, N, TV <: Array{T, N}} = TArray{T, N}

--- a/src/inference/Inference.jl
+++ b/src/inference/Inference.jl
@@ -87,8 +87,8 @@ include("gibbs.jl")
 
 @inline floatof(::Type{T}) where {T} = typeof(one(T)/one(T))
 # Make eltype(vi[spl]) lazy
-@inline Turing.Core.get_matching_type(spl::Turing.Sampler, vi::Turing.RandomVariables.VarInfo, ::Type{T}) where {T <: AbstractFloat} = floatof(eltype(vi[spl]))
-@inline Turing.Core.get_matching_type(spl::Turing.Sampler, vi::Turing.RandomVariables.VarInfo, ::Type{T}) where {T <: AbstractFloat} = floatof(eltype(vi[spl]))
+@inline Turing.Core.get_matching_type(spl::Turing.Sampler, vi::Turing.RandomVariables.VarInfo, ::Type{T}) where {T <: AbstractFloat} = floatof(eltype(vi, spl))
+@inline Turing.Core.get_matching_type(spl::Turing.Sampler, vi::Turing.RandomVariables.VarInfo, ::Type{T}) where {T <: AbstractFloat} = floatof(eltype(vi, spl))
 @inline Turing.Core.get_matching_type(spl::Turing.Sampler{<:Hamiltonian}, vi::Turing.RandomVariables.VarInfo, ::Type{TV}) where {T, N, TV <: Array{T, N}} = Array{Turing.Core.get_matching_type(spl, vi, T), N}
 @inline Turing.Core.get_matching_type(spl::Turing.Sampler{<:Union{PG, SMC}}, vi::Turing.RandomVariables.VarInfo, ::Type{TV}) where {T, N, TV <: Array{T, N}} = TArray{T, N}
 

--- a/src/inference/Inference.jl
+++ b/src/inference/Inference.jl
@@ -85,7 +85,8 @@ include("is.jl")
 include("AdvancedSMC.jl")
 include("gibbs.jl")
 
-@inline floatof(::Type{T}) where {T} = typeof(one(T)/one(T))
+@inline floatof(::Type{T}) where {T <: Real} = typeof(one(T)/one(T))
+@inline floatof(::Type) = Real
 # Make eltype(vi[spl]) lazy
 @inline Turing.Core.get_matching_type(spl::Turing.Sampler, vi::Turing.RandomVariables.VarInfo, ::Type{T}) where {T <: AbstractFloat} = floatof(eltype(vi, spl))
 @inline Turing.Core.get_matching_type(spl::Turing.Sampler, vi::Turing.RandomVariables.VarInfo, ::Type{T}) where {T <: AbstractFloat} = floatof(eltype(vi, spl))

--- a/src/inference/Inference.jl
+++ b/src/inference/Inference.jl
@@ -85,6 +85,13 @@ include("is.jl")
 include("AdvancedSMC.jl")
 include("gibbs.jl")
 
+@inline floatof(::Type{T}) where {T} = typeof(one(T)/one(T))
+# Make eltype(vi[spl]) lazy
+@inline Turing.Core.get_matching_type(spl::Turing.Sampler, vi::Turing.RandomVariables.VarInfo, ::Type{T}) where {T <: AbstractFloat} = floatof(eltype(vi[spl]))
+@inline Turing.Core.get_matching_type(spl::Turing.Sampler, vi::Turing.RandomVariables.VarInfo, ::Type{T}) where {T <: AbstractFloat} = floatof(eltype(vi[spl]))
+@inline Turing.Core.get_matching_type(spl::Turing.Sampler{<:Hamiltonian}, vi::Turing.RandomVariables.VarInfo, ::Type{TV}) where {T, N, TV <: Array{T, N}} = Array{Turing.Core.get_matching_type(spl, vi, T), N}
+@inline Turing.Core.get_matching_type(spl::Turing.Sampler{<:Union{PG, SMC}}, vi::Turing.RandomVariables.VarInfo, ::Type{TV}) where {T, N, TV <: Array{T, N}} = TArray{T, N}
+
 ## Fallback functions
 
 # utility funcs for querying sampler information

--- a/src/inference/dynamichmc.jl
+++ b/src/inference/dynamichmc.jl
@@ -15,7 +15,6 @@ To use it, make sure you have the DynamicHMC package installed.
 
 """
 DynamicNUTS(args...) = DynamicNUTS{ADBackend()}(args...)
-DynamicNUTS{AD}(n_iters::Integer, ::Tuple{}) where AD = DynamicNUTS{AD}(n_iters)
 function DynamicNUTS{AD}(n_iters::Integer, space::Symbol...) where AD
     DynamicNUTS{AD}(n_iters, space)
 end

--- a/src/inference/dynamichmc.jl
+++ b/src/inference/dynamichmc.jl
@@ -15,7 +15,8 @@ To use it, make sure you have the DynamicHMC package installed.
 
 """
 DynamicNUTS(args...) = DynamicNUTS{ADBackend()}(args...)
-function DynamicNUTS{AD}(n_iters::Integer, space...) where AD
+DynamicNUTS{AD}(n_iters::Integer, ::Tuple{}) where AD = DynamicNUTS{AD}(n_iters)
+function DynamicNUTS{AD}(n_iters::Integer, space::Symbol...) where AD
     DynamicNUTS{AD}(n_iters, space)
 end
 

--- a/src/inference/dynamichmc.jl
+++ b/src/inference/dynamichmc.jl
@@ -2,10 +2,10 @@
 ### DynamicHMC backend - https://github.com/tpapp/DynamicHMC.jl
 ###
 
-struct DynamicNUTS{AD, T} <: Hamiltonian{AD}
-    n_iters   ::  Integer   # number of samples
-    space     ::  Set{T}    # sampling space, emtpy means all
+struct DynamicNUTS{AD, space} <: Hamiltonian{AD}
+    n_iters   ::  Int   # number of samples
 end
+DynamicNUTS{AD}(n_iters::Int, space::Tuple) where {AD} = DynamicNUTS{AD, space}(n_iters)
 
 """
     DynamicNUTS(n_iters::Integer)
@@ -16,9 +16,10 @@ To use it, make sure you have the DynamicHMC package installed.
 """
 DynamicNUTS(args...) = DynamicNUTS{ADBackend()}(args...)
 function DynamicNUTS{AD}(n_iters::Integer, space...) where AD
-    _space = isa(space, Symbol) ? Set([space]) : Set(space)
-    DynamicNUTS{AD, eltype(_space)}(n_iters, _space)
+    DynamicNUTS{AD}(n_iters, space)
 end
+
+getspace(::DynamicNUTS{<:Any, space}) where {space} = space
 
 function Sampler(alg::DynamicNUTS{T}, s::Selector=Selector()) where T <: Hamiltonian
   return Sampler(alg, Dict{Symbol,Any}(), s)

--- a/src/inference/gibbs.jl
+++ b/src/inference/gibbs.jl
@@ -52,14 +52,14 @@ function Sampler(alg::Gibbs, model::Model, s::Selector)
         else
             @error("[Gibbs] unsupport base sampling algorithm $alg")
         end
-        space = union(space, sub_alg.space)
+        space = (space..., getspace(sub_alg)...)
     end
 
     # Sanity check for space
-    @assert issubset(Set(get_pvars(model)), space) "[Gibbs] symbols specified to samplers ($space) doesn't cover the model parameters ($(Set(get_pvars(model))))"
+    @assert issubset(get_pvars(model), space) "[Gibbs] symbols specified to samplers ($space) doesn't cover the model parameters ($(get_pvars(model)))"
 
-    if Set(get_pvars(model)) != space
-        @warn("[Gibbs] extra parameters specified by samplers don't exist in model: $(setdiff(space, Set(get_pvars(model))))")
+    if !(issetequal(get_pvars(model), space))
+        @warn("[Gibbs] extra parameters specified by samplers don't exist in model: $(setdiff(space, get_pvars(model)))")
     end
 
     info[:samplers] = samplers

--- a/src/inference/hmc.jl
+++ b/src/inference/hmc.jl
@@ -44,17 +44,17 @@ end
 function HMC{AD}(
     n_iters::Int,
     ϵ::Float64,
-    n_leapfrog::Int;
-    metricT=AHMC.UnitEuclideanMetric
+    n_leapfrog::Int,
+    ::Tuple{};
+    kwargs...
 ) where AD
-    return HMC{AD}(n_iters, ϵ, n_leapfrog, metricT, ())
+    return HMC{AD}(n_iters, ϵ, n_leapfrog; kwargs...)
 end
-
 function HMC{AD}(
     n_iters::Int,
     ϵ::Float64,
     n_leapfrog::Int,
-    space...;
+    space::Symbol...;
     metricT=AHMC.UnitEuclideanMetric
 ) where AD
     return HMC{AD}(n_iters, ϵ, n_leapfrog, metricT, space)
@@ -113,11 +113,11 @@ function HMCDA{AD}(
     n_iters::Int,
     n_adapts::Int,
     δ::Float64,
-    λ::Float64;
-    init_ϵ::Float64=0.1,
-    metricT=AHMC.UnitEuclideanMetric
+    λ::Float64,
+    ::Tuple{};
+    kwargs...
 ) where AD
-    return HMCDA{AD}(n_iters, n_adapts, δ, λ, init_ϵ, metricT, ())
+    return HMCDA{AD}(n_iters, n_adapts, δ, λ; kwargs...)
 end
 
 function HMCDA{AD}(
@@ -125,7 +125,7 @@ function HMCDA{AD}(
     n_adapts::Int,
     δ::Float64,
     λ::Float64,
-    space...;
+    space::Symbol...;
     init_ϵ::Float64=0.1,
     metricT=AHMC.UnitEuclideanMetric
 ) where AD
@@ -163,7 +163,16 @@ mutable struct NUTS{AD, space, metricT <: AHMC.AbstractMetric} <: AdaptiveHamilt
 end
 
 NUTS(args...; kwargs...) = NUTS{ADBackend()}(args...; kwargs...)
-function NUTS{AD}(n_iters::Int, n_adapts::Int, δ::Float64, max_depth::Int, Δ_max::Float64, init_ϵ::Float64, ::Type{metricT}, space::Tuple) where {AD, metricT}
+function NUTS{AD}(
+    n_iters::Int, 
+    n_adapts::Int, 
+    δ::Float64, 
+    max_depth::Int, 
+    Δ_max::Float64, 
+    init_ϵ::Float64, 
+    ::Type{metricT}, 
+    space::Tuple
+) where {AD, metricT}
     return NUTS{AD, space, metricT}(n_iters, n_adapts, δ, max_depth, Δ_max, init_ϵ)
 end
 
@@ -171,7 +180,17 @@ function NUTS{AD}(
     n_iters::Int,
     n_adapts::Int,
     δ::Float64,
-    space...;
+    ::Tuple{};
+    kwargs...
+) where AD
+    NUTS{AD}(n_iters, n_adapts, δ; kwargs...)
+end
+
+function NUTS{AD}(
+    n_iters::Int,
+    n_adapts::Int,
+    δ::Float64,
+    space::Symbol...;
     max_depth::Int=5,
     Δ_max::Float64=1000.0,
     init_ϵ::Float64=0.1,

--- a/src/inference/sghmc.jl
+++ b/src/inference/sghmc.jl
@@ -25,14 +25,15 @@ Arguments:
 - `momentum_decay::Float64` : Momentum decay variable.
 
 """
-mutable struct SGHMC{AD, T} <: StaticHamiltonian{AD}
+mutable struct SGHMC{AD, space, metricT <: AHMC.AbstractMetric} <: StaticHamiltonian{AD}
     n_iters::Int       # number of samples
     learning_rate::Float64   # learning rate
     momentum_decay::Float64   # momentum decay
-    space::Set{T}    # sampling space, emtpy means all
-    metricT::Type{<:AHMC.AbstractMetric}
 end
 SGHMC(args...) = SGHMC{ADBackend()}(args...)
+function SGHMC{AD}(n_iters::Int, learning_rate::Float64, momentum_decay::Float64, ::Type{metricT}, space::Tuple) where {AD, metricT <: AHMC.AbstractMetric}
+    return SGHMC{AD, space, metricT}(n_iters, learning_rate, momentum_decay)
+end
 
 function SGHMC{AD}(
     n_iters,
@@ -40,7 +41,7 @@ function SGHMC{AD}(
     momentum_decay;
     metricT=AHMC.UnitEuclideanMetric
     ) where AD
-    return SGHMC{AD, Any}(n_iters, learning_rate, momentum_decay, Set(), metricT)
+    return SGHMC{AD}(n_iters, learning_rate, momentum_decay, metricT, ())
 end
 function SGHMC{AD}(
     n_iters,
@@ -49,8 +50,7 @@ function SGHMC{AD}(
     space...;
     metricT=AHMC.UnitEuclideanMetric
 ) where AD
-    _space = isa(space, Symbol) ? Set([space]) : Set(space)
-    return SGHMC{AD, eltype(_space)}(n_iters, learning_rate, momentum_decay, _space, metricT)
+    return SGHMC{AD}(n_iters, learning_rate, momentum_decay, metricT, space)
 end
 
 function step(
@@ -133,11 +133,12 @@ Reference:
 Welling, M., & Teh, Y. W. (2011).  Bayesian learning via stochastic gradient Langevin dynamics.
 In Proceedings of the 28th international conference on machine learning (ICML-11) (pp. 681-688).
 """
-mutable struct SGLD{AD, T} <: StaticHamiltonian{AD}
+mutable struct SGLD{AD, space, metricT <: AHMC.AbstractMetric} <: StaticHamiltonian{AD}
     n_iters :: Int       # number of samples
     ϵ :: Float64   # constant scale factor of learning rate
-    space   :: Set{T}    # sampling space, emtpy means all
-    metricT :: Type{<:AHMC.AbstractMetric}
+end
+function SGLD{AD}(n_iters::Int, ϵ::Float64, ::Type{metricT}, space::Tuple) where {AD, metricT <: AHMC.AbstractMetric}
+    return SGLD{AD, space, metricT}(n_iters, ϵ)
 end
 
 SGLD(args...; kwargs...) = SGLD{ADBackend()}(args...; kwargs...)
@@ -147,7 +148,7 @@ function SGLD{AD}(
     ϵ;
     metricT=AHMC.UnitEuclideanMetric
 ) where AD
-    SGLD{AD, Any}(n_iters, ϵ, Set(), metricT)
+    return SGLD{AD}(n_iters, ϵ, metricT, ())
 end
 
 function SGLD{AD}(
@@ -156,8 +157,7 @@ function SGLD{AD}(
     space...;
     metricT=AHMC.UnitEuclideanMetric
 ) where AD
-    _space = isa(space, Symbol) ? Set([space]) : Set(space)
-    return SGLD{AD, eltype(_space)}(n_iters, ϵ, _space, metricT)
+    return SGLD{AD}(n_iters, ϵ, metricT, space)
 end
 
 function step(

--- a/src/inference/sghmc.jl
+++ b/src/inference/sghmc.jl
@@ -38,16 +38,17 @@ end
 function SGHMC{AD}(
     n_iters,
     learning_rate,
-    momentum_decay;
-    metricT=AHMC.UnitEuclideanMetric
-    ) where AD
-    return SGHMC{AD}(n_iters, learning_rate, momentum_decay, metricT, ())
+    momentum_decay,
+    ::Tuple{};
+    kwargs...
+) where AD
+    return SGHMC{AD}(n_iters, learning_rate, momentum_decay; kwargs...)
 end
 function SGHMC{AD}(
     n_iters,
     learning_rate,
     momentum_decay,
-    space...;
+    space::Symbol...;
     metricT=AHMC.UnitEuclideanMetric
 ) where AD
     return SGHMC{AD}(n_iters, learning_rate, momentum_decay, metricT, space)
@@ -145,16 +146,17 @@ SGLD(args...; kwargs...) = SGLD{ADBackend()}(args...; kwargs...)
 
 function SGLD{AD}(
     n_iters,
-    ϵ;
-    metricT=AHMC.UnitEuclideanMetric
+    ϵ,
+    ::Tuple{};
+    kwargs...
 ) where AD
-    return SGLD{AD}(n_iters, ϵ, metricT, ())
+    return SGLD{AD}(n_iters, ϵ; kwargs...)
 end
 
 function SGLD{AD}(
     n_iters,
     ϵ,
-    space...;
+    space::Symbol...;
     metricT=AHMC.UnitEuclideanMetric
 ) where AD
     return SGLD{AD}(n_iters, ϵ, metricT, space)

--- a/src/utilities/helper.jl
+++ b/src/utilities/helper.jl
@@ -12,40 +12,36 @@ vectorize(d::MatrixDistribution, r::AbstractMatrix{<:Real}) = copy(vec(r))
 # otherwise we will have error for MatrixDistribution.
 # Note this is not the case for MultivariateDistribution so I guess this might be lack of
 # support for some types related to matrices (like PDMat).
-reconstruct(d::Distribution, val::AbstractVector) = reconstruct(d, val, typeof(val[1]))
-reconstruct(d::UnivariateDistribution, val::AbstractVector, T::Type) = val[1]
-reconstruct(d::MultivariateDistribution, val::AbstractVector, T::Type) = Vector{T}(val)
-function reconstruct(d::MatrixDistribution, val::AbstractVector, T::Type)
-    return Array{T, 2}(reshape(val, size(d)...))
+reconstruct(d::UnivariateDistribution, val::AbstractVector) = val[1]
+reconstruct(d::MultivariateDistribution, val::AbstractVector) = copy(val)
+function reconstruct(d::MatrixDistribution, val::AbstractVector)
+    return copy(reshape(val, size(d)))
 end
 function reconstruct!(r, d::Distribution, val::AbstractVector)
-    return reconstruct!(r, d, val, typeof(val[1]))
+    return reconstruct!(r, d, val)
 end
-function reconstruct!(r, d::MultivariateDistribution, val::AbstractVector, T::Type)
+function reconstruct!(r, d::MultivariateDistribution, val::AbstractVector)
     r .= val
     return r
 end
 function reconstruct(d::Distribution, val::AbstractVector, n::Int)
-    return reconstruct(d, val, typeof(val[1]), n)
+    return reconstruct(d, val, n)
 end
-function reconstruct(d::UnivariateDistribution, val::AbstractVector, T::Type, n::Int)
-    return Vector{T}(val)
+function reconstruct(d::UnivariateDistribution, val::AbstractVector, n::Int)
+    return copy(val)
 end
-function reconstruct(d::MultivariateDistribution, val::AbstractVector, T::Type, n::Int)
-    return Matrix{T}(reshape(val, size(d)[1], n))
+function reconstruct(d::MultivariateDistribution, val::AbstractVector, n::Int)
+    return copy(reshape(val, size(d)[1], n))
 end
-function reconstruct(d::MatrixDistribution, val::AbstractVector, T::Type, n::Int)
-    orig = Vector{Matrix{T}}(undef, n)
-    tmp = Array{T, 3}(reshape(val, size(d)[1], size(d)[2], n))
-    for i = 1:n
-        orig[i] = tmp[:, :, i]
-    end
+function reconstruct(d::MatrixDistribution, val::AbstractVector, n::Int)
+    tmp = reshape(val, size(d)[1], size(d)[2], n)
+    orig = [tmp[:, :, i] for i in 1:size(tmp, 3)]
     return orig
 end
 function reconstruct!(r, d::Distribution, val::AbstractVector, n::Int)
-    return reconstruct!(r, d, val, typeof(val[1]), n)
+    return reconstruct!(r, d, val, n)
 end
-function reconstruct!(r, d::MultivariateDistribution, val::AbstractVector, T::Type, n::Int)
+function reconstruct!(r, d::MultivariateDistribution, val::AbstractVector, n::Int)
     r .= val
     return r
 end

--- a/test/core/RandomVariables.jl
+++ b/test/core/RandomVariables.jl
@@ -61,7 +61,7 @@ include(dir*"/test/test_utils/AllUtils.jl")
         vn2 = VarName(csym, :x, "[1][2]", 1)
         @test vn2 == vn1
         @test hash(vn2) == hash(vn1)
-        @test in(vn1, Set([:x]))
+        @test in(vn1, (:x,))
 
         function test_base!(vi)
             empty!(vi)
@@ -96,7 +96,7 @@ include(dir*"/test/test_utils/AllUtils.jl")
             push!(vi, vn, r, dist, gid)
 
             function test_in()
-                space = Set([:x, :y, :(z[1])])
+                space = (:x, :y, :(z[1]))
                 vn1 = genvn(:x)
                 vn2 = genvn(:y)
                 vn3 = genvn(:(x[1]))

--- a/test/core/RandomVariables.jl
+++ b/test/core/RandomVariables.jl
@@ -324,8 +324,8 @@ include(dir*"/test/test_utils/AllUtils.jl")
         xs = rand(Normal(0.5, 1), 100)
 
         # Define model
-        @model priorsinarray(xs) = begin
-            priors = Vector{Real}(undef, 2)
+        @model priorsinarray(xs, ::Type{T}=Float64) where {T} = begin
+            priors = Vector{T}(undef, 2)
             priors[1] ~ InverseGamma(2, 3)
             priors[2] ~ Normal(0, sqrt(priors[1]))
             for i = 1:length(xs)

--- a/test/core/ad.jl
+++ b/test/core/ad.jl
@@ -53,10 +53,10 @@ _to_cov(B) = B * B' + Matrix(I, size(B)...)
     end
     @turing_testset "adr" begin
         ad_test_f = gdemo_default
-        vi = Turing.VarInfo(ad_test_f)
+        vi = Turing.VarInfo()
         ad_test_f(vi, SampleFromPrior())
-        svn = vi.metadata.s.vns[1]
-        mvn = vi.metadata.m.vns[1]
+        svn = vi.vns[1]
+        mvn = vi.vns[2]
         _s = getval(vi, svn)[1]
         _m = getval(vi, mvn)[1]
 

--- a/test/core/ad.jl
+++ b/test/core/ad.jl
@@ -53,10 +53,10 @@ _to_cov(B) = B * B' + Matrix(I, size(B)...)
     end
     @turing_testset "adr" begin
         ad_test_f = gdemo_default
-        vi = Turing.VarInfo()
+        vi = Turing.VarInfo(ad_test_f)
         ad_test_f(vi, SampleFromPrior())
-        svn = collect(Iterators.filter(vn -> vn.sym == :s, keys(vi)))[1]
-        mvn = collect(Iterators.filter(vn -> vn.sym == :m, keys(vi)))[1]
+        svn = vi.metadata.s.vns[1]
+        mvn = vi.metadata.m.vns[1]
         _s = getval(vi, svn)[1]
         _m = getval(vi, mvn)[1]
 

--- a/test/core/compiler.jl
+++ b/test/core/compiler.jl
@@ -330,7 +330,7 @@ priors = 0 # See "new grammar" test.
 
         t_vec = @elapsed res = sample(vdemo5(), alg)
 
-        @model vdemo6(::Type{T}=Float64) where {T} = begin
+        @model vdemo6(::Type{T}=Float64) where {T <: Real} = begin
             x = Vector{T}(undef, N)
             x ~ [Normal(0, 2)]
         end
@@ -358,8 +358,8 @@ priors = 0 # See "new grammar" test.
 
         sample(vdemo8(), alg)
 
-        @model vdemo8(::Type{T}=Float64) where {T} = begin
-            x = Vector{T}(undef, N)
+        @model vdemo8(::Type{TV}=Vector{Float64}) where {TV <: AbstractVector} = begin
+            x = TV(undef, N)
             x ~ [InverseGamma(2, 3)]
         end
 

--- a/test/core/compiler.jl
+++ b/test/core/compiler.jl
@@ -130,6 +130,8 @@ priors = 0 # See "new grammar" test.
         end
         f1_mm = testmodel1(1., 10.)
         @test f1_mm() == (1, 10)
+        f1_mm = testmodel1(x1=1., x2=10.)
+        @test f1_mm() == (1, 10)
 
         @info "Testing the compiler's ability to catch bad models..."
 
@@ -214,7 +216,9 @@ priors = 0 # See "new grammar" test.
         end
 
         chain = sample(gauss2(x), PG(10, 10))
+        chain = sample(gauss2(x=x, TV=Vector{Float64}), PG(10, 10))
         chain = sample(gauss2(x), SMC(10))
+        chain = sample(gauss2(x=x, TV=Vector{Float64}), SMC(10))
     end
     @testset "new interface" begin
         obs = [0, 1, 0, 1, 1, 1, 1, 1, 1, 1]
@@ -314,6 +318,8 @@ priors = 0 # See "new grammar" test.
         end
 
         t_loop = @elapsed res = sample(vdemo4(), alg)
+        t_loop = @elapsed res = sample(vdemo4(Float64), alg)
+        t_loop = @elapsed res = sample(vdemo4(T=Float64), alg)
 
 
         # Test for vectorize UnivariateDistribution
@@ -330,6 +336,8 @@ priors = 0 # See "new grammar" test.
         end
   
         t_vec = @elapsed res = sample(vdemo6(), alg)
+        t_vec = @elapsed res = sample(vdemo6(Float64), alg)
+        t_vec = @elapsed res = sample(vdemo6(T=Float64), alg)
   
         @model vdemo7() = begin
           x ~ MvNormal(zeros(N), 2 * ones(N))
@@ -354,8 +362,10 @@ priors = 0 # See "new grammar" test.
             x = Vector{T}(undef, N)
             x ~ [InverseGamma(2, 3)]
         end
-  
+
         sample(vdemo8(), alg)
+        sample(vdemo8(Float64), alg)
+        sample(vdemo8(T=Float64), alg)
     end
     @testset "tilde" begin
         model_info = Dict(

--- a/test/inference/hmc.jl
+++ b/test/inference/hmc.jl
@@ -40,7 +40,7 @@ include(dir*"/test/test_utils/AllUtils.jl")
         check_numerical(chain, ["ps[1]", "ps[2]"], [5/16, 11/16], eps=0.015)
     end
     @numerical_testset "hmc reverse diff" begin
-        alg = HMC(3000, 0.15, 10)
+        alg = HMC(4000, 0.15, 10)
         res = sample(gdemo_default, alg)
         check_gdemo(res, eps=0.1)
     end
@@ -115,7 +115,7 @@ include(dir*"/test/test_utils/AllUtils.jl")
     @numerical_testset "hmcda inference" begin
         alg1 = HMCDA(3000, 1000, 0.8, 0.015)
         # alg2 = Gibbs(3000, HMCDA(1, 200, 0.8, 0.35, :m), HMC(1, 0.25, 3, :s))
-        alg3 = Gibbs(1500,
+        alg3 = Gibbs(500,
             PG(30, 10, :s),
             HMCDA(1, 500, 0.8, 0.005, :m))
         # alg3 = Gibbs(2000, HMC(1, 0.25, 3, :m), PG(30, 3, :s))
@@ -149,7 +149,7 @@ include(dir*"/test/test_utils/AllUtils.jl")
         @test isa(sampler, Sampler{<:Turing.Hamiltonian})
     end
     @numerical_testset "nuts inference" begin
-        alg = NUTS(5000, 1000, 0.8)
+        alg = NUTS(6000, 1000, 0.8)
         res = sample(gdemo_default, alg)
         check_gdemo(res)
     end

--- a/test/inference/mh.jl
+++ b/test/inference/mh.jl
@@ -33,12 +33,12 @@ include(dir*"/test/test_utils/AllUtils.jl")
         check_gdemo(chain, eps = 0.2)
 
         # MH within Gibbs
-        alg = Gibbs(1000, MH(5, :m), MH(5, :s))
+        alg = Gibbs(2000, MH(5, :m), MH(5, :s))
         chain = sample(gdemo_default, alg)
         check_gdemo(chain, eps = 0.1)
 
         # MoGtest
-        gibbs = Gibbs(1000,
+        gibbs = Gibbs(2000,
             CSMC(10, 1, :z1, :z2, :z3, :z4),
             MH(10, (:mu1,GKernel(1)), (:mu2,GKernel(1))))
         chain = sample(MoGtest_default, gibbs)

--- a/test/skipped/vec_assume_mat.jl
+++ b/test/skipped/vec_assume_mat.jl
@@ -4,8 +4,8 @@ N = 5
 setchunksize(4*N)
 alg = HMC(1000, 0.2, 4)
 
-@model vdemo() = begin
-  v = Vector{Matrix{Real}}(undef, N)
+@model vdemo(::Type{T}=Float64) where {T} = begin
+  v = Vector{Matrix{T}}(undef, N)
   v ~ [Wishart(7, [1 0.5; 0.5 1])]
 end
 

--- a/test/test_utils/ad_utils.jl
+++ b/test/test_utils/ad_utils.jl
@@ -51,7 +51,7 @@ end
 
 function test_model_ad(model, f, syms::Vector{Symbol})
     # Set up VI.
-    vi = Turing.VarInfo()
+    vi = Turing.VarInfo(model)
     model(vi, SampleFromPrior())
 
     # Collect symbols.
@@ -59,9 +59,7 @@ function test_model_ad(model, f, syms::Vector{Symbol})
     vnvals = Vector{Float64}()
     for i in 1:length(syms)
         s = syms[i]
-        vnms[i] = collect(
-            Iterators.filter(vn -> vn.sym == s, keys(vi))
-        )[1]
+        vnms[i] = getfield(vi.metadata, s).vns[1]
 
         vals = getval(vi, vnms[i])
         for i in eachindex(vals)

--- a/test/test_utils/ad_utils.jl
+++ b/test/test_utils/ad_utils.jl
@@ -52,7 +52,6 @@ end
 function test_model_ad(model, f, syms::Vector{Symbol})
     # Set up VI.
     vi = Turing.VarInfo(model)
-    model(vi, SampleFromPrior())
 
     # Collect symbols.
     vnms = Vector(undef, length(syms))


### PR DESCRIPTION
This fixes #665 by enabling the specialization of type parameters for different sampler types. The following are still pending:

- [x] Make `eltype(vi[spl])` lazy.
- [x] Verify the type stability
- [x] Make tests
- [x] Update docstrings
- [x] Fix #802
- [x] Fix #829
- [x] Make the `vals` vectors `TrackedArray`s for reversediff AD
- [x] Fix perf of `TuringMvNormal` for `ForwardDiff.Dual`

The following works as expected:
```julia
using Turing

@model demo(y, N, K, ::Type{TV1}=Vector{Float64}, ::Type{TV2}=Vector{Vector{Float64}}) where {TV1, TV2} = begin
    m = TV1(undef, K)
    T = TV2(undef, K)
    for i = 1:K
        T[i] ~ Dirichlet(ones(K)/K)
        m[i] ~ Normal(i, 0.01)
    end
    for i = 2:N
        y[i] ~ Normal(m[i], 0.1)
    end
    return m
end
N = 3; K = 3
y = rand(N)
model = demo(y, 3, 3)
alg = HMC(1000, 0.1, 5)
sample(model, alg)
alg = SMC(50)
sample(model, alg)
```