### PR TITLE
Uniform interface of Benchmark

### DIFF
--- a/benchmarks/benchmark_config.jl
+++ b/benchmarks/benchmark_config.jl
@@ -1,3 +1,8 @@
+CONFIG = Dict(
+    "target.project_dir" => (@__DIR__) |> dirname |> abspath,
+    "reporter.use_dataframe" => true,
+)
+
 ON_TRAVIS = get(ENV, "TRAVIS", "false") == "true"
 
 if ON_TRAVIS
@@ -14,11 +19,8 @@ else
     ]
 end
 
-BENCHMARK_FILES = map(BENCHMARK_FILES) do x joinpath(@__DIR__, x) end
-
-
-COMMENT_TEMPLATES = Dict{Symbol, String}()
-COMMENT_TEMPLATES[:CI_BM_COMPLETE_FOR_COMMIT] = """
+CONFIG["benchmark_files"] = map(BENCHMARK_FILES) do x joinpath(@__DIR__, x) end
+CONFIG["comment_templates.ci_bm_complete_for_commit"] = """
 
 The benchmark job for this commit has completed. 
 Here is the benchmark [report]( {{{ :report_url }}}) and commit ({{{ :report_repo }}}@{{{ :commit_id }}}). 

--- a/benchmarks/dummy.jl
+++ b/benchmarks/dummy.jl
@@ -14,12 +14,10 @@ end
 
 log_report("Dummy model constructed!")
 
-bench_res = @tbenchmark(HMC(1000, 1.5, 3), constrained_test, data)
+LOG_DATA = @tbenchmark(HMC(1000, 1.5, 3), constrained_test, data)
 
 log_report("Dummy benchmark finished!")
 
-# bench_res[4].names = ["phi[1]", "phi[2]", "phi[3]", "phi[4]"]
-LOG_DATA = build_log_data("Dummy-Benchmark", bench_res...)
 print_log(LOG_DATA)
 
-log_report("Dummy benchmark reported!")
+log_report("Dummy benchmark printed!")

--- a/benchmarks/gdemo.jl
+++ b/benchmarks/gdemo.jl
@@ -11,7 +11,6 @@ end
 data = (1.5, 2.0)
 
 # sample(gdemo(1.5, 2.0), Turing.NUTS(2000000, 0.65));
-bench_res = @tbenchmark(Turing.NUTS(2000000, 0.65), gdemo, data...)
+LOG_DATA = @tbenchmark(Turing.NUTS(2000000, 0.65), gdemo, data...)
 
-LOG_DATA = build_log_data("GDemo-Benchmark", bench_res...)
 print_log(LOG_DATA)

--- a/benchmarks/mvnormal.jl
+++ b/benchmarks/mvnormal.jl
@@ -17,10 +17,9 @@ n_samples = 100_000
 n_adapts = 2_000
 
 # Sampling
-bench_res = @tbenchmark_expr("NUTS(Leapfrog(...))",
+LOG_DATA = @tbenchmark_expr("NUTS(Leapfrog(...))",
                              sample(target(D), HMC(n_samples, 0.1, 5)));
 
-LOG_DATA = build_log_data("MvNormal-Benchmark", bench_res...)
 print_log(LOG_DATA)
 
 ##

--- a/benchmarks/runbenchmarks.jl
+++ b/benchmarks/runbenchmarks.jl
@@ -13,7 +13,7 @@ Pkg.add(PackageSpec(
 Pkg.build("ContinuousBenchmarks")
 Pkg.resolve()
 
-# prepare BenchMark information
+# prepare benchmark information
 BASE_BRANCH = "master"
 CURRENT_BRANCH = strip(read(`git rev-parse --abbrev-ref HEAD`, String))
 
@@ -40,7 +40,6 @@ end
 # run
 code_run = """using ContinuousBenchmarks
 using ContinuousBenchmarks.Runner
-ContinuousBenchmarks.set_project_path("$PROJECT_DIR")
 ContinuousBenchmarks.set_benchmark_config_file(
     joinpath("$PROJECT_DIR", "benchmarks/benchmark_config.jl"))
 Runner.run_bm_on_travis("$BM_JOB_NAME", ("$BASE_BRANCH", "$CURRENT_BRANCH"), "$COMMIT_SHA")


### PR DESCRIPTION
- set all configurations via global var `CONFIG::Dict`
- use `DataFrame` or `Dict` type result

The benchmark CI job will fail due to it is based on the master branch, and the code in that branch is not updated to the new protocol. I think this PR can be merged ignoring that failure.