### PR TITLE
Bring back the generated functions

### DIFF
--- a/src/Turing.jl
+++ b/src/Turing.jl
@@ -89,8 +89,9 @@ Robust initialization method for model parameters in Hamiltonian samplers.
 struct SampleFromUniform <: AbstractSampler end
 struct SampleFromPrior <: AbstractSampler end
 
-getspace(::SampleFromPrior) = ()
-getspace(::SampleFromUniform) = ()
+getspace(::Union{SampleFromPrior, SampleFromUniform}) = ()
+getspace(::Type{<:SampleFromPrior}) = ()
+getspace(::Type{<:SampleFromUniform}) = ()
 
 """
     Sampler{T}

--- a/src/inference/Inference.jl
+++ b/src/inference/Inference.jl
@@ -66,6 +66,8 @@ getchunksize(::Type{<:Hamiltonian{AD}}) where AD = getchunksize(AD)
 getADtype(alg::Hamiltonian) = getADtype(typeof(alg))
 getADtype(::Type{<:Hamiltonian{AD}}) where {AD} = AD
 
+getspace(alg::InferenceAlgorithm) = getspace(typeof(alg))
+
 """
     mh_accept(H::T, H_new::T, log_proposal_ratio::T) where {T<:Real}
 
@@ -86,10 +88,10 @@ include("AdvancedSMC.jl")
 include("gibbs.jl")
 
 for alg in (:SMC, :PG, :PMMH, :IPMCMC, :MH)
-    @eval getspace(::$alg{space}) where {space} = space
+    @eval getspace(::Type{<:$alg{space}}) where {space} = space
 end
 for alg in (:HMC, :HMCDA, :NUTS, :SGLD, :SGHMC)
-    @eval getspace(::$alg{<:Any, space}) where {space} = space
+    @eval getspace(::Type{<:$alg{<:Any, space}}) where {space} = space
 end
 
 @inline floatof(::Type{T}) where {T <: Real} = typeof(one(T)/one(T))
@@ -254,6 +256,7 @@ function Sample(vi::AbstractVarInfo, spl::Sampler)
     return s
 end
 
-getspace(spl::Sampler) = getspace(spl.alg)
+getspace(spl::Sampler) = getspace(typeof(spl))
+getspace(::Type{<:Sampler{Talg}}) where {Talg} = getspace(Talg)
 
 end # module

--- a/src/inference/Inference.jl
+++ b/src/inference/Inference.jl
@@ -66,8 +66,6 @@ getchunksize(::Type{<:Hamiltonian{AD}}) where AD = getchunksize(AD)
 getADtype(alg::Hamiltonian) = getADtype(typeof(alg))
 getADtype(::Type{<:Hamiltonian{AD}}) where {AD} = AD
 
-getspace(alg::InferenceAlgorithm) = getspace(typeof(alg))
-
 """
     mh_accept(H::T, H_new::T, log_proposal_ratio::T) where {T<:Real}
 
@@ -88,9 +86,11 @@ include("AdvancedSMC.jl")
 include("gibbs.jl")
 
 for alg in (:SMC, :PG, :PMMH, :IPMCMC, :MH)
+    @eval getspace(::$alg{space}) where {space} = space
     @eval getspace(::Type{<:$alg{space}}) where {space} = space
 end
 for alg in (:HMC, :HMCDA, :NUTS, :SGLD, :SGHMC)
+    @eval getspace(::$alg{<:Any, space}) where {space} = space
     @eval getspace(::Type{<:$alg{<:Any, space}}) where {space} = space
 end
 

--- a/src/inference/dynamichmc.jl
+++ b/src/inference/dynamichmc.jl
@@ -19,8 +19,8 @@ function DynamicNUTS{AD}(n_iters::Integer, space::Symbol...) where AD
     DynamicNUTS{AD}(n_iters, space)
 end
 
-getspace(alg::DynamicNUTS) = getspace(typeof(alg))
 getspace(::Type{<:DynamicNUTS{<:Any, space}}) where {space} = space
+getspace(alg::DynamicNUTS{<:Any, space}) where {space} = space
 
 function Sampler(alg::DynamicNUTS{T}, s::Selector=Selector()) where T <: Hamiltonian
   return Sampler(alg, Dict{Symbol,Any}(), s)

--- a/src/inference/dynamichmc.jl
+++ b/src/inference/dynamichmc.jl
@@ -19,7 +19,8 @@ function DynamicNUTS{AD}(n_iters::Integer, space::Symbol...) where AD
     DynamicNUTS{AD}(n_iters, space)
 end
 
-getspace(::DynamicNUTS{<:Any, space}) where {space} = space
+getspace(alg::DynamicNUTS) = getspace(typeof(alg))
+getspace(::Type{<:DynamicNUTS{<:Any, space}}) where {space} = space
 
 function Sampler(alg::DynamicNUTS{T}, s::Selector=Selector()) where T <: Hamiltonian
   return Sampler(alg, Dict{Symbol,Any}(), s)


### PR DESCRIPTION
This PR solves some overlooked type instability in certain internal functions. Relying on recursion, inlining and constant propagation is apparently too much magic to work reliably. The compiler inferred the types properly in some simple functions but in more complicated cases, it failed. The generated function is a sure-fire approach so here it is.

More interestingly though, here is some speedup as a result!
```julia
using Turing

@model gdemo(x) = begin
    s ~ InverseGamma(2,3)
    m ~ Normal(0, sqrt(s))
    for i in eachindex(x)
        x[i] ~ Normal(m, sqrt(s))
    end
end
sample(gdemo(rand(100)), NUTS(10000, 0.65))
# master - 2.06 s
# This PR - 1.43 s
```