### PR TITLE
Increment version number to 0.6.19

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Turing"
 uuid = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-version = "0.6.18"
+version = "0.6.19"
 
 [deps]
 AdvancedHMC = "0bf59076-c3b1-5ca4-86bd-e02cd72cde3d"


### PR DESCRIPTION
I'd like to update Turing to 0.6.19 ahead of JuliaCon.