### PR TITLE
dispatch-based AD, updated manifest

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -8,9 +8,9 @@ version = "1.0.0"
 
 [[AdvancedHMC]]
 deps = ["ArgCheck", "InplaceOps", "LazyArrays", "LinearAlgebra", "Parameters", "ProgressMeter", "Random", "Statistics", "StatsBase"]
-git-tree-sha1 = "66547521b1d25c2fc5af8076b5e55aa148eba033"
+git-tree-sha1 = "c8fa90ee42ccab3c998e086c4ee82e229eb2f948"
 uuid = "0bf59076-c3b1-5ca4-86bd-e02cd72cde3d"
-version = "0.2.0"
+version = "0.2.1"
 
 [[ArgCheck]]
 deps = ["Random"]

--- a/src/core/ad.jl
+++ b/src/core/ad.jl
@@ -37,13 +37,9 @@ struct TrackerAD <: ADBackend end
 
 ADBackend() = ADBackend(ADBACKEND[])
 ADBackend(T::Symbol) = ADBackend(Val(T))
-function ADBackend(::Val{T}) where {T}
-    if T === :forward_diff
-        return ForwardDiffAD{CHUNKSIZE[]}
-    else
-        return TrackerAD
-    end
-end
+
+ADBackend(::Val{:forward_diff}) where {T} = ForwardDiffAD{CHUNKSIZE[]}
+ADBackend(::Val{T}) where {T} = TrackerAD
 
 """
 getADtype(alg)


### PR DESCRIPTION
Very minor improvement replacing branching with dispatch for `Val{S}`