### PR TITLE
Tracker ambiguity patch

### DIFF
--- a/src/core/ad.jl
+++ b/src/core/ad.jl
@@ -344,6 +344,13 @@ getchol(m::PDMats.PDiagMat) = cholesky(Diagonal(m.diag))
 getchol(m::PDMats.ScalMat) = cholesky(Diagonal(fill(m.value, m.dim)))
 
 # Deal with ambiguities.
+import Base: *
+function Base.:*(
+    A::Transpose{T, <:AbstractMatrix{T}}, 
+    B::Tracker.TrackedVector
+) where {T}
+    return Tracker.track(*, A, B)
+end
 function Base.:*(
     A::Tracker.TrackedMatrix,
     B::Adjoint{T, V} where V<:LinearAlgebra.AbstractTriangular{T} where {T},


### PR DESCRIPTION
This fixes an issue that was raised in Slack.

```julia
using Turing
Turing.setadbackend(:reverse_diff)

@model m(X, y) = begin
   D = size(X, 2)
   sigma ~ TruncatedNormal(0, 1, 0, Inf) 
   alpha ~ Normal(0, 5)
   beta ~ MvNormal(zeros(D), ones(D))
   lp = alpha .+ X * beta
   y ~ MvNormal(lp, sigma)
end

samples = 5000
X = rand(10, 52)
y = rand(10)
model = m(X, y)
alg = HMC(samples, 0.65, 5);
chain = sample(model, alg);
```
CC: @elizavetasemenova 