### PR TITLE
Fix Base.rand Signature

### DIFF
--- a/docs/_docs/using-turing/advanced.md
+++ b/docs/_docs/using-turing/advanced.md
@@ -29,12 +29,12 @@ end
 ### 2. Implement Sampling and Evaluation of the log-pdf
 
 
-Second, define `rand()` and `logpdf()`, which will be used to run the model.
+Second, define `rand` and `logpdf`, which will be used to run the model.
 
 
 ```julia
-Distributions.rand(d::Flat) = rand()
-Distributions.logpdf{T<:Real}(d::Flat, x::T) = zero(x)
+Distributions.rand(rng::AbstractRNG, d::Flat) = rand(rng)
+Distributions.logpdf(d::Flat, x::Real) = zero(x)
 ```
 
 
@@ -47,7 +47,7 @@ In most cases, it may be required to define helper functions, such as the `minim
 #### 3.1 Domain Transformation
 
 
-Some helper functions are necessary for domain transformation. For univariate distributions, the necessary ones to implement are `minimum()` and `maximum()`.
+Some helper functions are necessary for domain transformation. For univariate distributions, the necessary ones to implement are `minimum` and `maximum`.
 
 
 ```julia
@@ -62,12 +62,11 @@ Functions for domain transformation which may be required by multivariate or mat
 #### 3.2 Vectorization Support
 
 
-The vectorization syntax follows `rv ~ [distribution]`, which requires `rand()` and `logpdf()` to be called on multiple data points at once. An appropriate implementation for `Flat` are shown below.
+The vectorization syntax follows `rv ~ [distribution]`, which requires `rand()` and `logpdf()` to be called on multiple data points at once. An appropriate implementation for `Flat` is shown below.
 
 
 ```julia
-Distributions.rand(d::Flat, n::Int) = Vector([rand() for _ = 1:n])
-Distributions.logpdf{T<:Real}(d::Flat, x::Vector{T}) = zero(x)
+Distributions.logpdf(d::Flat, x::AbstractVector{<:Real}) = zero(x)
 ```
 
 
@@ -247,4 +246,3 @@ model = gdemo([1.2, 3.5]
 # Run all samples.
 chns = reduce(chainscat, pmap(x->sample(model,sampler),1:num_chains))
 ```
-

--- a/docs/_docs/using-turing/advanced.md
+++ b/docs/_docs/using-turing/advanced.md
@@ -56,13 +56,13 @@ Distributions.maximum(d::Flat) = +Inf
 ```
 
 
-Functions for domain transformation which may be required by multivariate or matrix-variate distributions are `size(d)`, `link(d, x)` and `invlink(d, x)`. Please see Turing's [`transform.jl`](https://github.com/TuringLang/Turing.jl/blob/master/src/utilities/transform.jl) for examples.
+Functions for domain transformation which may be required by multivariate or matrix-variate distributions are `size`, `link` and `invlink`. Please see Turing's [`transform.jl`](https://github.com/TuringLang/Turing.jl/blob/master/src/utilities/transform.jl) for examples.
 
 
 #### 3.2 Vectorization Support
 
 
-The vectorization syntax follows `rv ~ [distribution]`, which requires `rand()` and `logpdf()` to be called on multiple data points at once. An appropriate implementation for `Flat` is shown below.
+The vectorization syntax follows `rv ~ [distribution]`, which requires `rand` and `logpdf` to be called on multiple data points at once. An appropriate implementation for `Flat` is shown below.
 
 
 ```julia

--- a/src/stdlib/distributions.jl
+++ b/src/stdlib/distributions.jl
@@ -9,7 +9,6 @@ Distributions.minimum(d::Flat) = -Inf
 Distributions.maximum(d::Flat) = +Inf
 
 # For vec support
-# Distributions.rand(rng::AbstractRNG, d::Flat, n::Int) = Vector([rand(rng) for _ = 1:n])
 Distributions.logpdf(d::Flat, x::AbstractVector{<:Real}) = zero(x)
 
 # Pos

--- a/src/stdlib/distributions.jl
+++ b/src/stdlib/distributions.jl
@@ -1,13 +1,15 @@
+import Random: AbstractRNG
+
 # No info
 struct Flat <: ContinuousUnivariateDistribution end
 
-Distributions.rand(d::Flat) = rand()
-Distributions.logpdf(d::Flat, x::T) where T<:Real= zero(x)
+Distributions.rand(rng::AbstractRNG, d::Flat) = rand(rng)
+Distributions.logpdf(d::Flat, x::Real) = zero(x)
 Distributions.minimum(d::Flat) = -Inf
 Distributions.maximum(d::Flat) = +Inf
 
 # For vec support
-Distributions.rand(d::Flat, n::Int) = Vector([rand() for _ = 1:n])
+# Distributions.rand(rng::AbstractRNG, d::Flat, n::Int) = Vector([rand(rng) for _ = 1:n])
 Distributions.logpdf(d::Flat, x::AbstractVector{<:Real}) = zero(x)
 
 # Pos
@@ -15,13 +17,12 @@ struct FlatPos{T<:Real} <: ContinuousUnivariateDistribution
     l::T
 end
 
-Distributions.rand(d::FlatPos) = rand() + d.l
+Distributions.rand(rng::AbstractRNG, d::FlatPos) = rand(rng) + d.l
 Distributions.logpdf(d::FlatPos, x::Real) = x <= d.l ? -Inf : zero(x)
 Distributions.minimum(d::FlatPos) = d.l
 Distributions.maximum(d::FlatPos) = Inf
 
 # For vec support
-Distributions.rand(d::FlatPos, n::Int) = Vector([rand() for _ = 1:n] .+ d.l)
 function Distributions.logpdf(d::FlatPos, x::AbstractVector{<:Real})
     return any(x .<= d.l) ? -Inf : zero(x)
 end


### PR DESCRIPTION
The default `Base.rand` is `rand(rng::AbstractRNG, ...)` and the custom Turing distributions were not using this. Since all of the custom distributions are `Sampleable`, the Distributions.jl package already provides the necessary defaults for `rand(...)` without the `AbstractRNG` argument. This also covers the vectorized case since `rand(s::Sampleable, n::Integer)` is defined by Distributions.jl.