### PR TITLE
Removed include io.jl since io.jl is gone

### DIFF
--- a/src/interface/Interface.jl
+++ b/src/interface/Interface.jl
@@ -215,7 +215,7 @@ end
     )
 
 Performs whatever initial setup is required for your sampler. This function is not intended
-to return any value -- any set up should utate the sampler or the model type in-place.
+to return any value -- any set up should mutate the sampler or the model type in-place.
 
 A common use for `sample_init!` might be to instantiate a particle field for later use,
 or find an initial step size for a Hamiltonian sampler.
@@ -244,7 +244,7 @@ end
     )
 
 Performs whatever finalizing the sampler requires. This function is not intended
-to return any value -- any set up should utate the sampler or the model type in-place.
+to return any value -- any set up should mutate the sampler or the model type in-place.
 
 `sample_end!` is useful in cases where you might like to perform some transformation 
 on your vector of `AbstractTransitions`, save your sampler struct to disk, or otherwise

--- a/src/utilities/Utilities.jl
+++ b/src/utilities/Utilities.jl
@@ -17,6 +17,5 @@ export  vectorize,
 
 include("helper.jl")
 include("robustinit.jl")
-include("io.jl")           # I/O
 
 end # module


### PR DESCRIPTION
Master is currently broken due to `io.jl` being included when it does not exist anymore.