### PR TITLE
Early API functions and the interface guide.

### DIFF
--- a/docs/_data/toc.yml
+++ b/docs/_data/toc.yml
@@ -20,7 +20,10 @@
     url: "docs/using-turing/dynamichmc"
 
   - title: "Sampler Visualization"
-    url: "docs/using-turing/sampler-viz"
+    url: "docs/using-turing/sampler-viz" 
+
+  - title: "Interface Developer Guide"
+    url: "docs/using-turing/interface"
 
 - title: "TUTORIALS"
   url: "tutorials"
@@ -55,7 +58,7 @@
 - title: "LIBRARY"
   url: "docs/library"
   children:
-    - title: "Public"
+    - title: "API"
       url: "docs/library"
 
 - title: "CONTRIBUTING"

--- a/docs/src/interface-manual.md
+++ b/docs/src/interface-manual.md
@@ -26,6 +26,8 @@ The interface methods with exclamation points are those that are intended to all
 
 [Metropolis-Hastings](https://en.wikipedia.org/wiki/Markov_chain_Monte_Carlo) is often the first sampling method that people are exposed to. It is a very straightforward algorithm and is accordingly the easiest to implement, so it makes for a good example. In this section, you will learn how to use the types and functions listed above to implement the Metropolis-Hastings sampler using the MCMC interface.
 
+### Imports
+
 Let's begin by importing the relevant libraries. We'll import `Turing.Interface`, which contains the interface framework we'll fill out. We also need `Distributions` and `Random`.
 
 ```julia
@@ -57,6 +59,8 @@ import MCMCChains: Chains
 import Turing.Interface: step!, AbstractSampler, AbstractTransition, transition_type
 ```
 
+### Sampler
+
 Let's begin our sampler definition by defining a sampler called `MetropolisHastings` which is a subtype of `AbstractSampler`. Correct typing is very important for proper interface implementation -- if you are missing a subtype, your inference method will likely not work when you call `sample`.
 
 ```julia
@@ -69,6 +73,8 @@ end
 Above, we have defined a sampler that only stores the initial parameterization of the prior. You can have a struct that has no fields, and simply use it for dispatching onto the relevant functions, or you can store a large amount of state information in your sampler. This implementation of Metropolis-Hastings is a pure immutable one, and no state information need be saved. 
 
 The general intuition for what to store in your sampler struct is that anything you may need to perform inference between samples but you don't want to store in an `AbstractTransition` should go into the sampler struct. It's the only way you can carry non-sample related state information between `step!` calls. 
+
+### Model
 
 Next, we need to have a model of some kind. A model is a struct that's a subtype of `Sampleable{VariateForm, ValueSupport}` that contains whatever information is necessary to perform inference on your problem. In our case we want to know the mean and variance parameters for a standard Normal distribution, so we can keep our model to the log density of a Normal. 
 
@@ -93,13 +99,230 @@ The `DensityModel` struct has two fields:
 
 You could combine these two by making data be part of the `π` function, but for now we're mostly concerned with getting something that works well.
 
-The next step is to define some subtype of `AbstractTransition` which we will return from each `step!` call. We'll keep it simple by just defining a wrapper struct that holds only the parameter draws:
+We may also want a helper function that calculates the log probability of a model and a set of parameters. The two functions below provide the functionality we need. The first signature accepts any `θ`, whether it's a vector or a single value, and the the second signature unpacks a `Transition` type to give us a little bit of syntactic sugar. We'll explain what the `Transition` looks like in the following section.
 
 ```julia
-# Create a very basic Transition type, only stores the parameter draws.
+# Calculate the density of the model given some parameterization.
+ℓπ(model::DensityModel, θ::T) where T = model.π(model.data, θ)
+ℓπ(model::DensityModel, t::Transition) = t.lp
+```
+
+### Transition
+
+The next step is to define some subtype of `AbstractTransition` which we will return from each `step!` call. We'll keep it simple by just defining a wrapper struct that contains the parameter draws and the log density of that draw:
+
+```julia
+# Create a very basic Transition type, only stores the 
+# parameter draws and the log probability of the draw.
 struct Transition{T} <: AbstractTransition
     θ :: T
+    lp :: Float64
+end
+
+# A helpful constructor to store the new draw and its log density.
+Transition(model::DensityModel, θ::T) where T = Transition(θ, ℓπ(model, θ))
+```
+
+`Transition` can now store any type of parameter, whether it's a vector of draws from multiple parameters or a single univariate draw. We should also tell the interface what specific subtype of `AbstractTransition` we're going to use, so we can just define a new method on `transition_type`:
+
+```julia
+# Tell the interface what transition type we would like to use.
+transition_type(spl::MetropolisHastings) = Transition
+```
+
+This method only returns the abstract type, `Transition`, which can cause type instability. We can actually be a little more precise here than returning the abstract type. We can concretely type all the `Transition`s we expect to return, because the sampler object contains the initial parameterization:
+
+```julia
+# Tell the interface exactly what our type is,
+# by constructing a new interface and retrieving
+# it's full parameterization.
+transition_type(model::DensityModel, spl::MetropolisHastings) = typeof(Transition(spl.init_θ, ℓπ(model, spl.init_θ)))
+```
+
+### Metropolis-Hastings
+
+Now it's time to get into the actual inference method. We've defined all of the core pieces we need, but we need to implement the `step!` functions which actually perform our inference.
+
+As a refresher, Metropolis-Hastings implements a very basic algorithm:
+
+1. Pick some initial state, $\theta_0$.
+2. For $t$ in $[1,N]$, do
+    
+    a. Generate a proposal parameterization $θ'_t \sim q(\theta'_t \mid \theta_{t-1})$. 
+
+    b. Calculate the acceptance probability, $\alpha = \text{min}\Big[1,\frac{\pi(θ'_t)}{\pi(\theta_{t-1})} \frac{q(θ_{t-1} \mid θ'_t)}{q(θ'_t \mid θ_{t-1})}) \Big]$.
+
+    c. If $U \le α$ where $U \sim [0,1]$, then $\theta_t = \theta'_t$. Otherwise, $\theta_t = \theta_{t-1}$.
+
+Of course, it's much easier to do this in the log space, so the acceptance probability is more commonly written as 
+
+$$
+\alpha = \min\Big[\log \pi(θ'_t) - \log \pi(θ_{t-1}) + \log q(θ_{t-1} \mid θ'_t) - \log q(θ'_t \mid θ_{t-1}), 0\Big]
+$$
+
+In interface terms, we should do the following:
+
+1. Make a new transition containing a proposed sample.
+2. Calculate the acceptance probability.
+3. If we accept, return the new transition, otherwise, return the old one.
+
+### Steps
+
+The `step!` function is the function that performs the bulk of your inference. In our case, we will implement two `step!` functions -- one for the very first iteration, and one for every subsequent iteration.
+
+```julia
+# Define the first step! function, which is called at the 
+# beginning of sampling. Return the initial parameter used
+# to define the sampler.
+function step!(
+    rng::AbstractRNG,
+    model::M,
+    spl::S,
+    N::Integer;
+    kwargs...
+) where {
+    M <: DensityModel,
+    S <: MetropolisHastings
+}
+    return Transition(model, spl.init_θ)
 end
 ```
 
-`Transition` can now store any type, whether it's a vector of draws or a single univariate draw. Again, this could be improved by adding type constraints to `T`, but for this simple sampler we are largely unconcerned with 
+The first `step!` function just packages up the initial parameterization inside the sampler, and returns it. We implicity accept the very first parameterization.
+
+The other `step!` function performs the usual steps from Metropolis-Hastings. Included are several helper functions, `proposal` and `q`, which are designed to replicate the functions in the pseudocode above.
+
+- `proposal` generates a new proposal in the form of a `Transition`, which can be univariate if the value passed in is univariate, or it can be multivariate if the `Transition` given is multivariate. Proposals use a basic `Normal` or `MvNormal` proposal distribution.
+- `q` returns the log density of one parameterization conditional on another, according to the proposal distribution.
+- `step!` generates a new proposal, checks the acceptance probability, and then returns either the previous transition or the proposed transition.
+
+```julia
+# Define a function that makes a basic proposal depending on a univariate
+# parameterization or a multivariate parameterization.
+proposal(spl::MetropolisHastings, model::DensityModel, θ::Real) = Transition(model, rand(Normal(θ, 1)))
+proposal(spl::MetropolisHastings, model::DensityModel, θ::Vector{<:Real}) = Transition(model, rand(MvNormal(θ, 1)))
+proposal(spl::MetropolisHastings, model::DensityModel, t::Transition) = proposal(spl, model, t.θ)
+
+# Calculate the logpdf of one proposal given another proposal.
+q(spl::MetropolisHastings, θ1::Real, θ2::Real) = logpdf(Normal(θ2, 1.0), θ2)
+q(spl::MetropolisHastings, θ1::Vector{<:Real}, θ2::Vector{<:Real}) = logpdf(MvNormal(θ2, 1.0), θ2)
+q(spl::MetropolisHastings, t1::Transition, t2::Transition) = q(spl, t1.θ, t2.θ)
+
+# Define the other step function. Returns a Transition containing
+# either a new proposal (if accepted) or the previous proposal 
+# (if not accepted).
+function step!(
+    rng::AbstractRNG,
+    model::M,
+    spl::S,
+    ::Integer,
+    θ_prev::T;
+    kwargs...
+) where {
+    M <: DensityModel,
+    S <: MetropolisHastings,
+    T <: Transition
+}
+    # Generate a new proposal.
+    θ = proposal(spl, model, θ_prev)
+    
+    # Calculate the log acceptance probability.
+    α = ℓπ(model, θ) - ℓπ(model, θ_prev) + q(spl, θ_prev, θ) - q(spl, θ, θ_prev)
+
+    # Decide whether to return the previous θ or the new one.
+    if log(rand()) < min(α, 0.0)
+        return θ
+    else
+        return θ_prev
+    end
+end
+```
+
+### Chains
+
+The last piece in our puzzle is a `Chains` function, which accepts a `Vector{T<:Transition}` and returns an `MCMCChains.Chains` struct. Fortunately, our `Transition` is incredibly simple, and we only need to build a little bit of functionality to accept custom parameter names passed in by the user.
+
+```julia
+# A basic chains constructor that works with the Transition struct we defined.
+function Chains(
+    rng::AbstractRNG, 
+    ℓ::DensityModel, 
+    s::MetropolisHastings, 
+    N::Integer, 
+    ts::Vector{T}; 
+    param_names=missing,
+    kwargs...
+) where {T <: Transition}
+    # Turn all the transitions into a vector-of-vectors.
+    vals = [vcat(t.θ, t.lp) for t in ts]
+
+    # Check if we received any parameter names.
+    if ismissing(param_names)
+        param_names = ["Parameter $i" for i in 1:(length(first(vals))-1)]
+    end
+
+    # Add the log density field to the parameter names.
+    push!(param_names, "lp")
+
+    # Bundle everything up and return a Chains struct.
+    return Chains(vals, param_names, (internals=["lp"],))
+end
+```
+
+That was the final piece!
+
+### Testing the implementation
+
+Now that we have all the pieces, we should test the implementation by defining a model to calculate the mean and variance parameters of a Normal distribution. We can do this by constructing a target density function, providing a sample of data, and then running the sampler with `sample`.
+
+```julia
+# Define the components of a basic model.
+insupport(θ) = θ[2] >= 0
+dist(θ) = Normal(θ[1], θ[2])
+density(data, θ) = insupport(θ) ? sum(logpdf.(dist(θ), data)) : -Inf
+
+# Generate a set of data from the posterior we want to estimate.
+data = rand(Normal(5,3), 10)
+
+# Construct a DensityModel.
+model = DensityModel(density, data)
+
+# Set up our sampler.
+spl = MetropolisHastings([0.0, 0.0])
+
+# Sample from the posterior.
+chain = sample(model, spl, 10000; param_names=["μ", "σ"])
+```
+
+If all the interface functions have been extended properly, you should get an output from `display(chain)` that looks something like this:
+
+```
+Object of type Chains, with data of type 10000×3×1 Array{Float64,3}
+
+Iterations        = 1:10000
+Thinning interval = 1
+Chains            = 1
+Samples per chain = 10000
+internals         = lp
+parameters        = μ, σ
+
+2-element Array{MCMCChains.ChainDataFrame,1}
+
+Summary Statistics
+. Omitted printing of 1 columns
+│ Row │ parameters │ mean    │ std      │ naive_se   │ mcse      │ ess     │
+│     │ Symbol     │ Float64 │ Float64  │ Float64    │ Float64   │ Any     │
+├─────┼────────────┼─────────┼──────────┼────────────┼───────────┼─────────┤
+│ 1   │ μ          │ 5.21391 │ 1.09406  │ 0.0109406  │ 0.0342099 │ 900.188 │
+│ 2   │ σ          │ 3.47312 │ 0.934172 │ 0.00934172 │ 0.0307114 │ 905.218 │
+
+Quantiles
+
+│ Row │ parameters │ 2.5%    │ 25.0%   │ 50.0%   │ 75.0%   │ 97.5%   │
+│     │ Symbol     │ Float64 │ Float64 │ Float64 │ Float64 │ Float64 │
+├─────┼────────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
+│ 1   │ μ          │ 2.98559 │ 4.53086 │ 5.21764 │ 5.93417 │ 7.33767 │
+│ 2   │ σ          │ 2.14871 │ 2.8051  │ 3.29586 │ 3.96179 │ 5.75031 │
+```
+
+It looks like we're extremely close to our true parameters of `Normal(5,3)`, though with a fairly high variance due to the low sample size.

--- a/docs/src/interface-manual.md
+++ b/docs/src/interface-manual.md
@@ -204,8 +204,8 @@ proposal(spl::MetropolisHastings, model::DensityModel, θ::Vector{<:Real}) = Tra
 proposal(spl::MetropolisHastings, model::DensityModel, t::Transition) = proposal(spl, model, t.θ)
 
 # Calculate the logpdf of one proposal given another proposal.
-q(spl::MetropolisHastings, θ1::Real, θ2::Real) = logpdf(Normal(θ2, 1.0), θ2)
-q(spl::MetropolisHastings, θ1::Vector{<:Real}, θ2::Vector{<:Real}) = logpdf(MvNormal(θ2, 1.0), θ2)
+q(spl::MetropolisHastings, θ1::Real, θ2::Real) = logpdf(Normal(θ1, 1.0), θ2)
+q(spl::MetropolisHastings, θ1::Vector{<:Real}, θ2::Vector{<:Real}) = logpdf(MvNormal(θ1, 1.0), θ2)
 q(spl::MetropolisHastings, t1::Transition, t2::Transition) = q(spl, t1.θ, t2.θ)
 
 # Define the other step function. Returns a Transition containing
@@ -326,3 +326,4 @@ Quantiles
 ```
 
 It looks like we're extremely close to our true parameters of `Normal(5,3)`, though with a fairly high variance due to the low sample size.
+

--- a/docs/src/interface-manual.md
+++ b/docs/src/interface-manual.md
@@ -1,8 +1,14 @@
 # The Sampling Interface
 
-Turing's sampling interface presents several structures and functions that one needs to overload in order to implement an interface-compatible sampler.
+Turing implements a sampling interface that is intended to provide a common framework for Markov Chain Monte Carlo samplers. The interface presents several structures and functions that one needs to overload in order to implement an interface-compatible sampler. 
 
-1. A subtype of `AbstractSampler`, defined as a mutable struct containing state information.
+This guide will demonstrate how to implement the interface without Turing, and then demonstrate how to implement the same model with Turing.
+
+## Interface Overview
+
+Any implementation of an inference method that uses Turing's MCMC interface should implement some combination of the following types and functions:
+
+1. A subtype of `AbstractSampler`, defined as a mutable struct containing state information or sampler parameters.
 2. A subtype of `AbstractTransition`, which represents a single draw from the sampler.
 3. A function `transition_type` which returns the `AbstractTransition` type used by an implementation of an `AbstractSampler`, or a function `transition_init` with returns a `Vector{AbstractTransition}` of length `N`.
 4. A function `sample_init!` which performs any necessary set up. 
@@ -10,8 +16,90 @@ Turing's sampling interface presents several structures and functions that one n
 6. A function `sample_end!` which handles any sampler wrap-up.
 7. A function `MCMCChains.Chains` which accepts an `Vector{<:AbstractTransition}` and returns an `MCMCChains` object.
 
-The interface methods with exclamation points are those that are intended to allow for some state mutation. Any mutating function is meant to allow mutation where needed -- you might use 
+The interface methods with exclamation points are those that are intended to allow for some state mutation. Any mutating function is meant to allow mutation where needed -- you might use:
 
 - `sample_init!` to run some kind of sampler preparation, before sampling begins. This could mutate a sampler's state.
 - `step!` might mutate a sampler flag after each sample. MH does this for example by using a `violating_support` flag.
 - `sample_end!` contains any wrap-up you might need to do. If you were sampling in a transformed space, this might be where you convert everything back to a constrained space.
+
+## Implementing Metropolis-Hastings without Turing
+
+[Metropolis-Hastings](https://en.wikipedia.org/wiki/Markov_chain_Monte_Carlo) is often the first sampling method that people are exposed to. It is a very straightforward algorithm and is accordingly the easiest to implement, so it makes for a good example. In this section, you will learn how to use the types and functions listed above to implement the Metropolis-Hastings sampler using the MCMC interface.
+
+Let's begin by importing the relevant libraries. We'll import `Turing.Interface`, which contains the interface framework we'll fill out. We also need `Distributions` and `Random`.
+
+```julia
+# Import the relevant libraries.
+using Turing.Interface
+using Distributions
+using Random
+```
+
+An interface extension (like the one we're writing right now) typically requires that you overload or implement several functions. Specifically, you should `import` the functions you intend to overload. This next code block accomplishes that. 
+
+From `Distributions`, we need `Sampleable`, `VariateForm`, and `ValueSupport`, three abstract types that define a distribution. Models in the interface are assumed to be subtypes of `Sampleable{VariateForm, ValueSupport}`. In this section our model is going be be extremely simple, so we will not end up using these except to make sure that the inference functions are dispatching correctly.
+
+We need the `MCMCChains.Chains` function, because at the end of sampling we need to be able to convert a vector of `<:AbstractTransitions` to an `MCMCChains` object. Currently, the plan is to eventually move all the interface methods from `Turing.Interface` to `MCMCChains.Interface`, which is why this step needs to be done for the moment.
+
+Lastly, we import the specific functions from the `Interface` that we need to overload. Because Metropolis-Hastings is so simple we only need a few functions/types:
+
+- `step!`
+- `AbstractSampler`
+- `AbstractTransition`
+- `transition_type`
+
+More complex inference methods may need to import additional functions. For now, let's focus on the code:
+
+```julia
+# Import specific functions and types to use or overload.
+import Distributions: VariateForm, ValueSupport, variate_form, value_support, Sampleable
+import MCMCChains: Chains
+import Turing.Interface: step!, AbstractSampler, AbstractTransition, transition_type
+```
+
+Let's begin our sampler definition by defining a sampler called `MetropolisHastings` which is a subtype of `AbstractSampler`. Correct typing is very important for proper interface implementation -- if you are missing a subtype, your inference method will likely not work when you call `sample`.
+
+```julia
+# Define a sampler type.
+struct MetropolisHastings{T} <: AbstractSampler 
+    init_θ :: T
+end
+```
+
+Above, we have defined a sampler that only stores the initial parameterization of the prior. You can have a struct that has no fields, and simply use it for dispatching onto the relevant functions, or you can store a large amount of state information in your sampler. This implementation of Metropolis-Hastings is a pure immutable one, and no state information need be saved. 
+
+The general intuition for what to store in your sampler struct is that anything you may need to perform inference between samples but you don't want to store in an `AbstractTransition` should go into the sampler struct. It's the only way you can carry non-sample related state information between `step!` calls. 
+
+Next, we need to have a model of some kind. A model is a struct that's a subtype of `Sampleable{VariateForm, ValueSupport}` that contains whatever information is necessary to perform inference on your problem. In our case we want to know the mean and variance parameters for a standard Normal distribution, so we can keep our model to the log density of a Normal. 
+
+Note that we only have to do this because we are not yet integrating the sampler with Turing -- Turing has a very sophisticated modelling engine that removes the need to define custom model structs. 
+
+```julia
+# Define a model type. Stores the log density function and the data to 
+# evaluate the log density on.
+struct DensityModel{V<:VariateForm, S<:ValueSupport, T} <: Sampleable{V, S}
+    π :: Function
+    data :: T
+end
+
+# Default density constructor.
+DensityModel(π::Function, data::T) where T = DensityModel{VariateForm, ValueSupport, T}(π, data)
+```
+
+The `DensityModel` struct has two fields:
+
+1. `π`, which stores some log-density function. 
+2. `data`, which stores the data to evaluate the model on.
+
+You could combine these two by making data be part of the `π` function, but for now we're mostly concerned with getting something that works well.
+
+The next step is to define some subtype of `AbstractTransition` which we will return from each `step!` call. We'll keep it simple by just defining a wrapper struct that holds only the parameter draws:
+
+```julia
+# Create a very basic Transition type, only stores the parameter draws.
+struct Transition{T} <: AbstractTransition
+    θ :: T
+end
+```
+
+`Transition` can now store any type, whether it's a vector of draws or a single univariate draw. Again, this could be improved by adding type constraints to `T`, but for this simple sampler we are largely unconcerned with 

--- a/docs/src/using-turing/interface.md
+++ b/docs/src/using-turing/interface.md
@@ -35,6 +35,8 @@ The motivation for the interface is to allow Julia's fantastic probabilistic pro
 
 [Metropolis-Hastings](https://en.wikipedia.org/wiki/Markov_chain_Monte_Carlo) is often the first sampling method that people are exposed to. It is a very straightforward algorithm and is accordingly the easiest to implement, so it makes for a good example. In this section, you will learn how to use the types and functions listed above to implement the Metropolis-Hastings sampler using the MCMC interface.
 
+The full code for this implementation can be found [here](https://github.com/cpfiffer/MetropolisHastings/blob/master/mh-implementation.jl).
+
 ### Imports
 
 Let's begin by importing the relevant libraries. We'll import `Turing.Interface`, which contains the interface framework we'll fill out. We also need `Distributions` and `Random`.
@@ -349,6 +351,8 @@ Third, you no longer explicitly construct an `AbstractSampler` -- Turing has a d
 Fourth, instead of manually generating a proposal the way before, we will be using the `assume` interface. Turing uses an `observe`/`assume` style, where provided data is `observe`d and parameters are `assume`d. When you declare a model with `@model`, every line with a `~` is replaced with `observe` or `assume`. We'll get into that a little more in the following sections.
 
 Fifth, you don't have to have a `Chains` function anymore. Turing has a good default one.
+
+The full code for this implementation can be found [here](https://github.com/cpfiffer/MetropolisHastings/blob/master/mh-implementation-turing.jl).
 
 ### Imports
 

--- a/src/Turing.jl
+++ b/src/Turing.jl
@@ -110,6 +110,9 @@ Turing translates models to chunks that call the modelling functions at specifie
 The dispatch is based on the value of a `sampler` variable.
 To include a new inference algorithm implements the requirements mentioned above in a separate file,
 then include that file at the end of this one.
+
+If no overload of `Sampler(alg, model, s)` is provided, the `Sampler.state` field
+defaults to containing a `SamplerState(model)` struct, which only contains a `VarInfo`.
 """
 mutable struct Sampler{T, S<:AbstractSamplerState} <: AbstractSampler
     alg      ::  T
@@ -119,7 +122,7 @@ mutable struct Sampler{T, S<:AbstractSamplerState} <: AbstractSampler
 end
 Sampler(alg) = Sampler(alg, Selector())
 Sampler(alg, model::Model) = Sampler(alg, model, Selector())
-Sampler(alg, model::Model, s::Selector) = Sampler(alg, model, s)
+Sampler(alg, model::Model, s::Selector) = Sampler(alg, model, s, SamplerState(model))
 
 include("utilities/Utilities.jl")
 using .Utilities

--- a/src/Turing.jl
+++ b/src/Turing.jl
@@ -123,6 +123,7 @@ end
 Sampler(alg) = Sampler(alg, Selector())
 Sampler(alg, model::Model) = Sampler(alg, model, Selector())
 Sampler(alg, model::Model, s::Selector) = Sampler(alg, model, s, SamplerState(model))
+Sampler(alg, model::Model, s::Selector, state::AbstractSamplerState) = Sampler(alg, Dict{Symbol, Any}(), s, state)
 
 include("utilities/Utilities.jl")
 using .Utilities

--- a/src/core/RandomVariables.jl
+++ b/src/core/RandomVariables.jl
@@ -1165,7 +1165,7 @@ function parameters!(vi::VarInfo, metadata::NamedTuple{md_names}, nt::NamedTuple
     for key in nt_keys
         if key in md_names
             for (k, v) in zip(metadata[key].vns, nt[key])
-                vi[k] = v isa Array ? v : [v]
+                vi[k] = v isa AbstractArray ? v : [v]
             end
         else
             throw(ArgumentError("Key $key not found in VarInfo metadata, acceptable values are $md_names"))

--- a/src/core/RandomVariables.jl
+++ b/src/core/RandomVariables.jl
@@ -41,7 +41,8 @@ export  VarName,
         istrans,
         link!,
         invlink!,
-        tonamedtuple
+        tonamedtuple,
+        variables
 
 ####
 #### Types for typed and untyped VarInfo
@@ -168,7 +169,7 @@ symbols have been observed. `VarInfo{<:NamedTuple}` is aliased `TypedVarInfo`.
 
 Note: It is the user's responsibility to ensure that each "symbol" is visited at least
 once whenever the model is called, regardless of any stochastic branching. Each symbol
-refers to a Julia variable and can be a hierarchical array of many random variables, e.g. `x[1] ~ ...` and `x[2] ~ ...` both have the same symbol `x`.
+refers to a Julia variable and can be a hierarchical array of many random 7, e.g. `x[1] ~ ...` and `x[2] ~ ...` both have the same symbol `x`.
 """
 struct VarInfo{Tmeta, Tlogp} <: AbstractVarInfo
     metadata::Tmeta
@@ -519,6 +520,13 @@ end
     # Get all the idcs of the vns
     return filter((i) -> isempty(f_meta.gids[i]), 1:length(f_meta.gids))
 end
+
+"""
+    variables(spl::AbstractSampler)
+
+Returns a vector of the `VarName`s that `spl` has access to.
+"""
+variables(spl::AbstractSampler) = vcat([v for (_, v) in pairs(_getvns(spl.state.vi, spl))]...)
 
 # Get all vns of variables belonging to spl
 _getvns(vi::UntypedVarInfo, spl::AbstractSampler) = view(vi.vns, _getidcs(vi, spl))

--- a/src/core/RandomVariables.jl
+++ b/src/core/RandomVariables.jl
@@ -1100,9 +1100,8 @@ end
 """
     tonamedtuple(vi::Turing.VarInfo)
 
-Convert a `vi` into a `NamedTuple` where each variable symbol maps to the values,  
-indexing string, and `VarName` of the variable. For example, a model that had a vector of vector-valued
-variables `x` would return
+Convert a `vi` into a `NamedTuple` where each variable symbol maps to the values, and `VarName` of the variable. 
+For example, a model that had a vector of vector-valued variables `x` would return
 
 ```julia
 (x = ([1.5, 2.0], [3.0, 1.0], ["x[1]", "x[2]"]), )
@@ -1116,7 +1115,6 @@ end
     expr = Expr(:tuple)
     map(names) do f
         push!(expr.args, Expr(:(=), f, :(getindex.(Ref(vi), metadata.$f.vns), 
-                                         string.(metadata.$f.vns, all=false), 
                                          metadata.$f.vns)))
     end
     return expr

--- a/src/inference/AdvancedSMC.jl
+++ b/src/inference/AdvancedSMC.jl
@@ -272,11 +272,12 @@ function sample_end!(
     spl.state.average_logevidence = loge
 end
 
-function assume(  spl::Sampler{T},
-                  dist::Distribution,
-                  vn::VarName,
-                  _::VarInfo
-                ) where T<:Union{PG,SMC}
+function assume(  
+    spl::Sampler{T},
+    dist::Distribution,
+    vn::VarName,
+    _::VarInfo
+) where T<:Union{PG,SMC}
 
     vi = current_trace().vi
     if isempty(getspace(spl.alg)) || vn.sym in getspace(spl.alg)
@@ -305,12 +306,16 @@ function assume(  spl::Sampler{T},
     return r, zero(Real)
 end
 
-function assume(  spl::Sampler{A},
-                  dists::Vector{D},
-                  vn::VarName,
-                  var::Any,
-                  vi::VarInfo
-                ) where {A<:Union{PG,SMC},D<:Distribution}
+function assume(  
+    spl::Sampler{A},
+    dists::Vector{D},
+    vn::VarName,
+    var::Any,
+    vi::VarInfo
+) where {
+    A<:Union{PG,SMC},
+    D<:Distribution
+}
     error("[Turing] PG and SMC doesn't support vectorizing assume statement")
 end
 
@@ -319,11 +324,12 @@ function observe(spl::Sampler{T}, dist::Distribution, value, vi) where T<:Union{
     return zero(Real)
 end
 
-function observe( spl::Sampler{A},
-                  ds::Vector{D},
-                  value::Any,
-                  vi::VarInfo
-                ) where {A<:Union{PG,SMC},D<:Distribution}
+function observe( 
+    spl::Sampler{A},
+    ds::Vector{D},
+    value::Any,
+    vi::VarInfo
+) where {A<:Union{PG,SMC},D<:Distribution}
     error("[Turing] PG and SMC doesn't support vectorizing observe statement")
 end
 

--- a/src/inference/AdvancedSMC.jl
+++ b/src/inference/AdvancedSMC.jl
@@ -140,7 +140,7 @@ function step!(
 
     # update the master vi.
     particle = spl.state.particles.vals[iteration]
-    params = tonamedtuple(particle.vi)
+    params = parameters(particle.vi)
     lp = getlogp(particle.vi)
 
     return ParticleTransition(params, lp, spl.state.particles.logE, Ws[iteration])
@@ -235,7 +235,7 @@ function step!(
     indx = randcat(Ws)
 
     # Extract the VarInfo from the retained particle.
-    params = tonamedtuple(spl.state.vi)
+    params = parameters(spl.state.vi)
     spl.state.vi = particles[indx].vi
     lp = getlogp(spl.state.vi)
 

--- a/src/inference/AdvancedSMC.jl
+++ b/src/inference/AdvancedSMC.jl
@@ -141,6 +141,7 @@ function step!(
     # update the master vi.
     particle = spl.state.particles.vals[iteration]
     params = parameters(particle.vi)
+    spl.state.vi = particle.vi
     lp = getlogp(particle.vi)
 
     return ParticleTransition(params, lp, spl.state.particles.logE, Ws[iteration])

--- a/src/inference/AdvancedSMC.jl
+++ b/src/inference/AdvancedSMC.jl
@@ -319,7 +319,7 @@ function assume(
     error("[Turing] PG and SMC doesn't support vectorizing assume statement")
 end
 
-function observe(spl::Sampler{T}, dist::Distribution, value, vi) where T<:Union{PG,SMC}
+function observe(spl::Sampler{T}, dist::Distribution, value::Any, vi::VarInfo) where T<:Union{PG,SMC}
     produce(logpdf(dist, value))
     return zero(Real)
 end

--- a/src/inference/Inference.jl
+++ b/src/inference/Inference.jl
@@ -121,6 +121,12 @@ function additional_parameters(::Type{<:Transition})
     return [:lp]
 end
 
+"""
+    parameters!(spl::Sampler, t::T)
+
+Sets the `VarInfo` in a sampler's state to the values of the `Transition`
+struct, and returns a vector-form parameterization.
+"""
 function parameters!(spl::Sampler, t::T) where T<:Transition
     for (key, (params, vns)) in pairs(t.θ)
         for i in 1:length(params)
@@ -131,6 +137,12 @@ function parameters!(spl::Sampler, t::T) where T<:Transition
     return copy(spl.state.vi[spl])
 end
 
+"""
+    parameter(t::T, vn::VarName)
+
+Retrieves the value of `vn` from `Transition` `t`, or `missing` if the `VarName`
+is not in `t`.
+"""
 function parameter(t::T, vn::VarName) where T<:Transition
     for (_, xs) in pairs(t.θ)
         for (v, x) in zip(xs[1], xs[2])

--- a/src/inference/Inference.jl
+++ b/src/inference/Inference.jl
@@ -646,11 +646,11 @@ function observe(
 end
 
 function observe(
-    spl::A,
+    spl::AbstractSampler,
     dist::Distribution,
     value::Any,
     vi::VarInfo
-) where A<:Union{SampleFromPrior, SampleFromUniform}
+)# where A<:Union{SampleFromPrior, SampleFromUniform}
 
     vi.num_produce += one(vi.num_produce)
     Turing.DEBUG && @debug "dist = $dist"

--- a/src/inference/Inference.jl
+++ b/src/inference/Inference.jl
@@ -561,10 +561,12 @@ observe(spl::Sampler, weight::Float64) =
 error("Turing.observe: unmanaged inference algorithm: $(typeof(spl))")
 
 ## Default definitions for assume, observe, when sampler = nothing.
-function assume(spl::A,
+function assume(
+    spl::A,
     dist::Distribution,
     vn::VarName,
-    vi::VarInfo) where {A<:AbstractSampler}#{A<:Union{SampleFromPrior, SampleFromUniform}}
+    vi::VarInfo
+) where {A<:AbstractSampler}
 
     if haskey(vi, vn)
         r = vi[vn]
@@ -579,11 +581,13 @@ function assume(spl::A,
     r, logpdf_with_trans(dist, r, istrans(vi, vn))
 end
 
-function assume(spl::A,
+function assume(
+    spl::A,
     dists::Vector{T},
     vn::VarName,
     var::Any,
-    vi::VarInfo) where {T<:Distribution, A<:AbstractSampler}#{T<:Distribution, A<:Union{SampleFromPrior, SampleFromUniform}}
+    vi::VarInfo
+) where {T<:Distribution, A<:Union{SampleFromPrior, SampleFromUniform}}
 
     @assert length(dists) == 1 "Turing.assume only support vectorizing i.i.d distribution"
     dist = dists[1]

--- a/src/inference/Inference.jl
+++ b/src/inference/Inference.jl
@@ -632,7 +632,7 @@ end
 
 # If no observe statement is given, default to accumulating the
 # log density from the prior.
-function observe(spl::Sampler, d::Distribution, value::Any, vi::VarInfo)
+function observe(spl::Sampler{A}, d::Distribution, value::Any, vi::VarInfo) where A<:AbstractSampler
     return observe(nothing, d, value, vi)
 end
 

--- a/src/inference/hmc.jl
+++ b/src/inference/hmc.jl
@@ -28,7 +28,7 @@ struct HamiltonianTransition{T, NT<:NamedTuple, F<:AbstractFloat} <: AbstractTra
 end
 
 function HamiltonianTransition(spl::Sampler{<:Hamiltonian}, t::T) where T<:AHMC.Transition
-    theta = tonamedtuple(spl.state.vi)
+    theta = parameters(spl.state.vi)
     lp = getlogp(spl.state.vi)
     return HamiltonianTransition(theta, lp, t.stat)
 end

--- a/src/inference/mh.jl
+++ b/src/inference/mh.jl
@@ -125,6 +125,7 @@ function step!(
         setlogp!(spl.state.vi, old_logp)  # reset logp
     end
 
+    println(Transition(spl))
     return Transition(spl)
 end
 

--- a/src/inference/mh.jl
+++ b/src/inference/mh.jl
@@ -125,7 +125,6 @@ function step!(
         setlogp!(spl.state.vi, old_logp)  # reset logp
     end
 
-    println(Transition(spl))
     return Transition(spl)
 end
 

--- a/src/interface/Interface.jl
+++ b/src/interface/Interface.jl
@@ -58,8 +58,9 @@ abstract type AbstractTransition end
 """
     AbstractCallback
 
-An `AbstractCallback` types is a supertype to be inherited from if you want to use custom callback 
-functionality. This is used to report sampling progress such as parameters calculated, remaining
+An `AbstractCallback` types is a supertype to be inherited from if you
+want to use custom callback functionality. This is used to report sampling
+progress such as parameters calculated, remaining
 samples to run, or even plot graphs if you so choose.
 
 In order to implement callback functionality, you need the following:
@@ -312,7 +313,8 @@ function step!(
     kwargs...
 ) where {ModelType<:Sampleable, SamplerType<:AbstractSampler}
     # Do nothing.
-    debug && @warn "No step! function has been implemented for objects of types \n- $(typeof(ℓ)) \n- $(typeof(s))"
+    debug && @warn "No step! function has been implemented for objects" *
+                    "of types \n- $(typeof(ℓ)) \n- $(typeof(s))"
 end
 
 function step!(
@@ -375,7 +377,7 @@ function transitions_init(
     N::Integer;
     kwargs...
 ) where {ModelType<:Sampleable, SamplerType<:AbstractSampler}
-    return Vector{transition_type(s)}(undef, N)
+    return Vector{transition_type(ℓ, s)}(undef, N)
 end
 
 """
@@ -433,10 +435,14 @@ end
 
 """
     transition_type(s::AbstractSampler)
+    transition_type(ℓ::M, s::AbstractSampler)
 
 Return the type of `AbstractTransition` that is to be returned by an 
-`AbstractSampler` after each `step!` call. 
+`AbstractSampler` after each `step!` call. This can be constructed by passing 
+in the model type as well, but if no model is passed in, only the sampler
+will be used to construct the transition type.
 """
 transition_type(s::AbstractSampler) = AbstractTransition
+transition_type(ℓ::M, s::AbstractSampler) where M<:Sampleable = transition_type(s)
 
 end # module Interface


### PR DESCRIPTION
This PR includes

1. Some convenience functions for developers, some of which were discussed in https://github.com/TuringLang/Turing.jl/issues/886.
2. A guide on how to use the interface methods on both Turing and non-Turing methods by implementing MH.
3. Miscellaneous changes to internals, such as 
- allowing a default `Sampler` constructor
- storing `VarName` instead of a string in `Transition` structs (for later access)
- a default `observe` statement for all samplers which just uses `SampleFromPrior()` 
- a default `assume` statement which just returns the current value and it's density 

There are some things in here I think we should discuss before merging, because I've made a couple design choices that I hope might enable more people to work with immutable `Transition` structs instead of relying so heavily on mutable states. The guide is an attempt to showcase partial immutable sampling to mirror the non-Turing implementation, and the functions I added in to Turing's code base might make this a little easier.

# New functions

Here are the new tools I've added in for developers. I'd like some feedback on these specifically to see how we feel about them.

- A new `Transition` constructor, which has the signature `Transition(model::Model, spl::Sampler, θ::T, nt::NamedTuple=NamedTuple())`. You can pass in the model and the sampler, it'll run the model, grab the density, and bundle everything up for you into a `Transition`.
- `parameters!` is a function with the signature `parameters!(spl::Sampler, t::Transition)`, which accepts a `Transition` and updates the `VarInfo` to contain the parameters in the `Transition`. It returns a vector of the parameters if you would prefer to work with vectors instead of a `NamedTuple`.
- `parameters` is a function which simply returns a `NamedTuple` of the `vi`.
- `variables(spl::Sampler)` is a function that returns a vector containing the `VarNames` of a sampler, so you can retrieve or set information about them in a `VarInfo`. I would like this to be an iterator or something slightly quicker than what it is now, but I like the idea of giving developers quick access to some iterable of `VarName`.
- `Distributions.logpdf(model::Model, spl::T, θ::P)` accepts a model, a sampler, and a vector, and returns the log density. It's a little clumsy but it should get us closer to models that people can just evaluate.

There's some bugs in here I still have to fix, but this is the core of the PR.