### PR TITLE
Lock "faraday" to 0.15.4

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -11,6 +11,7 @@ ruby RUBY_VERSION
 # Happy Jekylling!
 # gem "jekyll", "3.2.1"
 gem "jekyll"
+gem "faraday", "0.15.4"
 
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 # gem "minima"


### PR DESCRIPTION
After https://github.com/TuringLang/Turing.jl/pull/915 was merged, I found the documentation building on CI failed (https://travis-ci.org/TuringLang/Turing.jl/jobs/590813375).

Then I had a check and found that the ruby package `faraday` just released a new version yesterday (https://github.com/lostisland/faraday/releases) and it broke our documentation building process. So I lock this package to v0.15.4.