### PR TITLE
docs bugfix: context url and version switcher

### DIFF
--- a/docs/assets/js/version-switch.js
+++ b/docs/assets/js/version-switch.js
@@ -26,8 +26,10 @@ $(document).ready(function(){
         });
     }
 
+    var current_ver = url_parts[2].replace(/\.0+$/, '');
+
     $.each(DOC_VERSIONS, function(index, value) {
-        if(value == url_parts[2]) {
+        if(value == current_ver) {
             // mobile
             $("select#version-selector").append(
                 $('<option value="' + value + '" selected="selected">' + value + '</option>'));

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -25,7 +25,7 @@ in("no-tutorials", ARGS) || copy_tutorial(tutorial_path)
 
 baseurl = "/dev"
 if get(ENV, "TRAVIS_TAG", "") != ""
-    baseurl = ENV["TRAVIS_TAG"]
+    baseurl = "/" * ENV["TRAVIS_TAG"]
 end
 jekyll_build = joinpath(@__DIR__, "jekyll-build")
 with_baseurl(() -> run(`$jekyll_build`), baseurl)


### PR DESCRIPTION
After v0.7.0 was tagged, I found two other bugs of the docs building process:
1. the `baseurl`(i.e. context path of the URL) was wrong, it should start with a slash
2. the version-switcher has a small glitch, it can not distinguish `v0.N` and `v0.N.0` very well.

This PR fixed them.

Also, these issues on the gh-pages branch were fixed manually.