### PR TITLE
Fix histogram plotting on Quick Start example

### DIFF
--- a/docs/src/using-turing/quick-start.md
+++ b/docs/src/using-turing/quick-start.md
@@ -48,8 +48,7 @@ iterations = 1000
 # Start sampling.
 chain = sample(coinflip(data), HMC(ϵ, τ), iterations);
 
-# Construct summary of the sampling process for the parameter p, i.e. the probability of heads in a coin.
-psummary = Chains(chain[:p])
-histogram(psummary)
+# Plot a summary of the sampling process for the parameter p, i.e. the probability of heads in a coin.
+histogram(chain[:p])
 ```
 


### PR DESCRIPTION
As per https://discourse.julialang.org/t/how-can-i-solve-no-method-matching-chains-in-turing-julia/27166

I needed this change to get the "Probabilistic Programming in Thirty Seconds" tutorial to run correctly