### PR TITLE
A few updates of HMC, Gibbs, and NUTS to new API.

### DIFF
--- a/benchmarks/mvnormal.jl
+++ b/benchmarks/mvnormal.jl
@@ -18,7 +18,7 @@ n_adapts = 2_000
 
 # Sampling
 LOG_DATA = @tbenchmark_expr("NUTS(Leapfrog(...))",
-                             sample(target(D), HMC(n_samples, 0.1, 5)));
+                             sample(target(D), HMC(0.1, 5), n_samples));
 
 print_log(LOG_DATA)
 
@@ -42,10 +42,10 @@ d   = MvNormal(zeros(dim2), A)
 
 # ForwardDiff
 Turing.setadbackend(:forward_diff)
-@benchmark chain = sample(mdemo(d, 1), HMC(5000, 0.1, 5))
+@benchmark chain = sample(mdemo(d, 1), HMC(0.1, 5), 5000)
 
 #BackwardDiff
 Turing.setadbackend(:reverse_diff)
-@benchmark chain = sample(mdemo(d, 1), HMC(5000, 0.1, 5))
+@benchmark chain = sample(mdemo(d, 1), HMC(0.1, 5), 5000)
 
 # build log and send data back to github.

--- a/docs/src/using-turing/guide.md
+++ b/docs/src/using-turing/guide.md
@@ -80,7 +80,7 @@ The arguments for each sampler are:
   * HMC: leapfrog step size, leapfrog step numbers.
   * Gibbs: component sampler 1, component sampler 2, ...
   * HMCDA: total leapfrog length, target accept ratio.
-  * NUTS: Number of adaptation steps (optional), target accept ratio.
+  * NUTS: number of adaptation steps (optional), target accept ratio.
 
 
 For detailed information on the samplers, please review Turing.jl's [API]({{site.baseurl}}/docs/library) documentation.

--- a/docs/src/using-turing/guide.md
+++ b/docs/src/using-turing/guide.md
@@ -77,10 +77,10 @@ The arguments for each sampler are:
 
   * SMC: number of particles.
   * PG: number of particles, number of iterations.
-  * HMC: number of samples, leapfrog step size, leapfrog step numbers.
-  * Gibbs: number of samples, component sampler 1, component sampler 2, ...
-  * HMCDA: number of samples, total leapfrog length, target accept ratio.
-  * NUTS: number of samples, target accept ratio.
+  * HMC: leapfrog step size, leapfrog step numbers.
+  * Gibbs: component sampler 1, component sampler 2, ...
+  * HMCDA: total leapfrog length, target accept ratio.
+  * NUTS: Number of adaptation steps (optional), target accept ratio.
 
 
 For detailed information on the samplers, please review Turing.jl's [API]({{site.baseurl}}/docs/library) documentation.
@@ -373,7 +373,7 @@ end
 ```
 
 
-If we are trying to generate random random values from the `generator` model and we call `sample(generator(), HMC(1000, 0.01, 5))`, we will receive an error. This is because there is no way to determine `length(x)`, whether `x` is a vector, and the type of the values in `x`.
+If we are trying to generate random random values from the `generator` model and we call `sample(generator(), HMC(0.01, 5), 1000)`, we will receive an error. This is because there is no way to determine `length(x)`, whether `x` is a vector, and the type of the values in `x`.
 
 
 A sensible default value might be:

--- a/src/inference/gibbs.jl
+++ b/src/inference/gibbs.jl
@@ -20,7 +20,7 @@ end
 # Use PG for a 'v2' variable, and use HMC for the 'v1' variable.
 # Note that v2 is discrete, so the PG sampler is more appropriate
 # than is HMC.
-alg = Gibbs(1000, HMC(1, 0.2, 3, :v1), PG(20, 1, :v2))
+alg = Gibbs(HMC(0.2, 3, :v1), PG(20, 1, :v2))
 ```
 
 Tips:

--- a/src/inference/hmc.jl
+++ b/src/inference/hmc.jl
@@ -68,10 +68,10 @@ Tips:
 
 ```julia
 # Original step_size
-sample(gdemo([1.5, 2]), HMC(1000, 0.1, 10))
+sample(gdemo([1.5, 2]), HMC(0.1, 10), 1000)
 
 # Reduced step_size.
-sample(gdemo([1.5, 2]), HMC(1000, 0.01, 10))
+sample(gdemo([1.5, 2]), HMC(0.01, 10), 1000)
 ```
 """
 mutable struct HMC{AD, space, metricT <: AHMC.AbstractMetric} <: StaticHamiltonian{AD}
@@ -224,7 +224,7 @@ NUTS(200, 0.6j_max)
 
 Arguments:
 
-- `n_adapts::Int` : The number of samples to use with adapatation.
+- `n_adapts::Int` : The number of samples to use with adaptation.
 - `δ::Float64` : Target acceptance rate.
 - `max_depth::Float64` : Maximum doubling tree depth.
 - `Δ_max::Float64` : Maximum divergence during doubling tree.

--- a/src/utilities/stan-interface.jl
+++ b/src/utilities/stan-interface.jl
@@ -45,17 +45,17 @@ function sample(mf::T,
     if adapt.engaged == false
         if isa(alg.engine, CmdStan.Static)   # hmc
             stepnum = Int(round(alg.engine.int_time / alg.stepsize))
-            sample(mf, HMC(num_samples, alg.stepsize, stepnum); adaptor=NUTSAdaptor(adapt))
+            sample(mf, HMC(alg.stepsize, stepnum), num_samples; adaptor=NUTSAdaptor(adapt))
         elseif isa(alg.engine, CmdStan.Nuts) # error
             error("[Turing.sample] CmdStan.Nuts cannot be used with adapt.engaged set as false")
         end
     else
         if isa(alg.engine, CmdStan.Static)   # hmcda
-            sample(mf, HMCDA(num_samples, num_warmup, adapt.delta, alg.engine.int_time);
+            sample(mf, HMCDA(num_warmup, adapt.delta, alg.engine.int_time), num_samples;
                     adaptor=NUTSAdaptor(adapt))
         elseif isa(alg.engine, CmdStan.Nuts) # nuts
             if isa(alg.metric, CmdStan.diag_e)
-                sample(mf, NUTS(num_samples, num_warmup, adapt.delta);
+                sample(mf, NUTS(num_warmup, adapt.delta), num_samples;
                         adaptor=NUTSAdaptor(adapt))
             else # TODO: reove the following since Turing support this feature now.
                 @warn("[Turing.sample] Turing does not support full covariance matrix for pre-conditioning yet.")

--- a/test/inference/hmc.jl
+++ b/test/inference/hmc.jl
@@ -118,9 +118,9 @@ include(dir*"/test/test_utils/AllUtils.jl")
     Random.seed!(123)
     @numerical_testset "hmcda inference" begin
         alg1 = HMCDA(1000, 0.8, 0.015)
-        # alg2 = Gibbs(3000, HMCDA(1, 200, 0.8, 0.35, :m), HMC(1, 0.25, 3, :s))
+        # alg2 = Gibbs(HMCDA(200, 0.8, 0.35, :m), HMC(0.25, 3, :s))
         alg3 = Gibbs(PG(10, :s), HMCDA(200, 0.8, 0.005, :m))
-        # alg3 = Gibbs(2000, HMC(1, 0.25, 3, :m), PG(30, 3, :s))
+        # alg3 = Gibbs(HMC(0.25, 3, :m), PG(30, 3, :s))
         # alg3 = PG(50, 2000)
 
         res1 = sample(gdemo_default, alg1, 3000)

--- a/test/skipped/bayes_lr.jl
+++ b/test/skipped/bayes_lr.jl
@@ -23,7 +23,7 @@ ys = xs * β + rand(Normal(0, sqrt(s)), N)
 println("s=$s, β=$β")
 
 mf = bayes_lr(xs, ys)
-chn = sample(mf, HMC(2000, 0.005, 3))
+chn = sample(mf, HMC(0.005, 3), 2000)
 
 println("mean of β: $(mean(chn[1000:end, :β, :].value))")
 

--- a/test/skipped/explicit_ret.jl
+++ b/test/skipped/explicit_ret.jl
@@ -11,7 +11,7 @@ end
 
 mf = test_ex_rt()
 
-for alg = [HMC(2000, 0.2, 3), PG(20, 2000), SMC(), IS(10000), Gibbs(2000, PG(20, 1, :x), HMC(1, 0.2, 3, :y))]
+for alg = [HMC(0.2, 3), PG(20, 2000), SMC(), IS(10000), Gibbs(PG(20, 1, :x), HMC(0.2, 3, :y))]
   chn = sample(mf, alg)
   @test mean(chn[:x].value) ≈ 10.0 atol=0.2
   @test mean(chn[:y].value) ≈ 5.0 atol=0.2

--- a/test/skipped/gdemo_hmc.jl
+++ b/test/skipped/gdemo_hmc.jl
@@ -6,7 +6,7 @@ include("gdemo.jl")
 # Turing
 
 mf = gdemo()
-chn = sample(mf, HMC(2000, 0.05, 5))
+chn = sample(mf, HMC(0.05, 5), 2000)
 
 println("mean of s: $(mean(chn[1000:end, :s, :].value))")
 println("mean of m: $(mean(chn[1000:end, :m, :].value))")

--- a/test/skipped/gdemo_nuts.jl
+++ b/test/skipped/gdemo_nuts.jl
@@ -9,7 +9,7 @@ include("dual_averaging.jl")
 # Turing
 
 # mf = gdemo()
-# chn = sample(mf, HMC(5000, 0.05, 5))
+# chn = sample(mf, HMC(0.05, 5), 5000)
 
 # println("mean of m: $(mean(chn[:m][1000:end]))")
 

--- a/test/skipped/hmcda_geweke.jl
+++ b/test/skipped/hmcda_geweke.jl
@@ -31,8 +31,8 @@ end
 end
 
 fw = PG(50, NSamples)
-# bk = Gibbs(10, PG(10,10, :s, :y), HMC(1, 0.25, 5, :m));
-bk = HMCDA(50, 0.65, 0.2);
+# bk = Gibbs(10, PG(10,10, :s, :y), HMC(0.25, 5, :m));
+bk = HMCDA(0.65, 0.2);
 
 s = sample(gdemo_fw(), fw);
 # describe(s)

--- a/test/skipped/sv.jl
+++ b/test/skipped/sv.jl
@@ -20,7 +20,7 @@ sv_data = load(TPATH*"/example-models/nips-2017/sv-data.jld.data")["data"]
 
 
 mf = sv_model(data=sv_data[1])
-chain_nuts = sample(mf, HMC(2000, 0.05, 10))
+chain_nuts = sample(mf, HMC(0.05, 10), 2000)
 
 println("mean of m: $(mean(chn[1000:end, :μ, :].value))")
 

--- a/test/skipped/vec_assume_mat.jl
+++ b/test/skipped/vec_assume_mat.jl
@@ -2,7 +2,7 @@ using Turing, Test
 
 N = 5
 setchunksize(4*N)
-alg = HMC(1000, 0.2, 4)
+alg = HMC(0.2, 4, 1000)
 
 @model vdemo(::Type{T}=Float64) where {T} = begin
   v = Vector{Matrix{T}}(undef, N)

--- a/test/skipped/vec_assume_mv.jl
+++ b/test/skipped/vec_assume_mv.jl
@@ -4,7 +4,7 @@ using Turing, Test
 N = 10
 beta = [0.5, 0.5]
 setchunksize(N*length(beta))
-alg = HMC(3000, 0.2, 4)
+alg = HMC(0.2, 4)
 
 # Test for vectorize UnivariateDistribution
 @model vdemo() = begin


### PR DESCRIPTION
I think I got most of them but `@tbenchmark` looks like it might need to be updated to the new API so I haven't fixed the places where it's used. Also, from the changes I made to `stan-interface.jl` I'm wondering that it might not be tested but I can see that the coverage info is old. Any chance that you'd be able to upload new information? Finally, it looks like the tests in `test/skipped` have bitrotten so maybe they could just be deleted.