### PR TITLE
Update deprecated lbeta to logbeta

### DIFF
--- a/src/stdlib/distributions.jl
+++ b/src/stdlib/distributions.jl
@@ -40,7 +40,7 @@ end
 """
     BinomialLogit(n<:Real, I<:Integer)
 
-A univariate binomial logit distribution. 
+A univariate binomial logit distribution.
 """
 struct BinomialLogit{T<:Real, I<:Integer} <: DiscreteUnivariateDistribution
     n::I
@@ -50,7 +50,7 @@ end
 """
     BinomialLogit(n<:Real, I<:Integer)
 
-A multivariate binomial logit distribution. 
+A multivariate binomial logit distribution.
 """
 struct VecBinomialLogit{T<:Real, I<:Integer} <: DiscreteUnivariateDistribution
     n::Vector{I}
@@ -58,7 +58,7 @@ struct VecBinomialLogit{T<:Real, I<:Integer} <: DiscreteUnivariateDistribution
 end
 
 function logpdf_binomial_logit(n, logitp, k)
-    logcomb = -StatsFuns.log1p(n) - SpecialFunctions.lbeta(n - k + 1, k + 1)
+    logcomb = -StatsFuns.log1p(n) - SpecialFunctions.logbeta(n - k + 1, k + 1)
     return logcomb + k * logitp - n * StatsFuns.log1pexp(logitp)
 end
 


### PR DESCRIPTION
`lbeta` in the `BinomialLogit` function is deprecated in favor of `logbeta`. Fixing this deprecation resulted in about a 25 fold improvement on my system. I'm not sure whether performance was improved or deprecations reduce performance. 