### PR TITLE
Simplify ParticleContainer

### DIFF
--- a/.github/workflows/DynamicHMC.yml
+++ b/.github/workflows/DynamicHMC.yml
@@ -1,6 +1,11 @@
 name: DynamicHMC-CI
 
-on: [push] # [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   test:

--- a/.github/workflows/Numerical.yml
+++ b/.github/workflows/Numerical.yml
@@ -1,6 +1,11 @@
 name: Numerical
 
-on: [push] # [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   test:

--- a/.github/workflows/StanCI.yml
+++ b/.github/workflows/StanCI.yml
@@ -1,6 +1,11 @@
 name: Stan-CI
 
-on: [push] # [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   test:

--- a/.github/workflows/TuringCI.yml
+++ b/.github/workflows/TuringCI.yml
@@ -1,6 +1,11 @@
 name: Turing-CI
 
-on: [push] # [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   test:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: julia
 
+# avoids duplicate tests in PRs
+branches:
+  only:
+    - master
+
 matrix:
   fast_finish: true
 

--- a/src/core/container.jl
+++ b/src/core/container.jl
@@ -126,10 +126,10 @@ function Base.push!(pc :: ParticleContainer, n :: Int, spl :: Sampler, varInfo :
 end
 
 # clears the container but keep params, logweight etc.
-function Base.empty!(pc :: ParticleContainer)
+function Base.empty!(pc::ParticleContainer)
     pc.num_particles = 0
-    pc.vals  = Vector{Particle}()
-    pc.logWs = Vector{Float64}()
+    pc.vals  = eltype(pc.vals)[]
+    pc.logWs = Float64[]
     pc
 end
 

--- a/test/core/container.jl
+++ b/test/core/container.jl
@@ -15,7 +15,6 @@ include(dir*"/test/test_utils/AllUtils.jl")
 
         @test newpc.logE        == pc.logE
         @test newpc.logWs       == pc.logWs
-        @test newpc.conditional == pc.conditional
         @test newpc.n_consume   == pc.n_consume
     end
     @turing_testset "particle container" begin


### PR DESCRIPTION
This PR simplifies the type parameters of `ParticleContainer`, and removes the `conditional` field which by definition was always `nothing`.

Moreover, instead of appending newly allocated arrays, `push!` now resizes the existing arrays and sets the new values, which is faster:
```julia
using BenchmarkTools

function f(x, n)
    y = zeros(eltype(x), n)
    append!(x, y)
    nothing
end

function g(x, n)
    m = length(x)
    mpn = m + n
    resize!(x, mpn)
    @inbounds for i in (m + 1):mpn
        x[i] = zero(eltype(x))
    end
    nothing
end

a = rand(1_000)

@btime f($(copy(a)), 100) # 339.092 ns (1 allocation: 896 bytes)
@btime g($(copy(a)), 100) # 263.981 ns (0 allocations: 0 bytes)
```

The `empty!` function now defines an array of particles whose element type is based on the previously used array instead of always using the abstract element type `Particle`.

The `copy!` function of `ParticleContainer` creates a set of copied particles by list comprehension instead of pushing them individually to an initially empty array.

Moreover, the definition of `Trace` is simplified by removing the completely uninitialized inner constructor and reordering the fields (making it easier to create new instances without specifying a `task`).