### PR TITLE
Add numerically stable Poisson logpdf

### DIFF
--- a/src/Turing.jl
+++ b/src/Turing.jl
@@ -211,6 +211,7 @@ export  @model,                 # modelling
         FlatPos,
         BinomialLogit,
         VecBinomialLogit,
-        OrderedLogistic
+        OrderedLogistic,
+        LogPoisson
 
 end

--- a/src/stdlib/distributions.jl
+++ b/src/stdlib/distributions.jl
@@ -120,3 +120,15 @@ function Distributions.rand(rng::AbstractRNG, d::OrderedLogistic)
         return(-Inf)
     end
 end
+
+"""
+Numerically stable Poisson log likelihood.
+* `logλ`: log of rate parameter
+"""
+struct LogPoisson{T<:Real} <: DiscreteUnivariateDistribution
+    logλ::T
+end
+
+function Distributions.logpdf(lp::LogPoisson, k::Int)
+    return k * lp.logλ - exp(lp.logλ) - loggamma(k + 1)
+end

--- a/src/stdlib/distributions.jl
+++ b/src/stdlib/distributions.jl
@@ -40,7 +40,7 @@ end
 """
     BinomialLogit(n<:Real, I<:Integer)
 
-A univariate binomial logit distribution. 
+A univariate binomial logit distribution.
 """
 struct BinomialLogit{T<:Real, I<:Integer} <: DiscreteUnivariateDistribution
     n::I
@@ -50,7 +50,7 @@ end
 """
     BinomialLogit(n<:Real, I<:Integer)
 
-A multivariate binomial logit distribution. 
+A multivariate binomial logit distribution.
 """
 struct VecBinomialLogit{T<:Real, I<:Integer} <: DiscreteUnivariateDistribution
     n::Vector{I}
@@ -58,7 +58,7 @@ struct VecBinomialLogit{T<:Real, I<:Integer} <: DiscreteUnivariateDistribution
 end
 
 function logpdf_binomial_logit(n, logitp, k)
-    logcomb = -StatsFuns.log1p(n) - SpecialFunctions.lbeta(n - k + 1, k + 1)
+    logcomb = -StatsFuns.log1p(n) - SpecialFunctions.logbeta(n - k + 1, k + 1)
     return logcomb + k * logitp - n * StatsFuns.log1pexp(logitp)
 end
 

--- a/test/stdlib/distributions.jl
+++ b/test/stdlib/distributions.jl
@@ -25,8 +25,16 @@ include(dir*"/test/test_utils/AllUtils.jl")
         K = length(d.cutpoints) + 1
         p = [mean(y .== k) for k in 1:K]          # empirical probs
         pmf = [exp(logpdf(d, k)) for k in 1:K]
-        
+
         @test sum(abs.(p - pmf) .< 0.001) == K
+
+    end
+
+    @turing_testset "distributions functions" begin
+        λ = .01:.01:5
+        LLp = @. logpdf(Poisson(λ),1)
+        LLlp = @. logpdf(LogPoisson(log(λ)),1)
+        @test LLp ≈ LLlp atol = .0001
 
     end
 


### PR DESCRIPTION
I was hoping to add a numerically stable version of the Poisson logpdf suggested by Kai a few months ago. I found it to be useful. So I added it to your distributions.jl file and included a test. 