### PR TITLE
Simplify calculations of tables for DirichletProcess and PitmanYorProcess

### DIFF
--- a/src/stdlib/RandomMeasures.jl
+++ b/src/stdlib/RandomMeasures.jl
@@ -64,9 +64,7 @@ Parameters:
 * `m`: Cluster counts
 
 """
-function _logpdf_table(d::AbstractRandomProbabilityMeasure, m::AbstractVector{Int})
-    throw(MethodError(_logpdf_table(), (d, m)))
-end
+function _logpdf_table end
 
 function logpdf(d::ChineseRestaurantProcess, x::Int)
     if insupport(d, x)
@@ -143,8 +141,7 @@ function _logpdf_table(d::DirichletProcess{T}, m::AbstractVector{Int}) where {T<
 
     # pre-calculations
     dα = d.α
-    z = log(sum_m) - 1 + dα
-    table_zero = log(dα) - z
+    z = log(sum_m - 1 + dα)
 
     # construct the table
     K = length(m)
@@ -157,7 +154,7 @@ function _logpdf_table(d::DirichletProcess{T}, m::AbstractVector{Int}) where {T<
             if contains_zero
                 table[i] = -Inf
             else
-                table[i] = table_zero
+                table[i] = log(dα) - z
                 contains_zero = true
             end
         else
@@ -166,7 +163,7 @@ function _logpdf_table(d::DirichletProcess{T}, m::AbstractVector{Int}) where {T<
     end
 
     if !contains_zero
-        push!(table, table_zero)
+        push!(table, log(dα) - z)
     end
 
     return table
@@ -231,7 +228,6 @@ function _logpdf_table(d::PitmanYorProcess{T}, m::AbstractVector{Int}) where {T<
     dθ = d.θ
     dd = d.d
     z = log(sum_m + dθ)
-    table_zero = log(dθ + dd * d.t) - z
 
     # construct the table
     K = length(m)
@@ -244,7 +240,7 @@ function _logpdf_table(d::PitmanYorProcess{T}, m::AbstractVector{Int}) where {T<
             if contains_zero
                 table[i] = -Inf
             else
-                table[i] = a
+                table[i] = log(dθ + dd * d.t) - z
                 contains_zero = true
             end
         else
@@ -253,7 +249,7 @@ function _logpdf_table(d::PitmanYorProcess{T}, m::AbstractVector{Int}) where {T<
     end
 
     if !contains_zero
-        push!(table, table_zero)
+        push!(table, log(dθ + dd * d.t) - z)
     end
 
     return table

--- a/src/stdlib/RandomMeasures.jl
+++ b/src/stdlib/RandomMeasures.jl
@@ -3,7 +3,7 @@ module RandomMeasures
 using ..Core, ..Core.RandomVariables, ..Utilities
 using Distributions
 using LinearAlgebra
-using StatsFuns: logsumexp
+using StatsFuns: logsumexp, softmax!
 
 import Distributions: sample, logpdf
 import Base: maximum, minimum, rand
@@ -25,7 +25,7 @@ struct SizeBiasedSamplingProcess{T<:AbstractRandomProbabilityMeasure,V<:Abstract
     surplus::V
 end
 
-logpdf(d::SizeBiasedSamplingProcess, x::T) where {T<:Real} = _logpdf(d, x)
+logpdf(d::SizeBiasedSamplingProcess, x::Real) = _logpdf(d, x)
 rand(rng::AbstractRNG, d::SizeBiasedSamplingProcess) = _rand(rng, d)
 minimum(d::SizeBiasedSamplingProcess) = zero(d.surplus)
 maximum(d::SizeBiasedSamplingProcess) = d.surplus
@@ -39,7 +39,7 @@ struct StickBreakingProcess{T<:AbstractRandomProbabilityMeasure} <: ContinuousUn
     rpm::T
 end
 
-logpdf(d::StickBreakingProcess, x::T) where {T<:Real} = _logpdf(d, x)
+logpdf(d::StickBreakingProcess, x::Real) = _logpdf(d, x)
 rand(rng::AbstractRNG, d::StickBreakingProcess) = _rand(rng, d)
 minimum(d::StickBreakingProcess) = 0.0
 maximum(d::StickBreakingProcess) = 1.0
@@ -56,7 +56,7 @@ end
 
 
 """
-    _logpdf_table(d<:AbstractRandomProbabilityMeasure, m<:AbstractVector{Int})
+    _logpdf_table(d::AbstractRandomProbabilityMeasure, m::AbstractVector{Int})
 
 Parameters:
 
@@ -64,7 +64,7 @@ Parameters:
 * `m`: Cluster counts
 
 """
-function _logpdf_table(d::AbstractRandomProbabilityMeasure, m::T) where {T<:AbstractVector{Int}}
+function _logpdf_table(d::AbstractRandomProbabilityMeasure, m::AbstractVector{Int})
     throw(MethodError(_logpdf_table(), (d, m)))
 end
 
@@ -79,8 +79,8 @@ end
 
 function rand(rng::AbstractRNG, d::ChineseRestaurantProcess)
     lp = _logpdf_table(d.rpm, d.m)
-    p = exp.(lp)
-    return rand(rng, Categorical(p ./ sum(p)))
+    softmax!(lp)
+    return rand(rng, Categorical(lp))
 end
 
 minimum(d::ChineseRestaurantProcess) = 1
@@ -134,21 +134,42 @@ function _logpdf(d::SizeBiasedSamplingProcess{DirichletProcess{T}}, x::T) where 
     return logpdf(Beta(one(T), d.rpm.α), x/d.surplus)
 end
 
-function _logpdf_table(d::DirichletProcess{V}, m::T) where {T<:AbstractVector{Int},V<:Real}
-    if sum(m) == 0
-        return zeros(V,1)
-    elseif any(m_ -> m_ == 0, m)
-        z = log(sum(m) - 1 + d.α)
-        K = length(m)
-        zid = findfirst(m_ -> m_ == 0, m)
-        lpt(k) = k == zid ? log(d.α) - z : log(m[k]) - z
-        return map(k -> lpt(k), 1:K)
-    else
-        z = log(sum(m) - 1 + d.α)
-        K = length(m)
-        lp(k) = k > K ? log(d.α) - z : log(m[k]) - z
-        return map(k -> lp(k), 1:(K+1))
+function _logpdf_table(d::DirichletProcess{T}, m::AbstractVector{Int}) where {T<:Real}
+    # compute the sum of all cluster counts
+    sum_m = sum(m)
+
+    # shortcut if all cluster counts are zero
+    iszero(sum_m) && return zeros(T, 1)
+
+    # pre-calculations
+    dα = d.α
+    z = log(sum_m) - 1 + dα
+    table_zero = log(dα) - z
+
+    # construct the table
+    K = length(m)
+    table = Vector{T}(undef, K)
+    contains_zero = false
+    @inbounds for i in 1:K
+        mi = m[i]
+
+        if iszero(mi)
+            if contains_zero
+                table[i] = -Inf
+            else
+                table[i] = table_zero
+                contains_zero = true
+            end
+        else
+            table[i] = log(mi) - z
+        end
     end
+
+    if !contains_zero
+        push!(table, table_zero)
+    end
+
+    return table
 end
 
 """
@@ -199,21 +220,43 @@ function _logpdf(d::SizeBiasedSamplingProcess{PitmanYorProcess{T}}, x::T) where 
     return logpdf(Beta(one(V)-d.rpm.d, d.rpm.θ + d.rpm.t*d.rpm.d), x/d.surplus)
 end
 
-function _logpdf_table(d::PitmanYorProcess{V}, m::T) where {T<:AbstractVector{Int},V<:Real}
-    if sum(m) == 0
-        return zeros(V,1)
-    elseif any(m_ -> m_ == 0, m)
-        z = log(sum(m) + d.θ)
-        K = length(m)
-        zidx = findfirst(m_ -> m_ == 0, m)
-        lpt(k) = k == zid ? log(d.θ+d.d*d.t) - z : m[k] == 0 ? -Inf : log(m[k]-d.d) - z
-        return map(k -> lpt(k), 1:K)
-    else
-        z = log(sum(m) + d.θ)
-        K = length(m)
-        lp(k) = k > K ? log(d.θ + d.d*d.t) - z : log(m[k] - d.d) - z
-        return map(k -> lp(k), 1:(K+1))
+function _logpdf_table(d::PitmanYorProcess{T}, m::AbstractVector{Int}) where {T<:Real}
+    # compute the sum of all cluster counts
+    sum_m = sum(m)
+
+    # shortcut if all cluster counts are zero
+    iszero(sum_m) && return zeros(T, 1)
+
+    # pre-calculations
+    dθ = d.θ
+    dd = d.d
+    z = log(sum_m + dθ)
+    table_zero = log(dθ + dd * d.t) - z
+
+    # construct the table
+    K = length(m)
+    table = Vector{T}(undef, K)
+    contains_zero = false
+    @inbounds for i in 1:K
+        mi = m[i]
+
+        if iszero(mi)
+            if contains_zero
+                table[i] = -Inf
+            else
+                table[i] = a
+                contains_zero = true
+            end
+        else
+            table[i] = log(mi - dd) - z
+        end
     end
+
+    if !contains_zero
+        push!(table, table_zero)
+    end
+
+    return table
 end
 
 ## ####### ##


### PR DESCRIPTION
This PR simplifies the calculations of the tables for DirichletProcess and PitmanYorProcess by avoiding redundant summations and loops over the provided cluster counts. Additionally, the explicit definition of the output arrays (and in particular its element types) ensures that the function is type-stable.

Moreover, in the sampling from the Chinese restaurant process the use of the in-place softmax function reduces allocations.