### PR TITLE
Remove num_particles and pre-allocate children

### DIFF
--- a/test/core/container.jl
+++ b/test/core/container.jl
@@ -54,7 +54,6 @@ include(dir*"/test/test_utils/AllUtils.jl")
         @test consume(pc) == log(1)
 
         resample!(pc)
-        @test pc.num_particles == length(pc)
         @test weights(pc) == [1/3, 1/3, 1/3]
         @test logZ(pc) ≈ log(3)
         @test pc.logE ≈ log(1)


### PR DESCRIPTION
This PR removes the field `pc.num_particles` since it is redundant with `length(pc) = length(pc.vals)`. Moreover, in the resampling step the arrays of children and log weights are pre-allocated.