### PR TITLE
Simplify the acceptance check in MH and update the documentation

### DIFF
--- a/src/inference/Inference.jl
+++ b/src/inference/Inference.jl
@@ -75,14 +75,21 @@ getADtype(alg::Hamiltonian) = getADtype(typeof(alg))
 getADtype(::Type{<:Hamiltonian{AD}}) where {AD} = AD
 
 """
-    mh_accept(H::T, H_new::T, log_proposal_ratio::T) where {T<:Real}
+    mh_accept(logp_current::Real, logp_proposal::Real, log_proposal_ratio::Real)
 
-Peform MH accept criteria with log acceptance ratio. Returns a `Bool` for acceptance.
-
-Note: This function is only used in PMMH.
+Decide if a proposal ``x'`` with log probability ``\\log p(x') = logp_proposal`` and
+log proposal ratio ``\\log k(x', x) - \\log k(x, x') = log_proposal_ratio`` in a
+Metropolis-Hastings algorithm with Markov kernel ``k(x_t, x_{t+1})`` and current state
+``x`` with log probability ``\\log p(x) = logp_current`` is accepted by evaluating the
+Metropolis-Hastings acceptance criterion
+```math
+\\log U \\leq \\log p(x') - \\log p(x) + \\log k(x', x) - \\log k(x, x')
+```
+for a uniform random number ``U \\in [0, 1)``.
 """
-function mh_accept(H::T, H_new::T, log_proposal_ratio::T) where {T<:Real}
-    return log(rand()) + H_new < H + log_proposal_ratio, min(0, -(H_new - H))
+function mh_accept(logp_current::Real, logp_proposal::Real, log_proposal_ratio::Real)
+    # replacing log(rand()) with -randexp() yields test errors
+    return log(rand()) + logp_current ≤ logp_proposal + log_proposal_ratio
 end
 
 ######################

--- a/src/inference/mh.jl
+++ b/src/inference/mh.jl
@@ -6,15 +6,17 @@ mutable struct MHState{V<:VarInfo} <: AbstractSamplerState
 end
 
 MHState(model::Model) = MHState(0.0, 0.0, false, VarInfo(model))
+
 """
-    MH(n_iters::Int)
+    MH()
 
 Metropolis-Hastings sampler.
 
 Usage:
 
 ```julia
-MH(100, (:m, (x) -> Normal(x, 0.1)))
+MH(:m)
+MH((:m, x -> Normal(x, 0.1)))
 ```
 
 Example:
@@ -22,14 +24,13 @@ Example:
 ```julia
 # Define a simple Normal model with unknown mean and variance.
 @model gdemo(x) = begin
-  s ~ InverseGamma(2,3)
-  m ~ Normal(0,sqrt(s))
+  s ~ InverseGamma(2, 3)
+  m ~ Normal(0, sqrt(s))
   x[1] ~ Normal(m, sqrt(s))
   x[2] ~ Normal(m, sqrt(s))
-  return s, m
 end
 
-chn = sample(gdemo([1.5, 2]), MH(1000))
+chn = sample(gdemo([1.5, 2]), MH(), 1000)
 ```
 """
 mutable struct MH{space} <: InferenceAlgorithm
@@ -52,7 +53,7 @@ function MH(space...)
         if isa(element, Symbol)
             new_space = (new_space..., element)
         else
-            @assert isa(element[1], Symbol) "[MH] ($element[1]) should be a Symbol. For proposal, use the syntax MH(N, (:m, (x) -> Normal(x, 0.1)))"
+            @assert isa(element[1], Symbol) "[MH] ($element[1]) should be a Symbol. For proposal, use the syntax MH((:m, x -> Normal(x, 0.1)))"
             new_space = (new_space..., element[1])
             proposals[element[1]] = element[2]
         end

--- a/src/inference/mh.jl
+++ b/src/inference/mh.jl
@@ -113,16 +113,13 @@ function step!(
     Turing.DEBUG && @debug "Propose new parameters from proposals..."
     propose(model, spl, spl.state.vi)
 
-    Turing.DEBUG && @debug "computing accept rate α..."
-    is_accept, _ = mh_accept(-old_logp, -getlogp(spl.state.vi), spl.state.proposal_ratio)
+    Turing.DEBUG && @debug "Decide wether to accept..."
+    accepted = !spl.state.violating_support && mh_accept(old_logp, getlogp(spl.state.vi), spl.state.proposal_ratio)
 
-    Turing.DEBUG && @debug "decide wether to accept..."
-    if is_accept && !spl.state.violating_support  # accepted
-        is_accept = true
-    else                      # rejected
-        is_accept = false
-        spl.state.vi[spl] = old_θ         # reset Θ
-        setlogp!(spl.state.vi, old_logp)  # reset logp
+    # reset Θ and logp if the proposal is rejected
+    if !accepted
+        spl.state.vi[spl] = old_θ
+        setlogp!(spl.state.vi, old_logp)
     end
 
     return Transition(spl)

--- a/src/inference/mh.jl
+++ b/src/inference/mh.jl
@@ -114,7 +114,7 @@ function step!(
     Turing.DEBUG && @debug "Propose new parameters from proposals..."
     propose(model, spl, spl.state.vi)
 
-    Turing.DEBUG && @debug "Decide wether to accept..."
+    Turing.DEBUG && @debug "Decide whether to accept..."
     accepted = !spl.state.violating_support && mh_accept(old_logp, getlogp(spl.state.vi), spl.state.proposal_ratio)
 
     # reset Θ and logp if the proposal is rejected


### PR DESCRIPTION
This PR simplifies the acceptance check in MH by only returning if the proposal is accepted or not (the other returned value was always discarded). Moreover, the documentation of the acceptance criterion and the MH algorithm is updated. PMMH is updated as well to keep up with these changes (as far as I understand it's not working at the moment?).

To my big surprise, using `randexp()` instead of `log(rand())` in the MH acceptance criterion leads to 3 test errors. Naively I would have assumed that it might be an advantage to generate exponentially distributed random numbers directly. I added a comment about this observation.

