### PR TITLE
Implement getspace only for instances

### DIFF
--- a/src/Turing.jl
+++ b/src/Turing.jl
@@ -89,8 +89,6 @@ struct SampleFromUniform <: AbstractSampler end
 struct SampleFromPrior <: AbstractSampler end
 
 getspace(::Union{SampleFromPrior, SampleFromUniform}) = ()
-getspace(::Type{<:SampleFromPrior}) = ()
-getspace(::Type{<:SampleFromUniform}) = ()
 
 """
 An abstract type that mutable sampler state structs inherit from.

--- a/src/contrib/inference/dynamichmc.jl
+++ b/src/contrib/inference/dynamichmc.jl
@@ -48,8 +48,7 @@ mutable struct DynamicNUTSState{V<:VarInfo, D} <: AbstractSamplerState
     draws::Vector{D}
 end
 
-getspace(::Type{<:DynamicNUTS{<:Any, space}}) where {space} = space
-getspace(alg::DynamicNUTS{<:Any, space}) where {space} = space
+getspace(::DynamicNUTS{<:Any, space}) where {space} = space
 
 function sample_init!(
     rng::AbstractRNG,

--- a/src/core/RandomVariables.jl
+++ b/src/core/RandomVariables.jl
@@ -450,7 +450,7 @@ Returns a tuple of the unique symbols of random variables sampled in `vi`.
 syms(vi::UntypedVarInfo) = Tuple(unique!(map(vn -> vn.sym, vi.vns)))  # get all symbols
 syms(vi::TypedVarInfo) = keys(vi.metadata)
 
-getspaceval(alg::T) where T = Val(getspace(T))
+getspaceval(alg) = Val(getspace(alg))
 
 # Get all indices of variables belonging to SampleFromPrior:
 #   if the gid/selector of a var is an empty Set, then that var is assumed to be assigned to

--- a/src/inference/Inference.jl
+++ b/src/inference/Inference.jl
@@ -530,7 +530,7 @@ end
 getspace(::Gibbs) = ()
 
 floatof(::Type{T}) where {T <: Real} = typeof(one(T)/one(T))
-floatof(::Type{Any}) = Real # fallback if type inference failed
+floatof(::Type) = Real # fallback if type inference failed
 
 @inline Turing.Core.get_matching_type(spl::Turing.Sampler, vi::Turing.RandomVariables.VarInfo, ::Type{<:AbstractFloat}) = floatof(eltype(vi, spl))
 @inline Turing.Core.get_matching_type(spl::Turing.Sampler{<:Hamiltonian}, vi::Turing.RandomVariables.VarInfo, ::Type{Array{T,N}}) where {T, N} = Array{Turing.Core.get_matching_type(spl, vi, T), N}

--- a/src/inference/Inference.jl
+++ b/src/inference/Inference.jl
@@ -527,9 +527,10 @@ end
 for alg in (:HMC, :HMCDA, :NUTS, :SGLD, :SGHMC)
     @eval getspace(::$alg{<:Any, space}) where {space} = space
 end
-getspace(::Gibbs) = Tuple{}()
+getspace(::Gibbs) = ()
 
-@inline floatof(::Type{T}) where {T <: Real} = typeof(one(T)/one(T))
+floatof(::Type{T}) where {T <: Real} = typeof(one(T)/one(T))
+floatof(::Type{Any}) = Real # fallback if type inference failed
 
 @inline Turing.Core.get_matching_type(spl::Turing.Sampler, vi::Turing.RandomVariables.VarInfo, ::Type{<:AbstractFloat}) = floatof(eltype(vi, spl))
 @inline Turing.Core.get_matching_type(spl::Turing.Sampler{<:Hamiltonian}, vi::Turing.RandomVariables.VarInfo, ::Type{Array{T,N}}) where {T, N} = Array{Turing.Core.get_matching_type(spl, vi, T), N}

--- a/src/inference/Inference.jl
+++ b/src/inference/Inference.jl
@@ -523,14 +523,11 @@ include("../contrib/inference/AdvancedSMCExtensions.jl")
 
 for alg in (:SMC, :PG, :PMMH, :IPMCMC, :MH, :IS)
     @eval getspace(::$alg{space}) where {space} = space
-    @eval getspace(::Type{<:$alg{space}}) where {space} = space
 end
 for alg in (:HMC, :HMCDA, :NUTS, :SGLD, :SGHMC)
     @eval getspace(::$alg{<:Any, space}) where {space} = space
-    @eval getspace(::Type{<:$alg{<:Any, space}}) where {space} = space
 end
 getspace(::Gibbs) = Tuple{}()
-getspace(::Type{<:Gibbs}) = Tuple{}()
 
 @inline floatof(::Type{T}) where {T <: Real} = typeof(one(T)/one(T))
 @inline floatof(::Type) = Real
@@ -661,8 +658,6 @@ end
 # Utilities  #
 ##############
 
-getspace(spl::Sampler) = getspace(typeof(spl))
-getspace(::Type{<:Sampler{Talg}}) where {Talg} = getspace(Talg)
-
+getspace(spl::Sampler) = getspace(spl.alg)
 
 end # module

--- a/src/inference/Inference.jl
+++ b/src/inference/Inference.jl
@@ -530,11 +530,10 @@ end
 getspace(::Gibbs) = Tuple{}()
 
 @inline floatof(::Type{T}) where {T <: Real} = typeof(one(T)/one(T))
-@inline floatof(::Type) = Real
 
-@inline Turing.Core.get_matching_type(spl::Turing.Sampler, vi::Turing.RandomVariables.VarInfo, ::Type{T}) where {T <: AbstractFloat} = floatof(eltype(vi, spl))
-@inline Turing.Core.get_matching_type(spl::Turing.Sampler{<:Hamiltonian}, vi::Turing.RandomVariables.VarInfo, ::Type{TV}) where {T, N, TV <: Array{T, N}} = Array{Turing.Core.get_matching_type(spl, vi, T), N}
-@inline Turing.Core.get_matching_type(spl::Turing.Sampler{<:Union{PG, SMC}}, vi::Turing.RandomVariables.VarInfo, ::Type{TV}) where {T, N, TV <: Array{T, N}} = TArray{T, N}
+@inline Turing.Core.get_matching_type(spl::Turing.Sampler, vi::Turing.RandomVariables.VarInfo, ::Type{<:AbstractFloat}) = floatof(eltype(vi, spl))
+@inline Turing.Core.get_matching_type(spl::Turing.Sampler{<:Hamiltonian}, vi::Turing.RandomVariables.VarInfo, ::Type{Array{T,N}}) where {T, N} = Array{Turing.Core.get_matching_type(spl, vi, T), N}
+@inline Turing.Core.get_matching_type(spl::Turing.Sampler{<:Union{PG, SMC}}, vi::Turing.RandomVariables.VarInfo, ::Type{Array{T,N}}) where {T, N} = TArray{T, N}
 
 ## Fallback functions
 


### PR DESCRIPTION
According to the [Julia documentation](https://docs.julialang.org/en/v1/manual/style-guide/#Avoid-confusion-about-whether-something-is-an-instance-or-a-type-1), one should implement methods only for either instances or types, if possibly. This PR removes unneeded implementations of `getspace` for types.