### PR TITLE
Add space as type parameter to Gibbs sampler

### DIFF
--- a/src/inference/Inference.jl
+++ b/src/inference/Inference.jl
@@ -521,7 +521,7 @@ include("../contrib/inference/AdvancedSMCExtensions.jl")
 # Typing tools #
 ################
 
-for alg in (:SMC, :PG, :PMMH, :IPMCMC, :MH, :IS)
+for alg in (:SMC, :PG, :PMMH, :IPMCMC, :MH, :IS, :Gibbs)
     @eval getspace(::$alg{space}) where {space} = space
     @eval getspace(::Type{<:$alg{space}}) where {space} = space
 end
@@ -529,8 +529,6 @@ for alg in (:HMC, :HMCDA, :NUTS, :SGLD, :SGHMC)
     @eval getspace(::$alg{<:Any, space}) where {space} = space
     @eval getspace(::Type{<:$alg{<:Any, space}}) where {space} = space
 end
-getspace(::Gibbs) = Tuple{}()
-getspace(::Type{<:Gibbs}) = Tuple{}()
 
 @inline floatof(::Type{T}) where {T <: Real} = typeof(one(T)/one(T))
 @inline floatof(::Type) = Real

--- a/src/inference/gibbs.jl
+++ b/src/inference/gibbs.jl
@@ -2,6 +2,8 @@
 ### Gibbs samplers / compositional samplers.
 ###
 
+const GibbsComponent = Union{Hamiltonian,MH,PG}
+
 """
     Gibbs(algs...)
 
@@ -20,7 +22,7 @@ end
 # Use PG for a 'v2' variable, and use HMC for the 'v1' variable.
 # Note that v2 is discrete, so the PG sampler is more appropriate
 # than is HMC.
-alg = Gibbs(HMC(0.2, 3, :v1), PG(20, 1, :v2))
+alg = Gibbs(HMC(0.2, 3, :v1), PG(20, :v2))
 ```
 
 Tips:
@@ -28,11 +30,16 @@ Tips:
 methods like Particle Gibbs. You can increase the effectiveness of particle sampling by including
 more particles in the particle sampler.
 """
-mutable struct Gibbs{A} <: InferenceAlgorithm
-    algs      ::  A   # component sampling algorithms
-    function Gibbs(algs...)
-        return new{typeof(algs)}(algs)
-    end
+struct Gibbs{space, A<:Tuple{Vararg{GibbsComponent}}} <: InferenceAlgorithm
+    algs::A   # component sampling algorithms
+end
+
+function Gibbs(algs::GibbsComponent...)
+    # obtain space of sampling algorithms
+    spacearray = collect(Iterators.flatten(getspace(alg) for alg in algs))::Vector{Symbol}
+    space = ntuple(i -> spacearray[i], length(spacearray))
+
+    Gibbs{space, typeof(algs)}(algs)
 end
 
 alg_str(::Sampler{<:Gibbs}) = "Gibbs"
@@ -49,52 +56,46 @@ mutable struct GibbsState{V<:VarInfo, S<:Tuple{Vararg{Sampler}}} <: AbstractSamp
     samplers::S
 end
 
-function GibbsState(model::Model, samplers::S) where S<:Tuple{Vararg{Sampler}}
+function GibbsState(model::Model, samplers::Tuple{Vararg{Sampler}})
     return GibbsState(VarInfo(model), samplers)
 end
 
-const GibbsComponent = Union{Hamiltonian,MH,PG}
-
 function Sampler(alg::Gibbs, model::Model, s::Selector)
-    info = Dict{Symbol, Any}()
+    # sanity check for space
+    space = getspace(alg)
+    pvars = get_pvars(model)
+    @assert issubset(pvars, space) "[Gibbs] symbols specified to samplers ($space) doesn't cover the model parameters ($pvars)"
 
-    n_samplers = length(alg.algs)
-    samplers = Array{Sampler}(undef, n_samplers)
-    space = Set{Symbol}()
+    if !issetequal(pvars, space)
+        @warn("[Gibbs] extra parameters specified by samplers don't exist in model: $(setdiff(space, pvars))")
+    end
 
-    for i in 1:n_samplers
-        sub_alg = alg.algs[i]
-        if isa(sub_alg, GibbsComponent)
-            samplers[i] = Sampler(sub_alg, model, Selector(Symbol(typeof(sub_alg))))
-        else
-            @error("[Gibbs] Unsupported sampling algorithm $sub_alg")
+    # create tuple of samplers
+    samplers = let algs=alg.algs, model=model
+        ntuple(length(algs)) do i
+            Sampler(algs[i], model, Selector(Symbol(typeof(algs[i]))))
         end
-        space = (space..., getspace(sub_alg)...)
     end
 
-    # Sanity check for space
-    @assert issubset(get_pvars(model), space) "[Gibbs] symbols specified to samplers ($space) doesn't cover the model parameters ($(get_pvars(model)))"
+    # create a state variable
+    state = GibbsState(model, samplers)
 
-    if !(issetequal(get_pvars(model), space))
-        @warn("[Gibbs] extra parameters specified by samplers don't exist in model: $(setdiff(space, get_pvars(model)))")
-    end
-
-    # Create a state variable.
-    state = GibbsState(model, tuple(samplers...))
-
-    # Create the sampler.
+    # create the sampler
+    info = Dict{Symbol, Any}()
     spl = Sampler(alg, info, s, state)
 
-    # Add Gibbs to gids for all variables.
-    for sym in keys(spl.state.vi.metadata)
-        vns = getfield(spl.state.vi.metadata, sym).vns
+    # add Gibbs to gids for all variables
+    vi = spl.state.vi
+    for sym in keys(vi.metadata)
+        vns = getfield(vi.metadata, sym).vns
+
         for vn in vns
-            # Update the gid for the Gibbs sampler.
-            Turing.RandomVariables.updategid!(spl.state.vi, vn, spl)
-            
-            # Try to store each subsampler's gid in the VarInfo.
-            for local_spl in spl.state.samplers
-                Turing.RandomVariables.updategid!(spl.state.vi, vn, local_spl)
+            # update the gid for the Gibbs sampler
+            Turing.RandomVariables.updategid!(vi, vn, spl)
+
+            # try to store each subsampler's gid in the VarInfo
+            for local_spl in samplers
+                Turing.RandomVariables.updategid!(vi, vn, local_spl)
             end
         end
     end
@@ -142,7 +143,6 @@ function step!(
     Turing.DEBUG && @debug "Gibbs stepping..."
 
     time_elapsed = 0.0
-    lp = nothing; ϵ = nothing; eval_num = nothing
 
     # Iterate through each of the samplers.
     for local_spl in spl.state.samplers
@@ -186,9 +186,6 @@ function step!(
     Turing.DEBUG && @debug "Gibbs stepping..."
 
     time_elapsed = 0.0
-    lp = nothing 
-    ϵ = nothing
-    eval_num = nothing
 
     # Iterate through each of the samplers.
     for local_spl in spl.state.samplers

--- a/src/inference/gibbs.jl
+++ b/src/inference/gibbs.jl
@@ -67,10 +67,8 @@ function Sampler(alg::Gibbs, model::Model, s::Selector)
     end
 
     # create tuple of samplers
-    samplers = let algs=alg.algs, model=model
-        ntuple(length(algs)) do i
-            Sampler(algs[i], model, Selector(Symbol(typeof(algs[i]))))
-        end
+    samplers = map(alg.algs) do alg
+        Sampler(alg, model, Selector(Symbol(typeof(alg))))
     end
 
     # create a state variable

--- a/src/inference/gibbs.jl
+++ b/src/inference/gibbs.jl
@@ -36,8 +36,7 @@ end
 
 function Gibbs(algs::GibbsComponent...)
     # obtain space of sampling algorithms
-    spacearray = collect(Iterators.flatten(getspace(alg) for alg in algs))::Vector{Symbol}
-    space = ntuple(i -> spacearray[i], length(spacearray))
+    space = Tuple(union(getspace.(algs)...))
 
     Gibbs{space, typeof(algs)}(algs)
 end


### PR DESCRIPTION
This PR adds a space type parameter to the Gibbs algorithm, similar to the other algorithms. In that way the recomputation of the space can be avoided when a new sampler is constructed. Moreover, the checks of the types of the component algorithms in the constructor of the sampler are not needed anymore since the type parameters of the Gibbs algorithm are restricted to the supported algorithms.