### PR TITLE
Add fallbacks for `alg_str` and `transition_type`

### DIFF
--- a/src/inference/AdvancedSMC.jl
+++ b/src/inference/AdvancedSMC.jl
@@ -269,12 +269,7 @@ function sample_end!(
     spl.state.average_logevidence = loge
 end
 
-function assume(  spl::Sampler{T},
-                  dist::Distribution,
-                  vn::VarName,
-                  _::VarInfo
-                ) where T<:Union{PG,SMC}
-
+function assume(spl::Sampler{<:Union{PG,SMC}}, dist::Distribution, vn::VarName, ::VarInfo)
     vi = current_trace().vi
     if isempty(getspace(spl.alg)) || vn.sym in getspace(spl.alg)
         if ~haskey(vi, vn)
@@ -302,26 +297,23 @@ function assume(  spl::Sampler{T},
     return r, zero(Real)
 end
 
-function assume(  spl::Sampler{A},
-                  dists::Vector{D},
-                  vn::VarName,
-                  var::Any,
-                  vi::VarInfo
-                ) where {A<:Union{PG,SMC},D<:Distribution}
-    error("[Turing] PG and SMC doesn't support vectorizing assume statement")
+function assume(
+    spl::Sampler{<:Union{PG,SMC}},
+    ::Vector{<:Distribution},
+    ::VarName,
+    ::Any,
+    ::VarInfo
+)
+    error("[Turing] $(alg_str(spl)) doesn't support vectorizing assume statement")
 end
 
-function observe(spl::Sampler{T}, dist::Distribution, value, vi) where T<:Union{PG,SMC}
+function observe(spl::Sampler{<:Union{PG,SMC}}, dist::Distribution, value, vi)
     produce(logpdf(dist, value))
     return zero(Real)
 end
 
-function observe( spl::Sampler{A},
-                  ds::Vector{D},
-                  value::Any,
-                  vi::VarInfo
-                ) where {A<:Union{PG,SMC},D<:Distribution}
-    error("[Turing] PG and SMC doesn't support vectorizing observe statement")
+function observe(spl::Sampler{<:Union{PG,SMC}}, ::Vector{<:Distribution}, ::Any, ::VarInfo)
+    error("[Turing] $(alg_str(spl)) doesn't support vectorizing observe statement")
 end
 
 ####

--- a/src/inference/AdvancedSMC.jl
+++ b/src/inference/AdvancedSMC.jl
@@ -57,7 +57,6 @@ struct SMC{space, RT<:AbstractFloat} <: ParticleInference
     resampler_threshold   ::  RT
 end
 
-alg_str(spl::Sampler{SMC}) = "SMC"
 function SMC(
     resampler::Function,
     resampler_threshold::RT,
@@ -175,8 +174,6 @@ PG(n1::Int, ::Tuple{}) = PG(n1)
 function PG(n1::Int, space::Symbol...)
     PG(n1, resample_systematic, space)
 end
-
-alg_str(spl::Sampler{PG}) = "PG"
 
 mutable struct PGState{V<:VarInfo, F<:AbstractFloat} <: AbstractSamplerState
     vi                   ::   V

--- a/src/inference/Inference.jl
+++ b/src/inference/Inference.jl
@@ -104,8 +104,6 @@ function additional_parameters(::Type{<:Transition})
     return [:lp]
 end
 
-Interface.transition_type(::Sampler{alg}) where alg = transition_type(alg)
-
 ##########################################
 # Internal variable names for MCMCChains #
 ##########################################
@@ -540,6 +538,9 @@ getspace(::Type{<:Gibbs}) = Tuple{}()
 @inline Turing.Core.get_matching_type(spl::Turing.Sampler{<:Union{PG, SMC}}, vi::Turing.RandomVariables.VarInfo, ::Type{TV}) where {T, N, TV <: Array{T, N}} = TArray{T, N}
 
 ## Fallback functions
+
+alg_str(spl::Sampler) = string(nameof(typeof(spl.alg)))
+transition_type(spl::Sampler) = typeof(Transition(spl))
 
 # utility funcs for querying sampler information
 require_gradient(spl::Sampler) = false

--- a/src/inference/gibbs.jl
+++ b/src/inference/gibbs.jl
@@ -35,9 +35,6 @@ mutable struct Gibbs{A} <: InferenceAlgorithm
     end
 end
 
-alg_str(::Sampler{<:Gibbs}) = "Gibbs"
-transition_type(spl::Sampler{<:Gibbs}) = typeof(Transition(spl))
-
 """
     GibbsState{V<:VarInfo, S<:Tuple{Vararg{Sampler}}}
 

--- a/src/inference/hmc.jl
+++ b/src/inference/hmc.jl
@@ -433,7 +433,8 @@ gen_traj(alg::NUTS, ϵ) = AHMC.NUTS(AHMC.Leapfrog(ϵ), alg.max_depth, alg.Δ_max
 ####
 #### Compiler interface, i.e. tilde operators.
 ####
-function assume(spl::Sampler{<:Hamiltonian},
+function assume(
+    spl::Sampler{<:Hamiltonian},
     dist::Distribution,
     vn::VarName,
     vi::VarInfo
@@ -449,10 +450,11 @@ function assume(spl::Sampler{<:Hamiltonian},
     return r, logpdf_with_trans(dist, r, istrans(vi, vn))
 end
 
-function assume(spl::Sampler{<:Hamiltonian},
+function assume(
+    spl::Sampler{<:Hamiltonian},
     dists::Vector{<:Distribution},
     vn::VarName,
-    var::Any,
+    var,
     vi::VarInfo
 )
     @assert length(dists) == 1 "[observe] Turing only support vectorizing i.i.d distribution"
@@ -485,16 +487,14 @@ function assume(spl::Sampler{<:Hamiltonian},
     var, sum(logpdf_with_trans(dist, rs, istrans(vi, vns[1])))
 end
 
-observe(spl::Sampler{<:Hamiltonian},
-    d::Distribution,
-    value::Any,
-    vi::VarInfo) = observe(nothing, d, value, vi)
-
-observe(spl::Sampler{<:Hamiltonian},
-    ds::Vector{<:Distribution},
-    value::Any,
-    vi::VarInfo) = observe(nothing, ds, value, vi)
-
+function observe(
+    ::Sampler{<:Hamiltonian},
+    d::Union{Distribution,Vector{<:Distribution}},
+    value,
+    vi::VarInfo
+)
+    return observe(d, value, vi)
+end
 
 ####
 #### Default HMC stepsize and mass matrix adaptor

--- a/src/inference/hmc.jl
+++ b/src/inference/hmc.jl
@@ -79,7 +79,6 @@ mutable struct HMC{AD, space, metricT <: AHMC.AbstractMetric} <: StaticHamiltoni
     n_leapfrog  ::  Int       # leapfrog step number
 end
 
-transition_type(::Sampler{<:Hamiltonian}) = Transition
 alg_str(::Sampler{<:Hamiltonian}) = "HMC"
 
 HMC(args...) = HMC{ADBackend()}(args...)

--- a/src/inference/is.jl
+++ b/src/inference/is.jl
@@ -30,8 +30,6 @@ sample(gdemo([1.5, 2]), IS(), 1000)
 struct IS{space} <: InferenceAlgorithm end
 
 IS() = IS{()}()
-transition_type(spl::Sampler{<:IS}) = typeof(Transition(spl))
-alg_str(::Sampler{<:IS}) = "IS"
 
 mutable struct ISState{V<:VarInfo, F<:AbstractFloat} <: AbstractSamplerState
     vi                 ::  V

--- a/src/inference/is.jl
+++ b/src/inference/is.jl
@@ -75,7 +75,7 @@ function assume(spl::Sampler{<:IS}, dist::Distribution, vn::VarName, vi::VarInfo
     r, zero(Real)
 end
 
-function observe(spl::Sampler{<:IS}, dist::Distribution, value::Any, vi::VarInfo)
+function observe(spl::Sampler{<:IS}, dist::Distribution, value, vi::VarInfo)
     # acclogp!(vi, logpdf(dist, value))
     logpdf(dist, value)
 end

--- a/src/inference/mh.jl
+++ b/src/inference/mh.jl
@@ -36,9 +36,6 @@ mutable struct MH{space} <: InferenceAlgorithm
     proposals ::  Dict{Symbol,Any}  # Proposals for paramters
 end
 
-transition_type(spl::Sampler{<:MH}) = typeof(Transition(spl))
-alg_str(::Sampler{<:MH}) = "MH"
-
 function MH(proposals::Dict{Symbol, Any}, space::Tuple)
     return MH{space}(proposals)
 end

--- a/src/inference/mh.jl
+++ b/src/inference/mh.jl
@@ -168,23 +168,15 @@ function assume(spl::Sampler{<:MH}, dist::Distribution, vn::VarName, vi::VarInfo
     r, logpdf(dist, r)
 end
 
-function assume(  spl::Sampler{<:MH},
-                  dists::Vector{D},
-                  vn::VarName,
-                  var::Any,
-                  vi::VarInfo
-                ) where D<:Distribution
+function assume(::Sampler{<:MH}, ::Vector{<:Distribution}, ::VarName, ::Any, ::VarInfo)
     error("[Turing] MH doesn't support vectorizing assume statement")
 end
 
-function observe(spl::Sampler{<:MH}, d::Distribution, value::Any, vi::VarInfo)
-    return observe(nothing, d, value, vi)  # accumulate pdf of likelihood
-end
-
-function observe( spl::Sampler{<:MH},
-                  ds::Vector{D},
-                  value::Any,
-                  vi::VarInfo
-                )  where D<:Distribution
-    return observe(nothing, ds, value, vi) # accumulate pdf of likelihood
+function observe(
+    spl::Sampler{<:MH},
+    d::Union{Distribution,Vector{<:Distribution}},
+    value,
+    vi::VarInfo
+)
+    return observe(d, value, vi)  # accumulate pdf of likelihood
 end

--- a/src/interface/Interface.jl
+++ b/src/interface/Interface.jl
@@ -432,12 +432,12 @@ function callback(
 end
 
 """
-    transition_type(s::AbstractSampler)
+    transition_type(::AbstractSampler)
 
-Return the type of `AbstractTransition` that is to be returned by an 
-`AbstractSampler` after each `step!` call. 
+Return the type of `AbstractTransition` that is to be returned by an
+`AbstractSampler` after each `step!` call.
 """
-transition_type(s::AbstractSampler) = AbstractTransition
+transition_type(::AbstractSampler) = AbstractTransition
 
 """
     psample(ℓ::ModelType, s::SamplerType, N::Integer, n_chains::Integer; kwargs...)


### PR DESCRIPTION
This PR adds generic fallbacks for `alg_str` and `transition_type` that allow to remove most of the algorithm-specific implementations. Moreover, the type signatures of `assume` and `observe` are simplified. Additionally I removed the `assume` method that dispatches on `Nothing` (replacing it by a method without sampler argument, and addressing https://github.com/TuringLang/Turing.jl/issues/504#issue-358044985); in the tests I ran that seemed to work after adjusting some calls with `nothing`.