### PR TITLE
Reduce version number

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Turing"
 uuid = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-version = "0.7.5"
+version = "0.7.4"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"


### PR DESCRIPTION
Well, apparently we hadn't release 0.7.4 yet, so I'll need to go back to 0.7.4. Sorry for the noise, folks.