### PR TITLE
Update website

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -72,6 +72,9 @@ collections:
   tutorials:
     output: true
     permalink: /:collection/:path
+  posts:
+    output: true
+    permalink: /:collection/:path
 
 # Defaults
 defaults:

--- a/docs/_data/toc.yml
+++ b/docs/_data/toc.yml
@@ -63,6 +63,10 @@
   children:
     - title: "Public"
       url: "docs/library"
+    - title: "AdvancedHMC"
+      url: "docs/library/advancedhmc/"
+    - title: "Bijectors"
+      url: "docs/library/bijectors/"
 
 - title: "CONTRIBUTING"
   url: "docs/contributing/guide"

--- a/docs/_data/toc.yml
+++ b/docs/_data/toc.yml
@@ -61,7 +61,7 @@
 - title: "API"
   url: "docs/library"
   children:
-    - title: "Public"
+    - title: "Turing"
       url: "docs/library"
     - title: "AdvancedHMC"
       url: "docs/library/advancedhmc/"

--- a/docs/_includes/navigation.html
+++ b/docs/_includes/navigation.html
@@ -40,7 +40,7 @@
 
                 <div class="md-flex__cell md-flex__cell--shrink">
                   <div class="md-header-nav__source">
-                    <a class="md-source" href="{{ site.baseurl }}/docs/using-turing/get-started" title="Go to Get Started">
+                    <a class="md-source" href="{{ site.baseurl }}/docs/using-turing/get-started" title="Get started">
                       Get Started
                     </a>
                   </div>
@@ -48,7 +48,7 @@
 
                 <div class="md-flex__cell md-flex__cell--shrink">
                     <div class="md-header-nav__source">
-                      <a class="md-source" href="{{ site.baseurl }}/docs/using-turing/" title="Go to Documentation">
+                      <a class="md-source" href="{{ site.baseurl }}/docs/using-turing/" title="View documentation">
                         Documentation
                       </a>
                     </div>
@@ -56,8 +56,16 @@
 
                   <div class="md-flex__cell md-flex__cell--shrink">
                       <div class="md-header-nav__source">
-                        <a class="md-source" href="{{ site.baseurl }}/tutorials/" title="Go to Tutorial">
+                        <a class="md-source" href="{{ site.baseurl }}/tutorials/" title="View tutorials">
                           Tutorials
+                        </a>
+                      </div>
+                    </div>
+
+                    <div class="md-flex__cell md-flex__cell--shrink">
+                      <div class="md-header-nav__source">
+                        <a class="md-source" href="{{ site.baseurl }}/news/" title="News">
+                          News
                         </a>
                       </div>
                     </div>

--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -4,5 +4,6 @@ layout: page
 
 <h1 style="margin-bottom:0px">{{ page.title }}</h1>
 {% if page.badges %}{% for badge in page.badges %}<span class="badge badge-{{ badge.type }}">{{ badge.tag }}</span>{% endfor %}{% endif %}
+{% if page.author %} <span class"author"> {{ page.author }} </span> <br>{% endif %}
 <span class="post-date" style="font-style: italic;">{{ page.date | date: "%B %d, %Y" }}</span>
 {{ content }}

--- a/docs/_posts/.POSTING_GUIDE.MD
+++ b/docs/_posts/.POSTING_GUIDE.MD
@@ -1,0 +1,12 @@
+# How to write a blog post.
+
+1. Place all blog posts as markdown files in `docs/_posts`.
+2. Make sure you use the naming convention "YYYY-MM-DD-some-short-title.md".
+3. Include a YAML header in the very first line with the flags `title` and `author`, here's an example:
+
+```yaml
+---
+title: Turing's Blog
+author: Cameron Pfiffer
+---
+```

--- a/docs/_posts/2019-12-14-initial-post.md
+++ b/docs/_posts/2019-12-14-initial-post.md
@@ -1,0 +1,14 @@
+---
+title: Turing's Blog
+author: Cameron Pfiffer
+---
+
+All good open source projects should have a blog, and Turing is one such project. Later on, members of the Turing team may be populating this feed with posts on topics like
+
+- Interesting things you can do with Turing, or interesting things we have seen others do.
+- Development updates and major release announcements.
+- Research updates.
+- Explorations of Turing's internals.
+- Updates to Turing's sattelite projects [AdvancedHMC.jl](https://github.com/TuringLang/AdvancedHMC.jl) or [Bijectors.jl](https://github.com/TuringLang/Bijectors.jl).
+
+Stay tuned!

--- a/docs/assets/css/index.css
+++ b/docs/assets/css/index.css
@@ -75,8 +75,8 @@ body {
 }
 
 .swimlane {
-    padding-top: 6rem;
-    padding-bottom: 6rem;
+    padding-top: 0.2rem;
+    padding-bottom: 0.2rem;
 }
 
 .md-typeset h2 {

--- a/docs/make-utils.jl
+++ b/docs/make-utils.jl
@@ -171,7 +171,11 @@ function postprocess_markdown(folder, yaml_dict; original = "")
                             write(f, line)
                         end
 
+                        # This is needed to replace the hyperlinks Documenter.jl generates
+                        # for the API pages.
 						txt = replace(txt, "api.md" => "{{site.baseurl}}/docs/library/")
+						txt = replace(txt, "bijectors.md" => "{{site.baseurl}}/docs/library/bijectors/")
+						txt = replace(txt, "advancedhmc.md" => "{{site.baseurl}}/docs/library/advancedhmc/")
 
                         # Add the rest of the text.
 						if original_path == full_path

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,4 @@
-using Documenter, DocumenterMarkdown, Turing
+using Documenter, DocumenterMarkdown, Turing, AdvancedHMC, Bijectors
 using LibGit2: clone
 
 # Include the utility functions.

--- a/docs/pages/index.html
+++ b/docs/pages/index.html
@@ -136,6 +136,31 @@ support:
   </div>
 </div>
 
+<!-- A Quick Example -->
+<div class="swimlane">
+  <div class="container">
+    <div class="row">
+      <div class="col-xl-2"></div>
+      <div class="col-sm-6 col-md-8 col-xl-6">
+        <div class="archive__item-body  text-left">
+          <h2 class="archive__item-title" >News feed</h2>
+          <div class="archive__item-excerpt">
+            
+          </div>
+          {% for post in site.posts limit:10 %}
+              <div class="post-preview">
+              <a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }} —
+              <span class="post-date">{{ post.date | date: "%B %d, %Y" }}</span></a> <br>
+              </div>
+              <hr>
+          {% endfor %}
+          <p><a href="{{ site.baseurl}}/news" class="btn btn-default">News</a></p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
 <!-- Large Sampling Library -->
  <div class="swimlane">
   <div class="container">

--- a/docs/pages/news.md
+++ b/docs/pages/news.md
@@ -5,20 +5,15 @@ permalink: /news/
 
 # News
 
-<p>Subscribe with <a href="{{ site.baseurl }}/feed.xml">RSS</a> to keep up with the latest news.
-For site changes, see the <a href="https://github.com/{{ site.github_user }}/{{ site.github_repo }}/blob/master/CHANGELOG.md">changelog</a> kept with the code base.</p>
-
-<p class="editor-link"><a href="cloudcannon:collections/_posts" class="btn"><strong>&#9998;</strong> Update Change Log</a></p>
+<p>Subscribe with <a href="{{ site.baseurl }}/feed.xml">RSS</a> to keep up with the latest news about Turing.
 
 {% for post in site.posts limit:10 %}
    <div class="post-preview">
    <h2><a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></h2>
    <span class="post-date">{{ post.date | date: "%B %d, %Y" }}</span><br>
    {% if post.badges %}{% for badge in post.badges %}<span class="badge badge-{{ badge.type }}">{{ badge.tag }}</span>{% endfor %}{% endif %}
-   {{ post.content | split:'<!--more-->' | first }}
-   {% if post.content contains '<!--more-->' %}
-      <a href="{{ site.baseurl }}{{ post.url }}">read more</a>
-   {% endif %}
+   {{ post.excerpt }}
+   <a href="{{ site.baseurl }}{{ post.url }}">read more</a>
    </div>
    <hr>
 {% endfor %}

--- a/docs/src/library/advancedhmc.md
+++ b/docs/src/library/advancedhmc.md
@@ -1,0 +1,25 @@
+---
+title: AdvancedHMC
+permalink: /docs/library/advancedhmc/
+toc: true
+---
+
+## Index
+
+```@index
+Modules = [AdvancedHMC]
+```
+
+## Functions
+
+```@autodocs
+Modules = [AdvancedHMC]
+Order   = [:function]
+```
+
+## Types
+
+```@autodocs
+Modules = [AdvancedHMC]
+Order   = [:type]
+```

--- a/docs/src/library/api.md
+++ b/docs/src/library/api.md
@@ -10,6 +10,7 @@ CurrentModule = Turing
 ## Index
 
 ```@index
+Modules = [Turing, Turing.Core, Turing.Inference, Libtask]
 ```
 
 ## Modelling
@@ -25,14 +26,10 @@ Sampler
 Gibbs
 HMC
 HMCDA
-IPMCMC
 IS
 MH
 NUTS
 PG
-PMMH
-SGHMC
-SGLD
 SMC
 ```
 

--- a/docs/src/library/bijectors.md
+++ b/docs/src/library/bijectors.md
@@ -1,0 +1,25 @@
+---
+title: Bijectors
+permalink: /docs/library/bijectors/
+toc: true
+---
+
+## Index
+
+```@index
+Modules = [Bijectors]
+```
+
+## Functions
+
+```@autodocs
+Modules = [Bijectors]
+Order   = [:function]
+```
+
+## Types
+
+```@autodocs
+Modules = [Bijectors]
+Order   = [:type]
+```


### PR DESCRIPTION
Summary of changes:

- Adds a blog page called "News" where we can store blog posts and stuff. 
- Adds a blog feed to the splash page so people can click on blog posts.
- Reduces the padding for some of the boxes on the splash page to reduce footprint.
- Includes Bijectors.jl and AdvancedHMC.jl documentation in their own pages under the "Library" header in the documentation. By default these will print out all functions and types with docstrings, so @xukai92 and @torfjelde can just write docstrings and they'll show up on the site.

If you want to write a blog post, there's a little document in `docs/_posts/.POSTING_GUIDE.md` which describes the very brief steps you need to take to get a post up and running.