### PR TITLE
Add `sorted=true` in Chain constructor

### DIFF
--- a/src/inference/Inference.jl
+++ b/src/inference/Inference.jl
@@ -433,7 +433,8 @@ function AbstractMCMC.bundle_samples(
         string.(nms),
         deepcopy(TURING_INTERNAL_VARS);
         evidence=le,
-        info=info
+        info=info,
+        sorted=true
     )
 end
 


### PR DESCRIPTION
I am planning on removing the sort-by-default functionality in MCMCChains, so this PR just adds a keyword to make sure Turing keeps its current behavior.