### PR TITLE
Set up Ruby before building the documentation

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -16,9 +16,14 @@ jobs:
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v1.0.0
-      - uses: julia-actions/setup-julia@latest
+      - name: Set up Julia
+        uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.julia-version }}
+      - name: Set up Ruby 2.6
+        uses: actions/setup-ruby@v1
+        with:
+          version: 2.6.x
       - name: Install dependencies
         run: julia --project=docs -e 'using Pkg; Pkg.instantiate()'
       - name: Build and deploy


### PR DESCRIPTION
It seems (https://github.com/TuringLang/Turing.jl/runs/352510154) Ruby dependencies required for building the documentation are not installed. Hopefully this change is sufficient (see https://github.com/actions/setup-ruby).