### PR TITLE
Replace deprecated option

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Ruby 2.6
         uses: actions/setup-ruby@v1
         with:
-          version: 2.6.x
+          ruby-version: '2.6.x'
       - name: Install dependencies
         run: julia --project=docs -e 'using Pkg; Pkg.instantiate()'
       - name: Build and deploy


### PR DESCRIPTION
It seems the changes introduced by https://github.com/TuringLang/Turing.jl/pull/1029 work, but somehow I used a deprecated option. According to the [README](https://github.com/actions/setup-ruby) the version in this PR should be correct.