### PR TITLE
Do not allow `nothing` as sampler

### DIFF
--- a/src/inference/Inference.jl
+++ b/src/inference/Inference.jl
@@ -610,15 +610,6 @@ function observe(spl::Sampler, weight)
     error("Turing.observe: unmanaged inference algorithm: $(typeof(spl))")
 end
 
-## Default definitions for assume, observe, when sampler = nothing.
-function assume(
-    ::Nothing,
-    dist::Distribution,
-    vn::VarName,
-    vi::VarInfo,
-)
-    return assume(SampleFromPrior(), dist, vn, vi)
-end
 function assume(
     spl::Union{SampleFromPrior, SampleFromUniform},
     dist::Distribution,
@@ -638,14 +629,6 @@ function assume(
     return r, logpdf_with_trans(dist, r, istrans(vi, vn))
 end
 
-function observe(
-    ::Nothing,
-    dist::Distribution,
-    value,
-    vi::VarInfo,
-)
-    return observe(SampleFromPrior(), dist, value, vi)
-end
 function observe(
     spl::Union{SampleFromPrior, SampleFromUniform},
     dist::Distribution,
@@ -798,14 +781,6 @@ function _dot_tilde(sampler, right, left::AbstractArray, vi)
     return dot_observe(sampler, right, left, vi)
 end
 
-function dot_observe(
-    ::Nothing,
-    dist::Union{Distribution, AbstractArray{<:Distribution}},
-    value, 
-    vi::VarInfo,
-)
-    return dot_observe(SampleFromPrior(), dist, value, vi)
-end
 function dot_observe(
     spl::Union{SampleFromPrior, SampleFromUniform},
     dist::MultivariateDistribution,

--- a/src/inference/hmc.jl
+++ b/src/inference/hmc.jl
@@ -488,7 +488,7 @@ function observe(
     value,
     vi::VarInfo,
 )
-    return observe(nothing, d, value, vi)
+    return observe(SampleFromPrior(), d, value, vi)
 end
 
 function dot_observe(
@@ -497,7 +497,7 @@ function dot_observe(
     value::AbstractArray,
     vi::VarInfo,
 )
-    return dot_observe(nothing, ds, value, vi)
+    return dot_observe(SampleFromPrior(), ds, value, vi)
 end
 
 ####

--- a/src/inference/mh.jl
+++ b/src/inference/mh.jl
@@ -159,7 +159,7 @@ function assume(spl::Sampler{<:MH}, dist::Distribution, vn::VarName, vi::VarInfo
 end
 
 function observe(spl::Sampler{<:MH}, d::Distribution, value, vi::VarInfo)
-    return observe(nothing, d, value, vi)  # accumulate pdf of likelihood
+    return observe(SampleFromPrior(), d, value, vi)  # accumulate pdf of likelihood
 end
 
 function dot_observe(
@@ -168,5 +168,5 @@ function dot_observe(
     value,
     vi::VarInfo,
 )
-    return dot_observe(nothing, ds, value, vi) # accumulate pdf of likelihood
+    return dot_observe(SampleFromPrior(), ds, value, vi) # accumulate pdf of likelihood
 end


### PR DESCRIPTION
In https://github.com/TuringLang/Turing.jl/pull/995 the support of `nothing` as a sampler was removed, but this change was reverted by the compiler changes in https://github.com/TuringLang/Turing.jl/pull/965. In contrast to the previous approach, with this PR the interface for `assume` and `observe` always expects a sampler as first argument but `nothing` is not allowed anymore. Instead one has to specify `SampleFromPrior()` explicitly, which IMO is also more informative.