### PR TITLE
Make _params_to_array faster

### DIFF
--- a/src/inference/Inference.jl
+++ b/src/inference/Inference.jl
@@ -242,7 +242,7 @@ end
 function _params_to_array(ts::Vector{<:AbstractTransition}, spl::Sampler)
     names_set = Set{String}()
     # Extract the parameter names and values from each transition.
-    dicts = map(enumerate(ts)) do (i, t)
+    dicts = map(ts) do t
         nms, vs = flatten_namedtuple(t.θ)
         for nm in nms
             push!(names_set, nm)
@@ -257,8 +257,8 @@ function _params_to_array(ts::Vector{<:AbstractTransition}, spl::Sampler)
     return names, vals
 end
 
-function flatten_namedtuple(nt::NamedTuple{pnames}) where {pnames}
-    temp = map(keys(nt)) do k
+function flatten_namedtuple(nt::NamedTuple)
+    names_vals = mapreduce(vcat, keys(nt)) do k
         v = nt[k]
         if length(v) == 1
             return [(string(k), v)]
@@ -268,7 +268,6 @@ function flatten_namedtuple(nt::NamedTuple{pnames}) where {pnames}
             end
         end
     end
-    names_vals = vcat(temp...)
     return [vn[1] for vn in names_vals], [vn[2] for vn in names_vals]
 end
 

--- a/src/inference/Inference.jl
+++ b/src/inference/Inference.jl
@@ -240,85 +240,37 @@ end
 ##########################
 
 function _params_to_array(ts::Vector{<:AbstractTransition}, spl::Sampler)
-    names = Set{String}()
-    dicts = Vector{Dict{String, Any}}()
-
+    names_set = Set{String}()
     # Extract the parameter names and values from each transition.
-    for t in ts
+    dicts = map(enumerate(ts)) do (i, t)
         nms, vs = flatten_namedtuple(t.θ)
-        push!(names, nms...)
-
+        for nm in nms
+            push!(names_set, nm)
+        end
         # Convert the names and values to a single dictionary.
-        d = Dict{String, Any}()
-        for (k, v) in zip(nms, vs)
-            d[k] = v
-        end
-        push!(dicts, d)
+        return Dict(nms[j] => vs[j] for j in 1:length(vs))
     end
-
-    # Convert the set to an ordered vector so the parameter ordering
-    # is deterministic.
-    ordered_names = collect(names)
-    vals = Matrix{Union{Real, Missing}}(undef, length(ts), length(ordered_names))
-
-    # Place each element of all dicts into the returned value matrix.
-    for i in eachindex(dicts)
-        for (j, key) in enumerate(ordered_names)
-            vals[i,j] = get(dicts[i], key, missing)
-        end
-    end
-
-    return ordered_names, vals
-end
-
-function flatten_namedtuple(nt::NamedTuple{pnames}) where {pnames}
-    vals = Vector{Real}()
-    names = Vector{AbstractString}()
-
-    for k in pnames
-        v = nt[k]
-        if length(v) == 1
-            flatten(names, vals, string(k), v)
-        else
-            for (vnval, vn) in zip(v[1], v[2])
-                flatten(names, vals, vn, vnval)
-            end
-        end
-    end
+    names = collect(names_set)
+    vals = [get(dicts[i], key, missing) for i in eachindex(dicts), 
+        (j, key) in enumerate(names)]
 
     return names, vals
 end
 
-function flatten(names, value :: AbstractArray, k :: String, v)
-    if isa(v, Number)
-        name = k
-        push!(value, v)
-        push!(names, name)
-    elseif isa(v, Array)
-        for i = eachindex(v)
-            if isa(v[i], Number)
-                name = string(ind2sub(size(v), i))
-                name = replace(name, "(" => "[");
-                name = replace(name, ",)" => "]");
-                name = replace(name, ")" => "]");
-                name = k * name
-                isa(v[i], Nothing) && println(v, i, v[i])
-                push!(value, v[i])
-                push!(names, name)
-            elseif isa(v[i], AbstractArray)
-                name = k * string(ind2sub(size(v), i))
-                flatten(names, value, name, v[i])
-            else
-                error("Unknown var type: typeof($v[i])=$(typeof(v[i]))")
+function flatten_namedtuple(nt::NamedTuple{pnames}) where {pnames}
+    temp = map(keys(nt)) do k
+        v = nt[k]
+        if length(v) == 1
+            return [(string(k), v)]
+        else
+            return mapreduce(vcat, zip(v[1], v[2])) do (vnval, vn)
+                return [i for i in FlattenIterator(vn, vnval)]
             end
         end
-    else
-        error("Unknown var type: typeof($v)=$(typeof(v))")
     end
-    return
+    names_vals = vcat(temp...)
+    return [vn[1] for vn in names_vals], [vn[2] for vn in names_vals]
 end
-
-ind2sub(v, i) = Tuple(CartesianIndices(v)[i])
 
 function get_transition_extras(ts::Vector{<:AbstractTransition})
     # Get the extra field names from the sampler state type.
@@ -384,7 +336,7 @@ function AbstractMCMC.bundle_samples(
     extra_params, extra_values = get_transition_extras(ts)
 
     # Extract names & construct param array.
-    nms = string.(vcat(nms..., string.(extra_params)...))
+    nms = [nms; extra_params]
     parray = hcat(vals, extra_values)
 
     # If the state field has average_logevidence or final_logevidence, grab that.
@@ -759,6 +711,7 @@ function dot_assume(
     vi::VarInfo,
 )
     r = get_and_set_val!(vi, vns, dists, spl)
+    # Make sure `r` is not a matrix for multivariate distributions
     lp = sum(logpdf_with_trans.(dists, r, istrans(vi, vns[1])))
     var .= r
     return var, lp

--- a/src/inference/Inference.jl
+++ b/src/inference/Inference.jl
@@ -264,7 +264,7 @@ function flatten_namedtuple(nt::NamedTuple{pnames}) where {pnames}
             return [(string(k), v)]
         else
             return mapreduce(vcat, zip(v[1], v[2])) do (vnval, vn)
-                return [i for i in FlattenIterator(vn, vnval)]
+                return collect(FlattenIterator(vn, vnval))
             end
         end
     end

--- a/src/utilities/Utilities.jl
+++ b/src/utilities/Utilities.jl
@@ -13,8 +13,10 @@ export  vectorize,
         Chain,
         init,
         vectorize,
-        set_resume!
+        set_resume!,
+        FlattenIterator
 
 include("robustinit.jl")
+include("helper.jl")
 
 end # module

--- a/src/utilities/helper.jl
+++ b/src/utilities/helper.jl
@@ -3,12 +3,13 @@ struct FlattenIterator{Tname, Tvalue}
     value::Tvalue
 end
 
-Base.length(iter::FlattenIterator) where {T} = _length(iter.value)
-@inline _length(a::AbstractArray) = sum(_length, a)
+Base.length(iter::FlattenIterator) = _length(iter.value)
+_length(a::AbstractArray) = sum(_length, a)
+_length(a::AbstractArray{<:Number}) = length(a)
 @inline _length(::Number) = 1
 
 Base.eltype(iter::FlattenIterator{String}) = Tuple{String, _eltype(typeof(iter.value))}
-@inline _eltype(::Type{TA}) where {T, TA <: AbstractArray{T}} = _eltype(T)
+_eltype(::Type{TA}) where {TA <: AbstractArray} = _eltype(eltype(TA))
 @inline _eltype(::Type{T}) where {T <: Number} = T
 
 @inline function Base.iterate(iter::FlattenIterator{String, <:Number}, i = 1)

--- a/src/utilities/helper.jl
+++ b/src/utilities/helper.jl
@@ -1,0 +1,50 @@
+struct FlattenIterator{Tname, Tvalue}
+    name::Tname
+    value::Tvalue
+end
+
+Base.length(iter::FlattenIterator) where {T} = _length(iter.value)
+@inline _length(a::AbstractArray) = sum(_length, a)
+@inline _length(::Number) = 1
+
+@inline function Base.iterate(iter::FlattenIterator{String, <:Number}, i = 1)
+    i === 1 && return (iter.name, iter.value), 2
+    return nothing
+end
+@inline function Base.iterate(iter::FlattenIterator{String, T}, ind = (1,)) where {T <: AbstractArray{<:Number}}
+    i = ind[1]
+    i > length(iter.value) && return nothing
+    name = getname(iter, i)
+    return (name, iter.value[i]), (i+1,)
+end
+@inline function Base.iterate(iter::FlattenIterator{String, T}, ind = startind(T)) where {T <: AbstractArray}
+    @show ind
+    i = ind[1]
+    i > length(iter.value) && return nothing
+    name = getname(iter, i)
+    local out
+    while i <= length(iter.value)
+        v = iter.value[i]
+        out = iterate(FlattenIterator(name, v), Base.tail(ind))
+        out !== nothing && break
+        i += 1
+    end
+    if out === nothing
+        return nothing
+    else
+        return out[1], (i, out[2]...)
+    end
+end
+
+startind(::Type{<:AbstractArray{T}}) where {T} = (1, startind(T)...)
+startind(::Type{<:Number}) = ()
+startind(::Type{<:Any}) = throw("Type not supported.")
+function getname(iter::FlattenIterator, i::Int)
+    name = string(ind2sub(size(iter.value), i))
+    name = replace(name, "(" => "[");
+    name = replace(name, ",)" => "]");
+    name = replace(name, ")" => "]");
+    name = iter.name * name
+    return name
+end
+ind2sub(v, i) = Tuple(CartesianIndices(v)[i])

--- a/src/utilities/helper.jl
+++ b/src/utilities/helper.jl
@@ -7,6 +7,10 @@ Base.length(iter::FlattenIterator) where {T} = _length(iter.value)
 @inline _length(a::AbstractArray) = sum(_length, a)
 @inline _length(::Number) = 1
 
+Base.eltype(iter::FlattenIterator{String}) = Tuple{String, _eltype(typeof(iter.value))}
+@inline _eltype(::Type{TA}) where {T, TA <: AbstractArray{T}} = _eltype(T)
+@inline _eltype(::Type{T}) where {T <: Number} = T
+
 @inline function Base.iterate(iter::FlattenIterator{String, <:Number}, i = 1)
     i === 1 && return (iter.name, iter.value), 2
     return nothing

--- a/src/utilities/helper.jl
+++ b/src/utilities/helper.jl
@@ -11,14 +11,19 @@ Base.length(iter::FlattenIterator) where {T} = _length(iter.value)
     i === 1 && return (iter.name, iter.value), 2
     return nothing
 end
-@inline function Base.iterate(iter::FlattenIterator{String, T}, ind = (1,)) where {T <: AbstractArray{<:Number}}
+@inline function Base.iterate(
+    iter::FlattenIterator{String, <:AbstractArray{<:Number}}, 
+    ind = (1,),
+)
     i = ind[1]
     i > length(iter.value) && return nothing
     name = getname(iter, i)
     return (name, iter.value[i]), (i+1,)
 end
-@inline function Base.iterate(iter::FlattenIterator{String, T}, ind = startind(T)) where {T <: AbstractArray}
-    @show ind
+@inline function Base.iterate(
+    iter::FlattenIterator{String, T},
+    ind = startind(T),
+) where {T <: AbstractArray}
     i = ind[1]
     i > length(iter.value) && return nothing
     name = getname(iter, i)
@@ -36,10 +41,10 @@ end
     end
 end
 
-startind(::Type{<:AbstractArray{T}}) where {T} = (1, startind(T)...)
-startind(::Type{<:Number}) = ()
-startind(::Type{<:Any}) = throw("Type not supported.")
-function getname(iter::FlattenIterator, i::Int)
+@inline startind(::Type{<:AbstractArray{T}}) where {T} = (1, startind(T)...)
+@inline startind(::Type{<:Number}) = ()
+@inline startind(::Type{<:Any}) = throw("Type not supported.")
+@inline function getname(iter::FlattenIterator, i::Int)
     name = string(ind2sub(size(iter.value), i))
     name = replace(name, "(" => "[");
     name = replace(name, ",)" => "]");
@@ -47,4 +52,4 @@ function getname(iter::FlattenIterator, i::Int)
     name = iter.name * name
     return name
 end
-ind2sub(v, i) = Tuple(CartesianIndices(v)[i])
+@inline ind2sub(v, i) = Tuple(CartesianIndices(v)[i])

--- a/src/utilities/helper.jl
+++ b/src/utilities/helper.jl
@@ -6,11 +6,11 @@ end
 Base.length(iter::FlattenIterator) = _length(iter.value)
 _length(a::AbstractArray) = sum(_length, a)
 _length(a::AbstractArray{<:Number}) = length(a)
-@inline _length(::Number) = 1
+_length(::Number) = 1
 
 Base.eltype(iter::FlattenIterator{String}) = Tuple{String, _eltype(typeof(iter.value))}
 _eltype(::Type{TA}) where {TA <: AbstractArray} = _eltype(eltype(TA))
-@inline _eltype(::Type{T}) where {T <: Number} = T
+_eltype(::Type{T}) where {T <: Number} = T
 
 @inline function Base.iterate(iter::FlattenIterator{String, <:Number}, i = 1)
     i === 1 && return (iter.name, iter.value), 2


### PR DESCRIPTION
This PR optimizes the `_params_to_array` function. In the following example, the running time of `sample` was cut down from 22 s to 8 s. Of these times, < 2 s is spent doing the sampling and the rest is saving the chain. There is a lot of room for improvement here. The 50000 iterations case terminates in 134 s now of which 16 s is sampling. Before this PR, it was too slow to even wait and time it.

```julia
using Turing

fake_dat = [5*ones(Int64, 30) for j=1:18]
fake_N = fill(5*30, 18) #Total N

@model multinomial_RE(data, N, ::Type{T}=Vector{Float64}) where {T} = begin
    B = length(data)
    R = length(data[1,1])
    theta = [T(undef, R) for j = 1:B]
    beta ~ Dirichlet(R, 1)
    alpha ~ truncated(Normal(1, 100), 0, Inf)
    for b in 1:B
    	theta[b] ~ Dirichlet(beta * alpha)
    	if any(isnan, theta[b])
    		@logpdf() = -Inf
    		return
    	end
    	data[b] ~ Multinomial(N[b], theta[b])
    end
end
model2 = sample(multinomial_RE(fake_dat, fake_N), MH(), 5000);
@time model2 = sample(multinomial_RE(fake_dat, fake_N), MH(), 5000);
```