### PR TITLE
Use preferred `truncated` instead of `Truncated`

### DIFF
--- a/docs/src/using-turing/performancetips.md
+++ b/docs/src/using-turing/performancetips.md
@@ -56,7 +56,7 @@ The following example:
     p,n = size(x)
     params = Vector{Real}(undef, n)
     for i = 1:n
-        params[i] ~ Truncated(Normal(), 0, Inf)
+        params[i] ~ truncated(Normal(), 0, Inf)
     end
 
     a = x * params
@@ -70,7 +70,7 @@ can be transformed into the following type-stable representation:
     p,n = size(x)
     params = T(undef, n)
     for i = 1:n
-        params[i] ~ Truncated(Normal(), 0, Inf)
+        params[i] ~ truncated(Normal(), 0, Inf)
     end
 
     a = x * params
@@ -93,11 +93,11 @@ end
 we can use
 
 ```julia
-m = tmodel(1.0);
-varinfo = Turing.VarInfo(model);
-spl = Turing.SampleFromPrior();
+model = tmodel(1.0)
+varinfo = Turing.VarInfo(model)
+spl = Turing.SampleFromPrior()
 
-@code_warntype model.f(varinfo, spl, model);
+@code_warntype model.f(varinfo, spl, Turing.DefaultContext(), model)
 ```
 to inspect the type instabilities in the model.
 

--- a/test/skipped/sv.jl
+++ b/test/skipped/sv.jl
@@ -6,7 +6,7 @@ sv_data = load(TPATH*"/example-models/nips-2017/sv-data.jld.data")["data"]
 
 @model sv_model(T, y) = begin
     ϕ ~ Uniform(-1, 1)
-    σ ~ Truncated(Cauchy(0,5), 0, +Inf)
+    σ ~ truncated(Cauchy(0,5), 0, Inf)
     μ ~ Cauchy(0, 10)
     # h = tzeros(Real, T)
     h = Vector{Real}(T)


### PR DESCRIPTION
This PR replaces `Truncated` with `truncated`, which is the preferred alternative according to the documentation. Moreover, it fixes an example in the docs.