### PR TITLE
Simplify random processes

### DIFF
--- a/test/stdlib/RandomMeasures.jl
+++ b/test/stdlib/RandomMeasures.jl
@@ -281,7 +281,6 @@ include(dir*"/test/test_utils/AllUtils.jl")
 
             x = tzeros(Float64, N)
             J = tzeros(Float64, N)
-            z = tzeros(Int, N)
 
             k = 0
             surplus = 1.0


### PR DESCRIPTION
This PR simplifies `rand` and `logpdf` for random processes by defining the corresponding (scaled) Beta distribution and calling `rand` and `logpdf` for it instead of defining `rand` and `logpdf` from scratch. Moreover, it removes some static type parameters.