### PR TITLE
Make MH in Gibbs faster

### DIFF
--- a/src/Turing.jl
+++ b/src/Turing.jl
@@ -77,9 +77,14 @@ function getspace end
 struct Selector
     gid :: UInt64
     tag :: Symbol # :default, :invalid, :Gibbs, :HMC, etc.
+    rerun :: Bool
 end
-Selector() = Selector(time_ns(), :default)
-Selector(tag::Symbol) = Selector(time_ns(), tag)
+function Selector(tag::Symbol = :default, rerun = tag != :default)
+    return Selector(time_ns(), tag, rerun)
+end
+function Selector(gid::Integer, tag::Symbol = :default)
+    return Selector(gid, tag, tag != :default)
+end
 hash(s::Selector) = hash(s.gid)
 ==(s1::Selector, s2::Selector) = s1.gid == s2.gid
 

--- a/src/inference/gibbs.jl
+++ b/src/inference/gibbs.jl
@@ -60,10 +60,18 @@ function Sampler(alg::Gibbs, model::Model, s::Selector)
     # sanity check for space
     space = getspace(alg)
     # create tuple of samplers
-    samplers = map(alg.algs) do alg
-        Sampler(alg, model, Selector(Symbol(typeof(alg))))
+    i = 0
+    samplers = map(alg.algs) do _alg
+        i += 1
+        if i == 1
+            prev_alg = alg.algs[end]
+        else
+            prev_alg = alg.algs[i-1]
+        end
+        rerun = !(_alg isa MH) || prev_alg isa PG || prev_alg isa ESS
+        selector = Selector(Symbol(typeof(_alg)), rerun)
+        Sampler(_alg, model, selector)
     end
-
     # create a state variable
     state = GibbsState(model, samplers)
 

--- a/src/inference/mh.jl
+++ b/src/inference/mh.jl
@@ -94,7 +94,7 @@ function step!(
     ::Transition;
     kwargs...
 )
-    if spl.selector.tag != :default # Recompute joint in logp
+    if spl.selector.rerun # Recompute joint in logp
         runmodel!(model, spl.state.vi)
     end
     old_θ = copy(spl.state.vi[spl])

--- a/test/inference/gibbs.jl
+++ b/test/inference/gibbs.jl
@@ -37,11 +37,17 @@ include(dir*"/test/test_utils/AllUtils.jl")
         check_numerical(chain, [:s, :m], [49/24, 7/6], atol=0.1)
 
         Random.seed!(100)
+
+        alg = Gibbs(
+            MH(:s),
+            HMC(0.2, 4, :m))
+        chain = sample(gdemo(1.5, 2.0), alg, 3000)
+        check_numerical(chain, [:s, :m], [49/24, 7/6], atol=0.1)
+
         alg = Gibbs(
             CSMC(15, :s),
             ESS(:m))
         chain = sample(gdemo(1.5, 2.0), alg, 10_000)
-        check_numerical(chain, [:s, :m], [49/24, 7/6], atol=0.1)
 
         alg = CSMC(10)
         chain = sample(gdemo(1.5, 2.0), alg, 5000)

--- a/test/inference/gibbs.jl
+++ b/test/inference/gibbs.jl
@@ -48,6 +48,7 @@ include(dir*"/test/test_utils/AllUtils.jl")
             CSMC(15, :s),
             ESS(:m))
         chain = sample(gdemo(1.5, 2.0), alg, 10_000)
+        check_numerical(chain, [:s, :m], [49/24, 7/6], atol=0.1)
 
         alg = CSMC(10)
         chain = sample(gdemo(1.5, 2.0), alg, 5000)

--- a/test/inference/mh.jl
+++ b/test/inference/mh.jl
@@ -41,7 +41,7 @@ include(dir*"/test/test_utils/AllUtils.jl")
         gibbs = Gibbs(
             CSMC(15, :z1, :z2, :z3, :z4),
             MH((:mu1,GKernel(1)), (:mu2,GKernel(1))))
-        chain = sample(MoGtest_default, gibbs, 6000)
+        chain = sample(MoGtest_default, gibbs, 10000)
         check_MoGtest_default(chain, atol = 0.1)
     end
 end


### PR DESCRIPTION
This PR makes MH in Gibbs faster by skipping the re-running of the model when the previous alg had computed the `logjoint`. The following example is twice as fast:
```julia
using Turing
@model gdemo() = begin
  sum(ones(1000, 1000) * ones(1000))
  s ~ InverseGamma(2, 3)
  m ~ Normal(0, sqrt(s))
  1.5 ~ Normal(m, sqrt(s))
  2.0 ~ Normal(m, sqrt(s))
  return s, m
end
alg = Gibbs(MH(:m), MH(:s))
sample(gdemo(), alg, 1000)

#master: 17 s
#This PR: 8 s
```
I added some useless computation in the model to make the model's run time dominate the total sampling time. We need something similar for HMC at some point or a more systematic way to decide when to re-run the model and when not to.