### PR TITLE
Increment version number to 0.8.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Turing"
 uuid = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-version = "0.7.4"
+version = "0.8.0"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"


### PR DESCRIPTION
This PR incremenets the version number so we can release Turing 0.8, which has the probability querying functionality and the compiler 3.0 stuff.