### PR TITLE
Attempt to fix broken versioning on docs site

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -25,7 +25,7 @@ in("no-tutorials", ARGS) || copy_tutorial(tutorial_path)
 
 version_rx = r"v\d.\d.\d"
 baseurl = "/dev"
-ghref = get(ENV, "GITHUB_REF", "")
+ghref = replace(get(ENV, "GITHUB_REF", ""), "/refs/tags" => "")
 if get(ENV, "TRAVIS_TAG", "") != ""
     baseurl = "/" * ENV["TRAVIS_TAG"]
 elseif !isnothing(match(version_rx, ghref))


### PR DESCRIPTION
Looks like the current error with the page build is because of GitHub action's inclusion of `ref/tags/` in front of the version number, which is screwing up the paths. This PR just removes that part of the path manually.