### PR TITLE
Fix https://github.com/TuringLang/DynamicPPL.jl/issues/27

### DIFF
--- a/src/inference/Inference.jl
+++ b/src/inference/Inference.jl
@@ -696,7 +696,7 @@ function dot_assume(
     var::AbstractMatrix,
     vi::VarInfo,
 )
-    @assert dim(dist) == size(var, 1)
+    @assert length(dist) == size(var, 1)
     r = get_and_set_val!(vi, vns, dist, spl)
     lp = sum(logpdf_with_trans(dist, r, istrans(vi, vns[1])))
     var .= r

--- a/src/inference/hmc.jl
+++ b/src/inference/hmc.jl
@@ -456,7 +456,7 @@ function dot_assume(
     var::AbstractMatrix,
     vi::VarInfo,
 )
-    @assert dim(dist) == size(var, 1)
+    @assert length(dist) == size(var, 1)
     updategid!.(Ref(vi), vns, Ref(spl))
     r = vi[vns]
     var .= r

--- a/test/inference/hmc.jl
+++ b/test/inference/hmc.jl
@@ -183,4 +183,14 @@ include(dir*"/test/test_utils/AllUtils.jl")
         @test sample(gdemo_default, alg2, 300) isa Chains
         @test sample(gdemo_default, alg3, 300) isa Chains
     end
+
+    @turing_testset "Regression tests" begin
+        # https://github.com/TuringLang/DynamicPPL.jl/issues/27
+        @model mwe(::Type{T}=Float64) where {T<:Real} = begin
+            m = Matrix{T}(undef, 2, 3)
+            m .~ MvNormal(zeros(2), 1)
+        end
+        
+        @test sample(mwe(), HMC(0.2, 4), 1_000) isa Chains
+    end
 end

--- a/test/inference/hmc.jl
+++ b/test/inference/hmc.jl
@@ -188,7 +188,7 @@ include(dir*"/test/test_utils/AllUtils.jl")
         # https://github.com/TuringLang/DynamicPPL.jl/issues/27
         @model mwe(::Type{T}=Float64) where {T<:Real} = begin
             m = Matrix{T}(undef, 2, 3)
-            m .~ MvNormal(zeros(2), 1)
+            @. m ~ MvNormal(zeros(2), 1)
         end
         
         @test sample(mwe(), HMC(0.2, 4), 1_000) isa Chains


### PR DESCRIPTION
This PR fixes https://github.com/TuringLang/DynamicPPL.jl/issues/27.

https://github.com/TuringLang/DistributionsAD.jl/pull/19 is not needed to resolve the issue, the problem was just that the dimension of multivariate distributions was not checked with `length` but with `dim` (which I think is mostly used by PDMat and some matrixvariate distributions (even though it's not part of the official interface)).