### PR TITLE
Add method for pdf(::OrderedLogistic, x)

### DIFF
--- a/src/stdlib/distributions.jl
+++ b/src/stdlib/distributions.jl
@@ -103,6 +103,8 @@ function Distributions.logpdf(d::OrderedLogistic, k::Int)
     return logp
 end
 
+Distributions.pdf(d::OrderedLogistic, k::Int) = exp(logpdf(d,k))
+
 function Distributions.rand(rng::AbstractRNG, d::OrderedLogistic)
     cutpoints = d.cutpoints
     η = d.η


### PR DESCRIPTION
Before fix
```julia
julia> pdf(OrderedLogistic(1,[0.2,0.5]), 1.0)
ERROR: StackOverflowError:
Stacktrace:
 [1] pdf(::OrderedLogistic{Int64,Array{Float64,1}}, ::Int64) at /home/fredrikb/.julia/packages/Distributions/KjaXI/src/univariates.jl:333 (repeats 80000 times)
```
after fix
```julia
julia> pdf(OrderedLogistic(1,[0.2,0.5]), 1.0)
0.3100255188723875
```