### PR TITLE
Fix MH indexing bug

### DIFF
--- a/src/inference/mh.jl
+++ b/src/inference/mh.jl
@@ -143,7 +143,6 @@ end
     expr = Expr(:tuple)
     map(names) do f
         push!(expr.args, Expr(:(=), f, :(scalar_map(vi, metadata.$f.vns))))
-        #push!(expr.args, Expr(:(=), f, :(getindex(vi, metadata.$f.vns))))
     end
     return expr
 end

--- a/test/inference/mh.jl
+++ b/test/inference/mh.jl
@@ -29,7 +29,7 @@ include(dir*"/test/test_utils/AllUtils.jl")
         alg = MH(
             (:s, InverseGamma(2,3)),
             (:m, GKernel(1.0)))
-        chain = sample(gdemo_default, alg, 70000)
+        chain = sample(gdemo_default, alg, 7000)
         check_gdemo(chain, atol = 0.1)
 
         # MH within Gibbs
@@ -42,7 +42,30 @@ include(dir*"/test/test_utils/AllUtils.jl")
             CSMC(15, :z1, :z2, :z3, :z4),
             MH((:mu1,GKernel(1)), (:mu2,GKernel(1)))
         )
-        chain = sample(MoGtest_default, gibbs, 10000)
+        chain = sample(MoGtest_default, gibbs, 5000)
         check_MoGtest_default(chain, atol = 0.1)
+    end
+    @turing_testset "" begin
+        # Test MH shape passing.
+        @model M(mu, sigma, observable) = begin
+            z ~ MvNormal(mu, sigma)
+    
+            m = Vector{Any}(undef, 2)
+            m[1] ~ Normal(0,1)
+            m[2] ~ InverseGamma(2,1)
+            s ~ InverseGamma(2,1)
+    
+            observable ~ Bernoulli(cdf(Normal(), z'*z))
+    
+            1.5 ~ Normal(m[1], m[2])
+            -1.5 ~ Normal(m[1], m[2])
+    
+            1.5 ~ Normal(m[1], s)
+            2.0 ~ Normal(m[1], s)
+        end
+ 
+        chain = sample(M(zeros(2), ones(2), 1), MH(), 100)
+
+        @test chain isa MCMCChains.Chains
     end
 end


### PR DESCRIPTION
This PR fixes https://github.com/TuringLang/Turing.jl/issues/1133 by fixing a case where the Turing-side code was not passing scalars correctly to AdvancedMH. 

Currently the way I handle passing NamedTuples into Turing is not very robust (and could be more performant), so I'm doubly open to comments on this one. `set_namedtuple!` for example is a very messy and ugly function that relies far too much on heuristics.