### PR TITLE
Use Nanosoldier.jl to run benchmarks

### DIFF
--- a/.github/backup/MicroBenchmarks.yml
+++ b/.github/backup/MicroBenchmarks.yml
@@ -17,22 +17,17 @@ jobs:
         julia-arch: [x64]
         os: [ubuntu-latest]
     steps:
+      - uses: actions/checkout@v1.0.0
       - name: Set up Julia
         uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.julia-version }}
-      - name: Run benchmarks via Nanosoldier
+      - name: Install dependencies
+        run: julia -e 'using Pkg; pkg"""add JSON GitHub DataFrames BenchmarkTools;"""'
+      - name: Run benchmarks
         # `if` to temporarily disable the benchmark action
         # if: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BENCHMARK_KEY: ${{ secrets.BENCHMARK_KEY }}
-        run: |
-                bash -c '
-                git clone https://github.com/TuringLang/Nanosoldier.jl.git
-                cd Nanosoldier.jl
-                git checkout origin/turing
-                export JULIA_PROJECT=$PWD
-                julia -e "using Pkg;Pkg.instantiate();Pkg.build(verbose=true)"
-                julia ./bin/turing_benchmark.jl
-                '
+        run: julia ./benchmarks/github-action-runner.jl

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -24,7 +24,8 @@ After its run, the results will be saved under the directory
 All benchmarks under this directory can run on Github, triggered by
 the following event:
 
-- Comment on an issue
+- Comment on an issue (This is disable if we use Nanosoldier.jl to run
+  the action)
 - Comment on a Pull Request (a.k.a Code Review Comment)
 
 You must **@BayesBot** and include a command in pattern
@@ -33,29 +34,28 @@ specify the branches on which the benchmarks will run and trigger the
 benchmarks. This command pattern is borrowed from `Nanosoldier.jl`,
 please find more detail from its documents. Here are some examples:
 
-- `@BayesBot runbenchmarks("array", vs=[“br1”, "br2"])` will trigger benchmarks tagged
-    with `"array"` on branch `br1` and `br2`
+- `@BayesBot runbenchmarks("array", vs=[“:br1”, ":br2"])` will trigger
+    benchmarks tagged with `"array"` on branch `br1` and `br2`
 - Comments on a regular issue
   - `@BayesBot runbenchmarks("array")` won't trigger any benchmarks due to no
     branches are specified
-  - `@BayesBot runbenchmarks("tag2", vs="feature-1")` will trigger benchmarks
+  - `@BayesBot runbenchmarks("tag2", vs=":feature-1")` will trigger benchmarks
     tagged with `"tag2"` on branch `master` and `feature-1`
 - Comments on a pull request
   - `@BayesBot runbenchmarks(ALL)` will trigger all benchmarks on the pull
     request branch and the `master` branch
-  - `@BayesBot runbenchmark(ALL, vs="feature-1")` will trigger all benchmarks
-    on the pull request branch and the `feature-1` branch
+  - `@BayesBot runbenchmark(ALL, vs=":feature-1")` will trigger all benchmarks
+    on the pull request branch and the `:feature-1` branch
 
 
 After these triggered benchmarks finish, a reply comment will be made
-to report the results.
+to report the results, or a commit will be made to the
+TuringLang/BenchmarkReports repo if Nanodoldier is used.
 
 ### Notes
 
 - Put a Regex pattern to the `EXCLUDES` array in
   `benchmarks/config.toml` to exclude paricular benchmarks
-- One can use an existing Git commit ID in lieu of a branch name in
-  the `!benchmark` command
 
 ## Run on local machine
 


### PR DESCRIPTION
This workflow uses Nanosoldier (The `turing` branch in our forked repo, https://github.com/TuringLang/Nanosoldier.jl/tree/turing) to run our benchmarks. The reports will be committed to https://github.com/TuringLang/BenchmarkReports.

The feature will not be in effect before this PR is merged, I've tested a lot of this on a forked Turing.jl repo to ensure it works well. After the PR is merged, we can comment on a PR to trigger the benchmark job, the trigger pattern is 

```
r"@BayesBot\s*`runbenchmarks\((?P<tag>.*), vs=(?P<branch>.*)\)`" 
```

for example:

```
@BayesBot `runbenchmarks(ALL, vs=":master")`
```

More examples please see the document of Nanosoldier.