### PR TITLE
Disable progress logs in tests

### DIFF
--- a/src/inference/Inference.jl
+++ b/src/inference/Inference.jl
@@ -399,7 +399,7 @@ function save(c::Chains, spl::Sampler, model, vi, samples)
     return setinfo(c, merge(nt, c.info))
 end
 
-function resume(c::Chains, n_iter::Int; chain_type=Chains, kwargs...)
+function resume(c::Chains, n_iter::Int; chain_type=Chains, progress=PROGRESS[], kwargs...)
     @assert !isempty(c.info) "[Turing] cannot resume from a chain without state info"
 
     # Sample a new chain.
@@ -411,6 +411,7 @@ function resume(c::Chains, n_iter::Int; chain_type=Chains, kwargs...)
         resume_from=c,
         reuse_spl_n=n_iter,
         chain_type=Chains,
+        progress=progress,
         kwargs...
     )
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,8 +33,6 @@ include("test_utils/AllUtils.jl")
     end
 
     @testset "variational" begin
-        turnprogress(true)
-
         @testset "algorithms" begin
             include("variational/advi.jl")
         end
@@ -42,8 +40,6 @@ include("test_utils/AllUtils.jl")
         @testset "optimisers" begin
             include("variational/optimisers.jl")
         end
-
-        turnprogress(false)
     end
 
     @testset "stdlib" begin


### PR DESCRIPTION
It seems the output in the tests is too verbose.