### PR TITLE
Add compiler doc to website

### DIFF
--- a/docs/_data/toc.yml
+++ b/docs/_data/toc.yml
@@ -13,9 +13,6 @@
   - title: "Advanced Usage"
     url: "docs/using-turing/advanced"
 
-  - title: "Interface Guide"
-    url: "docs/using-turing/interface"
-
   - title: "Automatic Differentiation"
     url: "docs/using-turing/autodiff"
 
@@ -28,8 +25,14 @@
   - title: "Sampler Visualization"
     url: "docs/using-turing/sampler-viz"
 
+- title: "FOR DEVELOPERS"
+  url: "docs/for-developers/"
+  children:
   - title: "Turing Compiler Design"
-    url: "docs/using-turing/compiler"
+    url: "docs/for-developers/compiler"
+
+  - title: "Interface Guide"
+    url: "docs/for-developers/interface"
 
 - title: "TUTORIALS"
   url: "tutorials"

--- a/docs/_data/toc.yml
+++ b/docs/_data/toc.yml
@@ -28,6 +28,9 @@
   - title: "Sampler Visualization"
     url: "docs/using-turing/sampler-viz"
 
+  - title: "Turing Compiler Design"
+    url: "docs/using-turing/compiler"
+
 - title: "TUTORIALS"
   url: "tutorials"
   children:


### PR DESCRIPTION
Adds the compiler manual to the TOC on the website, fixes #1159.