### PR TITLE
Fixed LinkedIn links

### DIFF
--- a/docs/_data/members.yml
+++ b/docs/_data/members.yml
@@ -25,7 +25,6 @@
   institution: Graz University of Technology
   website: https://martint.blog/
   email: martin.trapp@tugraz.at
-  linkedin: linked-page
   twitter: martin_trapp
 
 - name: Will Tebbutt

--- a/docs/_data/members.yml
+++ b/docs/_data/members.yml
@@ -25,6 +25,7 @@
   institution: Graz University of Technology
   website: https://martint.blog/
   email: martin.trapp@tugraz.at
+  linkedin: martintrapp
   twitter: martin_trapp
 
 - name: Will Tebbutt

--- a/docs/_team/index.md
+++ b/docs/_team/index.md
@@ -18,7 +18,7 @@ title: The Team
         {% if member.github %} <a style="white-space: nowrap" href="https://github.com/{{ member.github }}"> <i class="fa fa-github"></i> </a> {% endif %}
         {% if member.twitter %} <a style="white-space: nowrap" href="https://twitter.com/{{ member.twitter }}"> <i class="fa fa-twitter"></i>  </a> {% endif %}
         {% if member.email %} <a style="white-space: nowrap" href="mailto:{{ member.email }}"> <i class="fa fa-envelope"></i> </a> {% endif %}
-        {% if member.linkedin %} <a style="white-space: nowrap" href="www.linkedin.com/in/{{ member.linkedin }}"> <i class="fa fa-linkedin"></i> </a> {% endif %}
+        {% if member.linkedin %} <a style="white-space: nowrap" href="https://www.linkedin.com/in/{{ member.linkedin }}"> <i class="fa fa-linkedin"></i> </a> {% endif %}
     </div>
 </div>
 


### PR DESCRIPTION
The LinkedIn hyperlinks on the [team page](https://turing.ml/dev/team/) don't point to LinkedIn correctly, which I fixed.

I also noticed that @trappmartin's LinkedIn username wasn't set, so I updated it. Martin, you can delete the `linkedin` line from the `members.yml` file if you don't want your LinkedIn to show up on the site.

This will also fix #1161.