### PR TITLE
Save transitions of samplers in Gibbs sampling

### DIFF
--- a/src/inference/mh.jl
+++ b/src/inference/mh.jl
@@ -37,21 +37,6 @@ end
 
 alg_str(::Sampler{<:MH}) = "MH"
 
-#################
-# MH Transition #
-#################
-
-struct MHTransition{T, F<:AbstractFloat, M<:AMH.Transition}
-    θ    :: T
-    lp   :: F
-    mh_trans :: M
-end
-
-function MHTransition(spl::Sampler{<:MH}, mh_trans::AMH.Transition)
-    theta = tonamedtuple(spl.state.vi)
-    return MHTransition(theta, mh_trans.lp, mh_trans)
-end
-
 #####################
 # Utility functions #
 #####################


### PR DESCRIPTION
I noticed that currently the Gibbs sampler just forwards the transition of the last sampling step (of type `Transition`) to all subsamplers. However, this is problematic if a subsampler expects a certain type of sampler-specific transitions. To resolve this issue I added a `GibbsTransition` that saves the transitions of the subsamplers and forwards them to the corresponding subsamplers.