### PR TITLE
Fix MH sampler for arrays of distributions

### DIFF
--- a/src/inference/mh.jl
+++ b/src/inference/mh.jl
@@ -12,8 +12,6 @@ function MH(space...)
     prop_syms = Symbol[]
     props = AMH.Proposal[]
 
-    check_support(dist) = insupport(dist, z)
-
     for s in space
         if s isa Symbol
             push!(syms, s)


### PR DESCRIPTION
I noticed that the test example for the MH sampler
```julia
@model M(mu, sigma, observable) = begin
    z ~ MvNormal(mu, sigma)

    m = Vector{Any}(undef, 2)
    m[1] ~ Normal(0,1)
    m[2] ~ InverseGamma(2,1)
    s ~ InverseGamma(2,1)

    observable ~ Bernoulli(cdf(Normal(), z'*z))

    1.5 ~ Normal(m[1], m[2])
    -1.5 ~ Normal(m[1], m[2])

    1.5 ~ Normal(m[1], s)
    2.0 ~ Normal(m[1], s)
end
```
that was added in https://github.com/TuringLang/Turing.jl/pull/1135 does not work correctly with Turing at the moment. The problem is that the MH sampler uses the prior distribution `Normal(0, 1)` of `m[1]` for `m`, i.e., also for `m[2]` (in the `logpdf` evaluation this leads to a deprecation warning that can be seen in the tests).

I changed the implementation so that an array of distributions with more than one element is forwarded completely to AdvancedMH. Moreover, I switched to `DynamicPPL.reconstruct` for unpacking samples of scalar-valued distributions and reshaping samples of matrix-valued distributions. Although these changes fix the bug described above (I added some tests for it), I'm pretty sure that one can still come up with other problematic examples. So far we just try to work around the issues that arise from DynamicPPL putting all samples into vectors.

Additionally, I removed the `MHState` which was only needed for keeping track of an `AdvancedMH.DensityModel`. Instead now the log density function is implemented explicitly as a callable struct that captures the model and the sampler and is not saved in the state anymore. That allows use to reuse a sampler with different models without having to define abstract fields in the state (additionally, the state had to be initialized with a dummy density model which is unsatisfying IMO).