### PR TITLE
FIX: `bijector` currently returns inverse of what it claims

### DIFF
--- a/src/variational/advi.jl
+++ b/src/variational/advi.jl
@@ -44,7 +44,7 @@ function bijector(model::Model; sym_to_ranges::Val{sym2ranges} = Val(false)) whe
         idx += varinfo.metadata[sym].ranges[end][end]
     end
 
-    bs = inv.(bijector.(tuple(dists...)))
+    bs = bijector.(tuple(dists...))
 
     if sym2ranges
         return Stacked(bs, ranges), (; collect(zip(keys(sym_lookup), values(sym_lookup)))...)


### PR DESCRIPTION
`bijector` should return a mapping /from/ the support of the posterior to the reals, i.e. `Θ → ℝᵈ` where `Θ` is the support of the posterior, as is the expected behaviour in Bijectors.jl. The current implementation returns the inverse mapping, i.e. from reals to support of posterior. This PR corrects this mistake.

`bijector` isn't used internally so no major change other than to impl of `bijector` itself is necessary. Should be a quick merge.