### PR TITLE
Do not store transitions in Gibbs sampler

### DIFF
--- a/src/inference/gibbs.jl
+++ b/src/inference/gibbs.jl
@@ -184,3 +184,27 @@ function AbstractMCMC.step!(
 
     return GibbsTransition(spl, transitions)
 end
+
+# Do not store transitions of subsamplers
+function AbstractMCMC.transitions_init(
+    transition::GibbsTransition,
+    ::Model,
+    ::Sampler{<:Gibbs},
+    N::Integer;
+    kwargs...
+)
+    return Vector{Transition{typeof(transition.θ),typeof(transition.lp)}}(undef, N)
+end
+
+function AbstractMCMC.transitions_save!(
+    transitions::Vector{<:Transition},
+    iteration::Integer,
+    transition::GibbsTransition,
+    ::Model,
+    ::Sampler{<:Gibbs},
+    ::Integer;
+    kwargs...
+)
+    transitions[iteration] = Transition(transition.θ, transition.lp)
+    return
+end


### PR DESCRIPTION
This PR is an addition to https://github.com/TuringLang/Turing.jl/pull/1166, as discussed in https://github.com/TuringLang/Turing.jl/pull/1166#issuecomment-601191605. The transitions of the subsamplers are still available in the subsequent step but not stored in the array of transitions that is used to build the resulting chain.