### PR TITLE
Catch Array{Any} return value

### DIFF
--- a/src/inference/Inference.jl
+++ b/src/inference/Inference.jl
@@ -334,7 +334,7 @@ function AbstractMCMC.bundle_samples(
 
     # Extract names & construct param array.
     nms = [nms; extra_params]
-    parray = hcat(vals, extra_values)
+    parray = map(x -> x, hcat(vals, extra_values))
 
     # If the state field has average_logevidence or final_logevidence, grab that.
     le = missing
@@ -355,9 +355,6 @@ function AbstractMCMC.bundle_samples(
     else
         info = NamedTuple()
     end
-
-    # Ensure that the chain is not of type Any.
-    parray = eltype(parray) == Any ? convert(Array{Union{Real, Missing}}, parray) : parray
 
     # Chain construction.
     return Chains(

--- a/src/inference/Inference.jl
+++ b/src/inference/Inference.jl
@@ -356,6 +356,9 @@ function AbstractMCMC.bundle_samples(
         info = NamedTuple()
     end
 
+    # Ensure that the chain is not of type Any.
+    parray = eltype(parray) == Any ? convert(Array{Union{Real, Missing}}, parray) : parray
+
     # Chain construction.
     return Chains(
         parray,


### PR DESCRIPTION
I haven't been able to run the infinite mixture model tutorial because it contains integer cluster assignments, and Julia is unable to determine that a more concrete type for `Array{Any, 2}` is `Array{Union{Real, Missing}}` or `Array{Union{Int64, Float74, Missing}}`. This is a quick fix to tell MCMCChains and others that the vector being given is a numeric type if the compiler is otherwise unable to determine the type of the array.