### PR TITLE
Add multinomial logistic regression tutorial from TuringTutorials

### DIFF
--- a/docs/_data/toc.yml
+++ b/docs/_data/toc.yml
@@ -63,6 +63,9 @@
 
   - title: "Bayesian Poisson Regression"
     url: "tutorials/7-poissonregression"
+    
+  - title: "Bayesian Multinomial Logistic Regression"
+    url: "tutorials/8-multinomiallogisticregression"
 
 - title: "API"
   url: "docs/library"


### PR DESCRIPTION
This pull request adds the multinomial logistic regression tutorial from TuringTutorials.

https://github.com/TuringLang/TuringTutorials/pull/55 needs to be merged before this pull request can be merged.