### PR TITLE
Fixed links and stuff for VI docs

### DIFF
--- a/docs/_data/toc.yml
+++ b/docs/_data/toc.yml
@@ -67,6 +67,12 @@
   - title: "Bayesian Poisson Regression"
     url: "tutorials/7-poissonregression"
 
+  - title: "Multinomial Logistic Regression"
+    url: "tutorials/8-multinomiallogisticregression"
+
+  - title: "Variational Inference"
+    url: "tutorials/9-variationalinference"
+
 - title: "API"
   url: "docs/library"
   children:

--- a/docs/src/for-developers/variational_inference.md
+++ b/docs/src/for-developers/variational_inference.md
@@ -7,7 +7,7 @@ toc: true
 
 In this post we'll have a look at what's know as **variational inference (VI)**, a family of _approximate_ Bayesian inference methods. In particular, we will focus on one of the more standard VI methods called **Automatic Differentation Variational Inference (ADVI)**. If 
 
-Here we'll have a look at the theory behind VI, but if you're interested in how to use ADVI in Turing.jl, [checkout this tutorial](../tutorials/8_VariationalInference.html).
+Here we'll have a look at the theory behind VI, but if you're interested in how to use ADVI in Turing.jl, [checkout this tutorial](../../tutorials/9-variationalinference).
 
 # Motivation
 
@@ -309,4 +309,4 @@ Hence, the resulting empirical estimate of the ELBO is
 
 And maximizing this wrt. \$\$\mu\$\$ and \$\$\Sigma\$\$ is what's referred to as **Automatic Differentation Variational Inference (ADVI)**!
 
-Now if you want to try it out, [check out the tutorial on how to use ADVI in Turing.jl!](../tutorials/8_VariationalInference.html)
+Now if you want to try it out, [check out the tutorial on how to use ADVI in Turing.jl](../../tutorials/9-variationalinference)!


### PR DESCRIPTION
Depends on https://github.com/TuringLang/TuringTutorials/pull/56.

Also makes the Multinomial Logistic Regression tutorial available on the website.