### PR TITLE
Docs: Remove duplicate TOC entry for multinomial logistic regression tutorial

### DIFF
--- a/docs/_data/toc.yml
+++ b/docs/_data/toc.yml
@@ -66,9 +66,6 @@
 
   - title: "Bayesian Poisson Regression"
     url: "tutorials/7-poissonregression"
-    
-  - title: "Bayesian Multinomial Logistic Regression"
-    url: "tutorials/8-multinomiallogisticregression"
 
   - title: "Multinomial Logistic Regression"
     url: "tutorials/8-multinomiallogisticregression"


### PR DESCRIPTION
Currently, the "Tutorials" section of the TOC has two entries for the multinomial logistic regression tutorial.

This pull request removes one of the entries.