### PR TITLE
Tutorials TOC links: more consistent naming

### DIFF
--- a/docs/_data/toc.yml
+++ b/docs/_data/toc.yml
@@ -49,10 +49,10 @@
   - title: "Gaussian Mixture Models"
     url: "tutorials/1-gaussianmixturemodel"
 
-  - title: "Bayesian Logistic Regression"
+  - title: "Logistic Regression"
     url: "tutorials/2-logisticregression"
 
-  - title: "Bayesian Neural Networks"
+  - title: "Neural Networks"
     url: "tutorials/3-bayesnn"
 
   - title: "Hidden Markov Models"
@@ -64,7 +64,7 @@
   - title: "Infinite Mixture Models"
     url: "tutorials/6-infinitemixturemodel"
 
-  - title: "Bayesian Poisson Regression"
+  - title: "Poisson Regression"
     url: "tutorials/7-poissonregression"
 
   - title: "Multinomial Logistic Regression"


### PR DESCRIPTION
Right now, the TOC links for the tutorials have inconsistent names: some of them use the word "Bayesian" and others do not.

Presumably, all of these tutorials are Bayesian, so it is redundant to include "Bayesian" in these TOC links.