### PR TITLE
Fix crashes in CI tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,11 +25,6 @@ include("test_utils/AllUtils.jl")
         Turing.setadbackend(adbackend)
         @testset "inference: $adbackend" begin
             @testset "samplers" begin
-                # FIXME: DynamicHMC version 1 has (??) a bug on 32bit platforms (but we were too
-                # lazy to open an issue so Tamas doesn't know about it), retest with 2.0
-                if Int === Int64 && Pkg.installed()["DynamicHMC"].major == 2
-                    include("contrib/inference/dynamichmc.jl")
-                end
                 include("inference/gibbs.jl")
                 include("inference/hmc.jl")
                 include("inference/is.jl")
@@ -37,6 +32,7 @@ include("test_utils/AllUtils.jl")
                 include("inference/ess.jl")
                 include("inference/AdvancedSMC.jl")
                 include("inference/Inference.jl")
+                include("contrib/inference/dynamichmc.jl")
             end
         end
 


### PR DESCRIPTION
This PR is a quick and dirty fix for https://github.com/TuringLang/Turing.jl/issues/1199 as long as the underlying issue is not resolved. Currently one Zygote AD test crashes Julia 1.4 and Julia master, which makes it impossible to evaluate any PRs on Julia 1.4.

Additionally it fixes a deprecation warning on Julia 1.4 (see https://github.com/TuringLang/Turing.jl/pull/1186#discussion_r398879717).