### PR TITLE
Update AHMC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,9 @@ docs/_site/
 docs/.gems/
 docs/Gemfile.lock
 
+.vscode
 .DS_Store
 Manifest.toml
+test/Project.toml
 
 benchmarks/output/

--- a/Project.toml
+++ b/Project.toml
@@ -29,7 +29,7 @@ Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 
 [compat]
 AbstractMCMC = "0.5.5"
-AdvancedHMC = "0.2.23"
+AdvancedHMC = "0.2.22, 0.2.23"
 AdvancedMH = "0.4"
 Bijectors = "0.6.4"
 Distributions = "0.22, 0.23"

--- a/Project.toml
+++ b/Project.toml
@@ -29,7 +29,7 @@ Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 
 [compat]
 AbstractMCMC = "0.5.5"
-AdvancedHMC = "0.2.20"
+AdvancedHMC = "0.2.23"
 AdvancedMH = "0.4"
 Bijectors = "0.6.4"
 Distributions = "0.22, 0.23"

--- a/src/contrib/inference/sghmc.jl
+++ b/src/contrib/inference/sghmc.jl
@@ -172,7 +172,7 @@ function step(
     spl.selector.tag != :default && link!(vi, spl)
 
     mssa = AHMC.Adaptation.ManualSSAdaptor(AHMC.Adaptation.MSSState(spl.alg.ϵ))
-    spl.info[:adaptor] = AHMC.NaiveHMCAdaptor(AHMC.UnitPreconditioner(), mssa)
+    spl.info[:adaptor] = AHMC.NaiveHMCAdaptor(AHMC.UnitMassMatrix(), mssa)
 
     spl.selector.tag != :default && invlink!(vi, spl)
     return vi, true

--- a/src/inference/hmc.jl
+++ b/src/inference/hmc.jl
@@ -499,8 +499,8 @@ end
 ####
 
 function AHMCAdaptor(alg::AdaptiveHamiltonian, metric::AHMC.AbstractMetric; ϵ=alg.ϵ)
-    pc = AHMC.Preconditioner(metric)
-    da = AHMC.NesterovDualAveraging(alg.δ, ϵ)
+    pc = AHMC.MassMatrixAdaptor(metric)
+    da = AHMC.StepSizeAdaptor(alg.δ, ϵ)
 
     if iszero(alg.n_adapts)
         adaptor = AHMC.Adaptation.NoAdaptation()
@@ -549,7 +549,7 @@ function HMCState(
 
     # Find good eps if not provided one
     if spl.alg.ϵ == 0.0
-        ϵ = AHMC.find_good_eps(h, θ_init)
+        ϵ = AHMC.find_good_stepsize(h, θ_init)
         @info "Found initial step size" ϵ
     else
         ϵ = spl.alg.ϵ

--- a/src/utilities/stan-interface.jl
+++ b/src/utilities/stan-interface.jl
@@ -70,8 +70,8 @@ end
 function AHMCAdaptor(adaptor)
     if :engaged in fieldnames(typeof(adaptor)) # CmdStan.Adapt
         adaptor.engaged ? spl.alg.n_adapts : 0,
-        AHMC.Preconditioner(metric),
-        AHMC.NesterovDualAveraging(adaptor.gamma,
+        AHMC.MassMatrixAdaptor(metric),
+        AHMC.StepSizeAdaptor(adaptor.gamma,
             adaptor.t0, adaptor.kappa, adaptor.δ, init_ϵ),
             adaptor.init_buffer,
             adaptor.term_buffer,
@@ -79,8 +79,8 @@ function AHMCAdaptor(adaptor)
     else # default adaptor
         @warn "Invalid adaptor type: $(typeof(adaptor)). Default adaptor is used instead."
         adaptor = AHMC.StanHMCAdaptor(
-            AHMC.Preconditioner(:DiagEuclideanMetric),
-            AHMC.NesterovDualAveraging(spl.alg.δ, init_ϵ)
+            AHMC.MassMatrixAdaptor(:DiagEuclideanMetric),
+            AHMC.StepSizeAdaptor(spl.alg.δ, init_ϵ)
         )
         AHMC.initialize!(adaptor, spl.alg.n_adapts)
         adaptor


### PR DESCRIPTION
Requires https://github.com/TuringLang/AdvancedHMC.jl/pull/192 to be merged and a new version of AHMC to be released.