### PR TITLE
Added kwargs to deafult HMC constructor

### DIFF
--- a/src/inference/hmc.jl
+++ b/src/inference/hmc.jl
@@ -78,7 +78,7 @@ end
 
 alg_str(::Sampler{<:Hamiltonian}) = "HMC"
 
-HMC(args...) = HMC{ADBackend()}(args...)
+HMC(args...; kwargs...) = HMC{ADBackend()}(args...; kwargs...)
 function HMC{AD}(ϵ::Float64, n_leapfrog::Int, ::Type{metricT}, space::Tuple) where {AD, metricT <: AHMC.AbstractMetric}
     return HMC{AD, space, metricT}(ϵ, n_leapfrog)
 end


### PR DESCRIPTION
The following currently fails:
```julia
spl = HMC(
    0.025,
    10;
    metricT=Turing.Inference.AHMC.DiagEuclideanMetric
)
```
because the method is missing, while
```julia
spl = HMC{Turing.ADBackend()}(
    0.025,
    10;
    metricT=Turing.Inference.AHMC.DiagEuclideanMetric
)
```
fails. This is because the default constructor for `HMC` which adds in the `ADBackend()` at the moment does not support keyword arguments. This PR fixes this.