### PR TITLE
Simplify ParticleContainer and add better tests for propagate!

### DIFF
--- a/src/core/container.jl
+++ b/src/core/container.jl
@@ -72,15 +72,16 @@ Data structure for particle filters
 - normalise!(pc::ParticleContainer)
 - consume(pc::ParticleContainer): return incremental likelihood
 """
-mutable struct ParticleContainer{T<:Particle, F}
-    model::F
+mutable struct ParticleContainer{T<:Particle}
+    "Particles."
     vals::Vector{T}
-    # logarithmic weights (Trace) or incremental log-likelihoods (ParticleContainer)
+    "Unnormalized logarithmic weights."
     logWs::Vector{Float64}
 end
 
-ParticleContainer(model, particles::Vector{<:Particle}) =
-    ParticleContainer(model, particles, zeros(length(particles)))
+function ParticleContainer(particles::Vector{<:Particle})
+    return ParticleContainer(particles, zeros(length(particles)))
+end
 
 Base.collect(pc::ParticleContainer) = pc.vals
 Base.length(pc::ParticleContainer) = length(pc.vals)
@@ -101,7 +102,7 @@ function Base.copy(pc::ParticleContainer)
     # copy weights
     logWs = copy(pc.logWs)
 
-    ParticleContainer(pc.model, vals, logWs)
+    ParticleContainer(vals, logWs)
 end
 
 """

--- a/src/inference/AdvancedSMC.jl
+++ b/src/inference/AdvancedSMC.jl
@@ -76,7 +76,7 @@ end
 
 function SMCState(model::Model)
     vi = VarInfo(model)
-    particles = ParticleContainer(model, Trace[])
+    particles = ParticleContainer(Trace[])
 
     return SMCState(vi, 0.0, particles)
 end
@@ -109,7 +109,7 @@ function AbstractMCMC.sample_init!(
     particles = T[Trace(model, spl, vi) for _ in 1:N]
 
     # create a new particle container
-    spl.state.particles = pc = ParticleContainer(model, particles)
+    spl.state.particles = pc = ParticleContainer(particles)
 
     # Run particle filter.
     logevidence = zero(spl.state.average_logevidence)
@@ -233,7 +233,7 @@ function AbstractMCMC.step!(
     end
 
     # create a new particle container
-    pc = ParticleContainer(model, particles)
+    pc = ParticleContainer(particles)
 
     # run the particle filter
     logevidence = zero(spl.state.average_logevidence)

--- a/test/core/container.jl
+++ b/test/core/container.jl
@@ -1,7 +1,7 @@
 using Turing, Random
 using Turing: ParticleContainer, getweights, resample!,
-    effectiveSampleSize, Trace, current_trace, VarName,
-    Sampler, consume, produce, copy, fork
+    effectiveSampleSize, Trace, current_trace, VarName, VarInfo,
+    Sampler, consume, produce, copy, fork, getlogp
 using Turing.Core: logZ, propagate!
 using Test
 
@@ -10,76 +10,74 @@ include(dir*"/test/test_utils/AllUtils.jl")
 
 @testset "container.jl" begin
     @turing_testset "copy particle container" begin
-        pc = ParticleContainer(x -> x * x, Trace[])
+        pc = ParticleContainer(Trace[])
         newpc = copy(pc)
 
         @test newpc.logWs == pc.logWs
         @test typeof(pc) === typeof(newpc)
     end
     @turing_testset "particle container" begin
-        n = Ref(0)
-
-        alg = PG(5)
-        spl = Turing.Sampler(alg, empty_model())
-        dist = Normal(0, 1)
-
-        function fpc()
-            t = TArray(Float64, 1);
-            t[1] = 0;
-            while true
-                ct = current_trace()
-                vn = @varname x[n]
-                Turing.assume(spl, dist, vn, ct.vi); n[] += 1;
-                produce(0)
-                vn = @varname x[n]
-                Turing.assume(spl, dist, vn, ct.vi); n[] += 1;
-                t[1] = 1 + t[1]
+        # Create a resumable function that always yields `logp`.
+        function fpc(logp)
+            f = let logp = logp
+                () -> begin
+                    while true
+                        produce(logp)
+                    end
+                end
             end
+            return f
         end
 
-        modelgen = Turing.ModelGen{()}(nothing, NamedTuple())
-        model = Turing.Model(fpc, NamedTuple(), modelgen)
-        particles = [Trace(fpc, model, spl, Turing.VarInfo()) for _ in 1:3]
-        pc = ParticleContainer(fpc, particles)
+        # Dummy sampler that is not actually used.
+        sampler = Sampler(PG(5), empty_model())
 
-        # Initial weights and likelihood.
-        weights = getweights(pc)
-        lz = logZ(pc)
-        @test weights == [1/3, 1/3, 1/3]
-        @test iszero(lz)
+        # Create particle container.
+        logps = [0.0, -1.0, -2.0]
+        particles = [Trace(fpc(logp), empty_model(), sampler, VarInfo()) for logp in logps]
+        pc = ParticleContainer(particles)
 
-        # Propagate particles.
-        propagate!(pc)
-        @test getweights(pc) == weights
-        @test logZ(pc) == lz
-
-        # Propagate particles.
-        propagate!(pc)
-        @test getweights(pc) == weights
-        @test logZ(pc) == lz
-
-        # Resample particles.
-        resample!(pc)
-        @test getweights(pc) == weights
-        @test logZ(pc) == lz
+        # Initial state.
+        @test all(iszero(getlogp(particle.vi)) for particle in pc.vals)
+        @test pc.logWs == zeros(3)
+        @test getweights(pc) == fill(1/3, 3)
+        @test iszero(logZ(pc))
         @test effectiveSampleSize(pc) == 3
 
         # Propagate particles.
         propagate!(pc)
-        @test getweights(pc) == weights
-        @test logZ(pc) == lz
+        @test all(iszero(getlogp(particle.vi)) for particle in pc.vals)
+        @test pc.logWs == logps
+        @test getweights(pc) ≈ exp.(logps) ./ sum(exp, logps)
+        @test logZ(pc) == log(sum(exp, logps)) - log(3)
 
-        # Resample and propagate particles.
-        resample!(pc)
+        # Propagate particles.
         propagate!(pc)
-        @test getweights(pc) == weights
-        @test logZ(pc) == lz
+        @test all(iszero(getlogp(particle.vi)) for particle in pc.vals)
+        @test pc.logWs == 2 .* logps
+        @test getweights(pc) == exp.(2 .* logps) ./ sum(exp, 2 .* logps)
+        @test logZ(pc) == log(sum(exp, 2 .* logps)) - log(3)
+
+        # Resample particles.
+        resample!(pc)
+        @test all(iszero(getlogp(particle.vi)) for particle in pc.vals)
+        @test pc.logWs == zeros(3)
+        @test getweights(pc) == fill(1/3, 3)
+        @test iszero(logZ(pc))
+        @test effectiveSampleSize(pc) == 3
+
+        # Propagate particles.
+        propagate!(pc)
+        @test all(iszero(getlogp(particle.vi)) for particle in pc.vals)
+        @test pc.logWs ⊆ logps
+        @test getweights(pc) == exp.(pc.logWs) ./ sum(exp, pc.logWs)
+        @test logZ(pc) == log(sum(exp, pc.logWs)) - log(3)
     end
     @turing_testset "trace" begin
         n = Ref(0)
 
         alg = PG(5)
-        spl = Turing.Sampler(alg, empty_model())
+        spl = Sampler(alg, empty_model())
         dist = Normal(0, 1)
         function f2()
             t = TArray(Int, 1);
@@ -96,9 +94,7 @@ include(dir*"/test/test_utils/AllUtils.jl")
         end
 
         # Test task copy version of trace
-        modelgen = Turing.ModelGen{()}(nothing, NamedTuple())
-        model = Turing.Model(f2, NamedTuple(), modelgen)
-        tr = Trace(f2, model, spl, Turing.VarInfo())
+        tr = Trace(f2, empty_model(), spl, VarInfo())
 
         consume(tr); consume(tr)
         a = fork(tr);


### PR DESCRIPTION
This PR simplifies ParticleContainer a bit more by removing the `model` field which hasn't been used (and was actually misused in the tests by setting it to arbitrary functions). Moreover, it adds the additional tests promised in https://github.com/TuringLang/Turing.jl/pull/1237#issuecomment-620051358.

When I added the tests I was a bit surprised actually that the implementation of `propagate!` (and `consume` before, that code was not modified in the recent PR) increases the unnormalized logarithmic weights of the particles with the values that are `produce`d by the particles and not just sets them to these values (as I would have expected from the algorithm since, if I understand correctly, these values correspond to the log probability of the next "observation"). In the currently implemented samplers (`SMC` and `PG`) this does not matter though since the unnormalized weights are reset in the `resample!` step which is performed before every `propagate!` step. Nevertheless, I'm wondering what's the reason for the current implementation?