### PR TITLE
Allow sampling from the prior

### DIFF
--- a/src/Turing.jl
+++ b/src/Turing.jl
@@ -67,6 +67,8 @@ export  @model,                 # modelling
         @varname,
         DynamicPPL,
 
+        Prior,                  # Sampling from the prior
+
         MH,                     # classic sampling
         RWMH,
         ESS,

--- a/src/inference/AdvancedSMC.jl
+++ b/src/inference/AdvancedSMC.jl
@@ -26,6 +26,8 @@ function additional_parameters(::Type{<:ParticleTransition})
     return [:lp,:le, :weight]
 end
 
+DynamicPPL.getlogp(t::ParticleTransition) = t.lp
+
 ####
 #### Generic Sequential Monte Carlo sampler.
 ####

--- a/src/inference/Inference.jl
+++ b/src/inference/Inference.jl
@@ -72,7 +72,7 @@ getchunksize(::Type{<:Hamiltonian{AD}}) where AD = getchunksize(AD)
 getADbackend(::Hamiltonian{AD}) where AD = AD()
 
 # Algorithm for sampling from the prior
-struct Prior end
+struct Prior <: InferenceAlgorithm end
 
 """
     mh_accept(logp_current::Real, logp_proposal::Real, log_proposal_ratio::Real)
@@ -142,7 +142,7 @@ const TURING_INTERNAL_VARS = (internals = [
 
 function AbstractMCMC.sample(
     model::AbstractModel,
-    alg::Union{InferenceAlgorithm,Prior},
+    alg::InferenceAlgorithm,
     N::Integer;
     kwargs...
 )
@@ -197,7 +197,7 @@ end
 
 function AbstractMCMC.sample(
     model::AbstractModel,
-    alg::Union{InferenceAlgorithm,Prior},
+    alg::InferenceAlgorithm,
     parallel::AbstractMCMC.AbstractMCMCParallel,
     N::Integer,
     n_chains::Integer;

--- a/src/inference/Inference.jl
+++ b/src/inference/Inference.jl
@@ -111,6 +111,8 @@ function additional_parameters(::Type{<:Transition})
     return [:lp]
 end
 
+DynamicPPL.getlogp(t::Transition) = t.lp
+
 ##########################################
 # Internal variable names for MCMCChains #
 ##########################################
@@ -302,14 +304,6 @@ Return a named tuple of parameters.
 getparams(t) = t.θ
 getparams(t::VarInfo) = tonamedtuple(TypedVarInfo(t))
 
-"""
-    getlp(t)
-
-Return the log probability.
-"""
-getlp(t) = t.lp
-getlp(t::VarInfo) = getlogp(t)
-
 function _params_to_array(ts)
     names_set = Set{String}()
     # Extract the parameter names and values from each transition.
@@ -470,7 +464,7 @@ function AbstractMCMC.bundle_samples(
 
         push!(k, :lp)
 
-        nts[i] = NamedTuple{tuple(k...)}(tuple(vs..., getlp(t)))
+        nts[i] = NamedTuple{tuple(k...)}(tuple(vs..., getlogp(t)))
     end
 
     return map(identity, nts)

--- a/src/inference/gibbs.jl
+++ b/src/inference/gibbs.jl
@@ -122,6 +122,8 @@ function additional_parameters(::Type{<:GibbsTransition})
     return [:lp]
 end
 
+DynamicPPL.getlogp(t::GibbsTransition) = t.lp
+
 # Initialize the Gibbs sampler.
 function AbstractMCMC.sample_init!(
     rng::AbstractRNG,

--- a/src/inference/hmc.jl
+++ b/src/inference/hmc.jl
@@ -37,6 +37,7 @@ function additional_parameters(::Type{<:HamiltonianTransition})
     return [:lp,:stat]
 end
 
+DynamicPPL.getlogp(t::HamiltonianTransition) = t.lp
 
 ###
 ### Hamiltonian Monte Carlo samplers.

--- a/test/inference/Inference.jl
+++ b/test/inference/Inference.jl
@@ -2,6 +2,8 @@ using Turing, Random, Test
 using DynamicPPL: getlogp
 import MCMCChains
 
+using Random
+
 dir = splitdir(splitdir(pathof(Turing))[1])[1]
 include(dir*"/test/test_utils/AllUtils.jl")
 
@@ -85,22 +87,27 @@ include(dir*"/test/test_utils/AllUtils.jl")
         @test isapprox(getlogp(varinfo2) / getlogp(varinfo1), 10)
     end
     @testset "Prior" begin
+        N = 5000
+
         # Note that all chains contain 3 values per sample: 2 variables + log probability
-        chains = sample(gdemo_d(), Prior(), 1000)
+        Random.seed!(100)
+        chains = sample(gdemo_d(), Prior(), N)
         @test chains isa MCMCChains.Chains
-        @test size(chains) == (1000, 3, 1)
+        @test size(chains) == (N, 3, 1)
         @test mean(chains, :s) ≈ 3 atol=0.1
         @test mean(chains, :m) ≈ 0 atol=0.1
 
-        chains = sample(gdemo_d(), Prior(), MCMCThreads(), 1000, 4)
+        Random.seed!(100)
+        chains = sample(gdemo_d(), Prior(), MCMCThreads(), N, 4)
         @test chains isa MCMCChains.Chains
-        @test size(chains) == (1000, 3, 4)
+        @test size(chains) == (N, 3, 4)
         @test mean(chains, :s) ≈ 3 atol=0.1
         @test mean(chains, :m) ≈ 0 atol=0.1
 
-        chains = sample(gdemo_d(), Prior(), 1000; chain_type = Vector{NamedTuple})
+        Random.seed!(100)
+        chains = sample(gdemo_d(), Prior(), N; chain_type = Vector{NamedTuple})
         @test chains isa Vector{<:NamedTuple}
-        @test length(chains) == 1000
+        @test length(chains) == N
         @test all(length(x) == 3 for x in chains)
         @test all(haskey(x, :lp) for x in chains)
         @test mean(x[:s][1] for x in chains) ≈ 3 atol=0.1


### PR DESCRIPTION
This PR is an alternative to https://github.com/TuringLang/Turing.jl/pull/1225. I tried to reduce the existing amount of type piracy and to clean the existing implementation by moving HMC-specific stuff to the implementation of the AbstractMCMC interface for HMC samplers. The bundle_samples implementations for SampleFromPrior are still type piracy, since neither the function nor the input types are owned by Turing. Also to avoid type piracy and too Turing-specific implementations of the interface for SampleFromPrior (Turing sets the default chain_type to `MCMCChains.Chains` which one can't do in a generic implementation in DynamicPPL), I added a `Prior` algorithm type that is owned by Turing and just samples using a `SampleFromPrior`. However, I'm not completely sure if that's a good idea.

The PR needs the implementation of `step!` for SampleFromPrior in the master branch of DynamicPPL.