### PR TITLE
Remove sidebar for news/teams

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -86,21 +86,31 @@ defaults:
       type: "docs"
     values:
       layout: "page"
+      sidebar: true
   - scope:
       path: "_tutorials"
       type: "tutorials"
     values:
       layout: "page"
+      sidebar: true
   - scope:
       path: ""
       type: "pages"
     values:
       layout: "page"
+      sidebar: true
   - scope:
       path: "_team"
       type: "team"
     values:
       layout: "team"
+      sidebar: false
+  - scope:
+      path: "_posts"
+      type: "posts"
+    values:
+      layout: "post"
+      sidebar: false
 
 
 plugins:

--- a/docs/_includes/sidebar.html
+++ b/docs/_includes/sidebar.html
@@ -1,3 +1,5 @@
+
+{% if page.sidebar %}
 <div class="md-sidebar md-sidebar--primary" data-md-component="navigation">
   <div class="md-sidebar__scrollwrap">
     <div class="md-sidebar__inner">
@@ -122,3 +124,4 @@
     </div>
   </div>
 </div>
+{% endif %}

--- a/docs/_includes/toc.html
+++ b/docs/_includes/toc.html
@@ -1,35 +1,38 @@
-<script
-  src="https://code.jquery.com/jquery-3.3.1.min.js"
-  integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
-  crossorigin="anonymous"></script>
 
-<script>
-$(document).ready(function() {
+{% if page.toc %}
+    <script
+    src="https://code.jquery.com/jquery-3.3.1.min.js"
+    integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
+    crossorigin="anonymous"></script>
 
-    var toc = $('#nav-toc');
+    <script>
+    $(document).ready(function() {
 
-    // Select each header
-    sections = $('#md-container-pancakes h1');
-        $.each(sections, function(idx, v) {
-            section = $(v);
-            var div_id = $(section).attr('id');
-            var div_text = section.text().split('¶')[0];
-            var parent = $("#" + div_id)
-            var content = '<li id="link_' + div_id + '" class="md-nav__item"><a class="md-nav__link toc-side-bar" href="#' + div_id + '" title="' + div_text +'">' + div_text +'</a></li>';
-            $(toc).append(content);
+        var toc = $('#nav-toc');
 
-            // Add section code to subnavigation
-            var children = $('<nav class="md-nav"><ul class="md-nav__list"></nav></ul>')
-            var contenders = $("#" + div_id).nextUntil( "h1" );
-            $.each(contenders, function(idx, contender){
-               if($(contender).is('h2')) {
-                   var contender_id = $(contender).attr('id');
-                   var contender_text = $(contender).text().split('¶')[0];
-                   var content = '<li class="md-nav__item"><a class="md-nav__link toc-side-bar" href="#' + contender_id + '" title="' + contender_text +'">' + contender_text +'</a></li>';
-                   children.append(content);
-                }
-             })
-             $("#link_" + div_id).append(children);
+        // Select each header
+        sections = $('#md-container-pancakes h1');
+            $.each(sections, function(idx, v) {
+                section = $(v);
+                var div_id = $(section).attr('id');
+                var div_text = section.text().split('¶')[0];
+                var parent = $("#" + div_id)
+                var content = '<li id="link_' + div_id + '" class="md-nav__item"><a class="md-nav__link toc-side-bar" href="#' + div_id + '" title="' + div_text +'">' + div_text +'</a></li>';
+                $(toc).append(content);
+
+                // Add section code to subnavigation
+                var children = $('<nav class="md-nav"><ul class="md-nav__list"></nav></ul>')
+                var contenders = $("#" + div_id).nextUntil( "h1" );
+                $.each(contenders, function(idx, contender){
+                if($(contender).is('h2')) {
+                    var contender_id = $(contender).attr('id');
+                    var contender_text = $(contender).text().split('¶')[0];
+                    var content = '<li class="md-nav__item"><a class="md-nav__link toc-side-bar" href="#' + contender_id + '" title="' + contender_text +'">' + contender_text +'</a></li>';
+                    children.append(content);
+                    }
+                })
+                $("#link_" + div_id).append(children);
+            });
         });
-    });
-</script>
+    </script>
+{% endif %}

--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -1,9 +1,19 @@
 ---
-layout: page
+layout: default
 ---
 
-<h1 style="margin-bottom:0px">{{ page.title }}</h1>
-{% if page.badges %}{% for badge in page.badges %}<span class="badge badge-{{ badge.type }}">{{ badge.tag }}</span>{% endfor %}{% endif %}
-{% if page.author %} <span class"author"> {{ page.author }} </span> <br>{% endif %}
-<span class="post-date" style="font-style: italic;">{{ page.date | date: "%B %d, %Y" }}</span>
-{{ content }}
+
+
+<div class="md-content full-width"> 
+    <article class="md-content__inner md-typeset  full-width">
+    <h1 style="margin-bottom:0px">{{ page.title }}</h1>
+    {% if page.badges %}{% for badge in page.badges %}<span class="badge badge-{{ badge.type }}">{{ badge.tag }}</span>{% endfor %}{% endif %}
+    {% if page.author %} <span class"author"> {{ page.author }} </span> <br>{% endif %}
+    <span class="post-date" style="font-style: italic;">{{ page.date | date: "%B %d, %Y" }}</span>
+
+    {{ content }}
+
+    {% if page.toc %} {% include toc.html %} {% endif %}
+    {% include editable.html %}
+    </article>
+</div>      

--- a/docs/pages/archive.md
+++ b/docs/pages/archive.md
@@ -2,6 +2,7 @@
 layout: page
 title: Articles
 permalink: /archive/
+sidebar: false
 ---
 # News Archive
 

--- a/docs/pages/news.md
+++ b/docs/pages/news.md
@@ -1,6 +1,7 @@
 ---
 title: News
 permalink: /news/
+sidebar: false
 ---
 
 # News


### PR DESCRIPTION
Removes the navigation sidebar and table of contents for the news and team pages, so we now have lovely white margins for things like blog posts.