### PR TITLE
Clean CI setup

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -8,9 +8,6 @@ jobs:
   CompatHelper:
     runs-on: ubuntu-latest
     steps:
-      - uses: julia-actions/setup-julia@latest
-        with:
-          version: 1.4
       - name: Pkg.add("CompatHelper")
         run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
       - name: CompatHelper.main()

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Julia
         uses: julia-actions/setup-julia@v1
         with:
-          version: '1.4'
+          version: '1'
       - name: Set up Ruby 2.6
         uses: actions/setup-ruby@v1
         with:

--- a/.github/workflows/DynamicHMC.yml
+++ b/.github/workflows/DynamicHMC.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.4'
+          - '1'
         os:
           - ubuntu-latest
         arch:

--- a/.github/workflows/MicroBenchmarks.yml
+++ b/.github/workflows/MicroBenchmarks.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: [1.3]
+        julia-version: ['1']
         julia-arch: [x64]
         os: [ubuntu-latest]
     steps:

--- a/.github/workflows/Numerical.yml
+++ b/.github/workflows/Numerical.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.4'
+          - '1'
         os:
           - ubuntu-latest
         arch:

--- a/.github/workflows/StanCI.yml
+++ b/.github/workflows/StanCI.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.4'
+          - '1'
         os:
           - ubuntu-latest
         arch:

--- a/.github/workflows/TuringCI.yml
+++ b/.github/workflows/TuringCI.yml
@@ -14,9 +14,7 @@ jobs:
       matrix:
         version:
           - '1.0'
-          - '1.2'
-          - '1.3'
-          - '1.4'
+          - '1'
         os:
           - ubuntu-latest
           - windows-latest


### PR DESCRIPTION
This PR removes tests on Julia 1.2 and 1.3, updates CompatHelper (it has Julia installed by default, so there's no need anymore to download Julia), and enforces the use of the latest stable Julia version (to avoid updates when a new Julia version is released).