### PR TITLE
Allow proposal matrix for MH

### DIFF
--- a/src/inference/mh.jl
+++ b/src/inference/mh.jl
@@ -187,6 +187,17 @@ end
     return expr
 end
 
+# Utility functions to link or 
+maybe_link!(varinfo, sampler, proposal) = nothing
+function maybe_link!(varinfo, sampler, proposal::AdvancedMH.RandomWalkProposal)
+    link!(varinfo, sampler)
+end
+
+maybe_invlink!(varinfo, sampler, proposal) = nothing
+function maybe_invlink!(varinfo, sampler, proposal::AdvancedMH.RandomWalkProposal)
+    invlink!(varinfo, sampler)
+end
+
 function AbstractMCMC.sample_init!(
     rng::AbstractRNG,
     model::Model,
@@ -204,9 +215,7 @@ function AbstractMCMC.sample_init!(
 
     # If we're doing random walk with a covariance matrix,
     # just link everything before sampling.
-    if spl.alg.proposals isa AdvancedMH.RandomWalkProposal{<:MvNormal}
-        link!(spl.state.vi, spl)
-    end
+    maybe_link!(spl.state.vi, spl, spl.alg.proposals)
 end
 
 function AbstractMCMC.sample_end!(
@@ -220,9 +229,8 @@ function AbstractMCMC.sample_end!(
     kwargs...
 )
     # We are doing a random walk, so we unlink everything when we're done.
-    if spl.alg.proposals isa AdvancedMH.RandomWalkProposal{<:MvNormal}
-        invlink!(spl.state.vi, spl)
-    end
+    maybe_invlink!(spl.state.vi, spl, spl.alg.proposals)
+
 end
 
 function AbstractMCMC.step!(

--- a/src/inference/mh.jl
+++ b/src/inference/mh.jl
@@ -6,6 +6,9 @@ struct MH{space, P} <: InferenceAlgorithm
     proposals::P
 end
 
+proposal(p::AdvancedMH.Proposal) = p
+proposal(cov::AbstractMatrix) = AdvancedMH.RandomWalkProposal(MvNormal(cov))
+
 function MH(space...)
     syms = Symbol[]
 
@@ -32,11 +35,7 @@ function MH(space...)
             # If we hit this block, check to see if it's 
             # a run-of-the-mill proposal or covariance
             # matrix.
-            prop = if s isa AdvancedMH.Proposal
-                s
-            elseif typeof(s) <: Array{<:Real, 2}
-                AdvancedMH.RandomWalkProposal(MvNormal(s))
-            end
+            prop = proposal(s)
 
             # Return early, we got a covariance matrix. 
             return MH{(), typeof(prop)}(prop)

--- a/test/inference/mh.jl
+++ b/test/inference/mh.jl
@@ -89,7 +89,7 @@ include(dir*"/test/test_utils/AllUtils.jl")
     @turing_testset "proposal matrix" begin
         Random.seed!(100)
         
-        mat = [2.0 -0.15; -0.15 2.0]
+        mat = [1.0 -0.05; -0.05 1.0]
 
         prop1 = mat # Matrix only constructor
         prop2 = AdvancedMH.RandomWalkProposal(MvNormal(mat)) # Explicit proposal constructor
@@ -102,8 +102,8 @@ include(dir*"/test/test_utils/AllUtils.jl")
         @test spl1.proposals.proposal.Σ.mat == spl2.proposals.proposal.Σ.mat
 
         # Test inference.
-        chain1 = sample(gdemo_default, spl1, 100000)
-        chain2 = sample(gdemo_default, spl2, 100000)
+        chain1 = sample(gdemo_default, spl1, 10000)
+        chain2 = sample(gdemo_default, spl2, 10000)
 
         check_gdemo(chain1)
         check_gdemo(chain2)

--- a/test/inference/mh.jl
+++ b/test/inference/mh.jl
@@ -85,4 +85,25 @@ include(dir*"/test/test_utils/AllUtils.jl")
 
         @test chain isa MCMCChains.Chains
     end
+
+    @turing_testset "proposal matrix" begin
+        mat = [2.0 -0.15; -0.15 2.0]
+
+        prop1 = mat # Matrix only constructor
+        prop2 = AdvancedMH.RandomWalkProposal(MvNormal(mat)) # Explicit proposal constructor
+
+        spl1 = MH(prop1)
+        spl2 = MH(prop2)
+
+        # Test that the two constructors are equivalent.
+        @test spl1.proposals.proposal.μ == spl2.proposals.proposal.μ
+        @test spl1.proposals.proposal.Σ.mat == spl2.proposals.proposal.Σ.mat
+
+        # Test inference.
+        chain1 = sample(gdemo_default, spl1, 10000)
+        chain2 = sample(gdemo_default, spl2, 10000)
+
+        check_gdemo(chain1)
+        check_gdemo(chain2)
+    end
 end

--- a/test/inference/mh.jl
+++ b/test/inference/mh.jl
@@ -87,6 +87,8 @@ include(dir*"/test/test_utils/AllUtils.jl")
     end
 
     @turing_testset "proposal matrix" begin
+        Random.seed!(100)
+        
         mat = [2.0 -0.15; -0.15 2.0]
 
         prop1 = mat # Matrix only constructor
@@ -100,8 +102,8 @@ include(dir*"/test/test_utils/AllUtils.jl")
         @test spl1.proposals.proposal.Σ.mat == spl2.proposals.proposal.Σ.mat
 
         # Test inference.
-        chain1 = sample(gdemo_default, spl1, 10000)
-        chain2 = sample(gdemo_default, spl2, 10000)
+        chain1 = sample(gdemo_default, spl1, 100000)
+        chain2 = sample(gdemo_default, spl2, 100000)
 
         check_gdemo(chain1)
         check_gdemo(chain2)


### PR DESCRIPTION
Allows you to specify a proposal matrix for MH and just use that instead of all the NamedTuple weirdness that happens by default:

```julia
using Turing

@model function gdemo()
    s ~ InverseGamma(2,3)
    m ~ Normal(0, sqrt(s))

    1.5 ~ Normal(m, sqrt(s))
    2.0 ~ Normal(m, sqrt(s))

    return m, s
end

model = gdemo()

proposal_matrix = [1.5 -0.15; -0.15 1.5]

chain = sample(model, MH(proposal_matrix), 100000)
```

It's a little faster in some cases than the default NamedTuple (though not by much, the NamedTuple stuff is really fast), depending on your choice of proposal matrix. 

Tests are included, but for the most part this is a really minor change.