### PR TITLE
Pass init_theta kwarg to initialize_parameters!

### DIFF
--- a/src/inference/hmc.jl
+++ b/src/inference/hmc.jl
@@ -122,7 +122,7 @@ function AbstractMCMC.sample_init!(
     set_resume!(spl; resume_from=resume_from, kwargs...)
 
     # Get `init_theta`
-    initialize_parameters!(spl; verbose=verbose, kwargs...)
+    initialize_parameters!(spl; init_theta = init_theta, verbose=verbose, kwargs...)
     if init_theta !== nothing
         # Doesn't support dynamic models
         link!(spl.state.vi, spl)

--- a/src/inference/hmc.jl
+++ b/src/inference/hmc.jl
@@ -122,7 +122,7 @@ function AbstractMCMC.sample_init!(
     set_resume!(spl; resume_from=resume_from, kwargs...)
 
     # Get `init_theta`
-    initialize_parameters!(spl; init_theta = init_theta, verbose=verbose, kwargs...)
+    initialize_parameters!(spl; init_theta=init_theta, verbose=verbose, kwargs...)
     if init_theta !== nothing
         # Doesn't support dynamic models
         link!(spl.state.vi, spl)


### PR DESCRIPTION
This PR passes the forgotten kwarg `init_theta` to the `initialize_parameters!` function for HMC.