### PR TITLE
Add CompatHelper secret

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -13,4 +13,5 @@ jobs:
       - name: CompatHelper.main()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}
         run: julia -e 'using CompatHelper; CompatHelper.main()'


### PR DESCRIPTION
This PR prepares CompatHelper for running the CI tests on Github (currently CompatHelper does not run any Github CI tests).

Someone with sufficient permissions has to follow the steps in https://github.com/bcbi/CompatHelper.jl#122-instructions-for-setting-up-the-ssh-deploy-key and add a private key and a deploy key to make it actually work.