### PR TITLE
add ColPrac guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Build Status](https://github.com/TuringLang/Turing.jl/workflows/Turing-CI/badge.svg)](https://github.com/TuringLang/Turing.jl/actions?query=workflow%3ATuring-CI+branch%3Amaster)
 [![Coverage Status](https://coveralls.io/repos/github/yebai/Turing.jl/badge.svg?branch=master)](https://coveralls.io/github/yebai/Turing.jl?branch=master)
 [![Documentation](https://img.shields.io/badge/doc-latest-blue.svg)](https://turing.ml/dev/docs/using-turing/)
+[![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
 
 **Turing.jl** is a Julia library for general-purpose [probabilistic programming](https://en.wikipedia.org/wiki/Probabilistic_programming_language). Turing allows the user to write models using standard Julia syntax, and provides a wide range of sampling-based inference methods for solving problems across probabilistic machine learning, Bayesian statistics, and data science. Compared to other probabilistic programming languages, Turing has a special focus on modularity, and decouples the modelling language (i.e. the compiler) and inference methods. This modular design, together with the use of a high-level numerical language Julia, makes Turing particularly extensible: new model families and inference methods can be easily added.
 


### PR DESCRIPTION
Adds the new collaborative practices guide. This seems to have buy in from several members of the team, but would require everyone to be on board.

We already do pretty much everything, the only thing that we _don't_ do is release a patch version after every merged PR. The reason to like this is that
1. it makes identifying where a bug was introduced really easy (if we accidentally introduce a bug with a release)
2. it means that patches get to users instantly, rather than having to wait for minor releases that we only do every so often

It doesn't really have any downsides because there's plenty of tooling in place to handle everything.

@yebai @xukai92 @devmotion @cpfiffer and anyone else that I've missed.