### PR TITLE
Add .jekyll-cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ docs/_tutorials/
 docs/_site/
 docs/.gems/
 docs/Gemfile.lock
+docs/.jekyll-cache
 
 .vscode
 .DS_Store


### PR DESCRIPTION
Adds `docs/.jekyll-cache` to the `.gitignore`, so we don't end up inadvertently tracking local cache files for the site if someone builds locally. 