### PR TITLE
Require Julia 1.3

### DIFF
--- a/.github/workflows/DynamicHMC.yml
+++ b/.github/workflows/DynamicHMC.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         version:
+          - '1.3'
           - '1'
         os:
           - ubuntu-latest

--- a/.github/workflows/Numerical.yml
+++ b/.github/workflows/Numerical.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         version:
+          - '1.3'
           - '1'
         os:
           - ubuntu-latest

--- a/.github/workflows/StanCI.yml
+++ b/.github/workflows/StanCI.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         version:
+          - '1.3'
           - '1'
         os:
           - ubuntu-latest

--- a/.github/workflows/TuringCI.yml
+++ b/.github/workflows/TuringCI.yml
@@ -23,6 +23,8 @@ jobs:
           - x86
           - x64
         exclude:
+          - os: windows-latest
+            arch: x86
           - os: macOS-latest
             arch: x86
     steps:

--- a/.github/workflows/TuringCI.yml
+++ b/.github/workflows/TuringCI.yml
@@ -13,12 +13,12 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.0'
+          - '1.3'
           - '1'
         os:
           - ubuntu-latest
           - windows-latest
-          - macOS-latest 
+          - macOS-latest
         arch:
           - x86
           - x64

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ os:
   - linux
 matrix:
   include:
-    - julia: 1.0
+    - julia: 1.3
     - julia: 1
       env: JULIA_NUM_THREADS=1
     - julia: 1

--- a/Project.toml
+++ b/Project.toml
@@ -53,7 +53,7 @@ SpecialFunctions = "0.7.2, 0.8, 0.9, 0.10"
 StatsBase = "0.32, 0.33"
 StatsFuns = "0.8, 0.9"
 Tracker = "0.2.3"
-julia = "1"
+julia = "1.3"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"


### PR DESCRIPTION
This PR drops support of Julia < 1.3 since other packages such as Tracker and NNlib only support Julia >= 1.3 which would require us to backport fixes if we want to support Julia < 1.3 properly.