### PR TITLE
Documentation updates

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - 'master'
     tags: '*'
+  workflow_dispatch:
 
 jobs:
   docs:

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -9,3 +9,4 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}

--- a/docs/src/for-developers/compiler.md
+++ b/docs/src/for-developers/compiler.md
@@ -2,7 +2,7 @@
 title: Turing Compiler Design
 ---
 
-In this section, I will describe the current design of Turing's model compiler which enables Turing to perform various types of Bayesian inference without changing the model definition. What we call "compiler" is essentially just a macro that transforms the user's code to something that Julia's dispatch can operate on and that Julia's compiler can successfully do type inference on for efficient machine code generation.
+In this section, the current design of Turing's model "compiler" is described which enables Turing to perform various types of Bayesian inference without changing the model definition. The "compiler" is essentially just a macro that rewrites the user's model definition to a function that generates a `Model` struct that Julia's dispatch can operate on and that Julia's compiler can successfully do type inference on for efficient machine code generation.
 
 # Overview
 
@@ -10,25 +10,46 @@ The following terminology will be used in this section:
 
 - `D`: observed data variables conditioned upon in the posterior,
 - `P`: parameter variables distributed according to the prior distributions, these will also be referred to as random variables,
-- `Model`: a fully defined probabilistic model with input data, and
-- `ModelGen`: a model generator function that can be used to instantiate a `Model` instance by inputing data `D`.
+- `Model`: a fully defined probabilistic model with input data
 
-`Turing`'s `@model` macro defines a `ModelGen` that can be used to instantiate a `Model` by passing in the observed data `D`.
-
-# `@model` macro and `ModelGen`
+`Turing`'s `@model` macro rewrites the user-provided function definition such that it can be used to instantiate a `Model` by passing in the observed data `D`.
 
 The following are the main jobs of the `@model` macro:
 1. Parse `~` and `.~` lines, e.g. `y .~ Normal.(c*x, 1.0)`
 2. Figure out if a variable belongs to the data `D` and or to the parameters `P`
 3. Enable the handling of missing data variables in `D` when defining a `Model` and treating them as parameter variables in `P` instead
 4. Enable the tracking of random variables using the data structures `VarName` and `VarInfo`
-5. Change `~`/`.~` lines with a variable in `P` on the LHS to a call to an `assume`/`dot_assume`-block
-6. Change `~`/`.~` lines with a variable in `D` on the LHS to a call to an `observe`/`dot_observe`-block
+5. Change `~`/`.~` lines with a variable in `P` on the LHS to a call to `tilde_assume` or `dot_tilde_assume`
+6. Change `~`/`.~` lines with a variable in `D` on the LHS to a call to `tilde_observe` or `dot_tilde_observe`
 7. Enable type stable automatic differentiation of the model using type parameters
 
-Let's take the following model as an example:
+
+## The model
+
+A `model::Model` is a callable struct that one can sample from by calling
 ```julia
-@model gauss(x = missing, y = 1.0, ::Type{TV} = Vector{Float64}) where {TV <: AbstractVector} = begin
+(model::Model)([rng, varinfo, sampler, context])
+```
+where `rng` is a random number generator (default: `Random.GLOBAL_RNG`), `varinfo` is a data structure that stores information
+about the random variables (default: `DynamicPPL.VarInfo()`), `sampler` is a sampling algorithm (default: `DynamicPPL.SampleFromPrior()`),
+and `context` is a sampling context that can, e.g., modify how the log probability is accumulated (default: `DynamicPPL.DefaultContext()`).
+
+Sampling resets the log joint probability of `varinfo` and increases the evaluation counter of `sampler`. If `context` is a `LikelihoodContext`,
+only the log likelihood will be accumulated. With the `DefaultContext` the log joint probability of `P` and `D` is accumulated.
+
+The `Model` struct contains the three internal fields `f`, `args` and `defaults`.
+When `model::Model` is called, then the internal function `model.f` is called as `model.f(rng, varinfo, sampler, context, model.args...)`
+(for multithreaded sampling, instead of `varinfo` a threadsafe wrapper is passed to `model.f`).
+The positional and keyword arguments that were passed to the user-defined model function when the model was created are saved as a `NamedTuple`
+in `model.args`. The default values of the positional and keyword arguments of the user-defined model functions, if any, are saved as a `NamedTuple`
+in `model.defaults`. They are used for constructing model instances with different arguments by the `logprob` and `prob` string macros.
+
+# Example
+
+Let's take the following model as an example:
+
+```julia
+@model function gauss(x = missing, y = 1.0, ::Type{TV} = Vector{Float64}) where {TV<:AbstractVector}
     if x === missing
         x = TV(undef, 3)
     end
@@ -40,184 +61,126 @@ Let's take the following model as an example:
     y ~ Normal(p[2], sqrt(p[1]))
 end
 ```
-The above call of the `@model` macro defines an instance of `ModelGen` called `gauss`. A `model::Model` can be defined using `gauss(rand(3), 1.0)` or `gauss(x = rand(3), y = 1.0)`. While constructing the model, if an argument is not passed in, it gets assigned to its default value. If there is no default value given, an error is thrown. If an argument has a default value `missing`, when not passed in, it is treated as a random variable. For variables which require an intialization because we need to loop or broadcast over its elements, such as `x` above, the following needs to be done:
+
+The above call of the `@model` macro defines the function `gauss` with positional arguments `x`, `y`, and `::Type{TV}`, rewritten in
+such a way that every call of it returns a `model::Model`. Note that only the function body is modified by the `@model` macro, and the
+function signature is left untouched. It is also possible to implement models with keyword arguments such as
+
+```julia
+@model function gauss(::Type{TV} = Vector{Float64}; x = missing, y = 1.0) where {TV<:AbstractVector}
+    ...
+end
+```
+
+This would allow us to generate a model by calling `gauss(; x = rand(3))`.
+
+If an argument has a default value `missing`, it is treated as a random variable. For variables which require an intialization because we
+need to loop or broadcast over its elements, such as `x` above, the following needs to be done:
 ```julia
 if x === missing
     x = ...
 end
 ```
-If `x` is sampled as a whole from a multivariate distribution, e.g. `x ~ MvNormal(...)`, there is no need to initialize it in an `if`-block.
+Note that since `gauss` behaves like a regular function it is possible to define additional dispatches in a second step as well. For
+instance, we could achieve the same behaviour by
 
-`ModelGen` is defined as:
 ```julia
-struct ModelGen{Targs, F, Tdefaults} <: Function
-    f::F
-    defaults::Tdefaults
+@model function gauss(x, y = 1.0, ::Type{TV} = Vector{Float64}) where {TV<:AbstractVector}
+    p = TV(undef, 2)
+    ...
 end
-ModelGen{Targs}(args...) where {Targs} = ModelGen{Targs, typeof.(args)...}(args...)
-(m::ModelGen)(args...; kwargs...) = m.f(args...; kwargs...)
-```
-`Targs` is the tuple of the symbols of the model's arguments, `(:x, :y, :TV)`. `defaults` is the `NamedTuple` of default values `(x = missing, y = 1.0, TV = Vector{Float64})`.
 
-The `@model` macro is defined as:
-```julia
-macro model(input_expr)
-    build_model_info(input_expr) |> replace_tilde! |> replace_vi! |> 
-        replace_logpdf! |> replace_sampler! |> build_output
+function gauss(::Missing, y = 1.0, ::Type{TV} = Vector{Float64}) where {TV<:AbstractVector}
+    return gauss(TV(undef, 3), y, TV)
 end
 ```
 
-## `build_model_info`
+If `x` is sampled as a whole from a distribution and not indexed, e.g., `x ~ Normal(...)` or `x ~ MvNormal(...)`,
+there is no need to initialize it in an `if`-block.
 
-The first stop that the model definition takes is `build_model_info`. This function extracts some information from the model definition such as:
-- `name`: the model name.
-- `main_body`: the model body excluding the header and `end`.
-- `arg_syms`: the argument symbols, e.g. `[:x, :y, :TV]` above.
-- `args`: a modified version of the arguments changing `::Type{TV}=Vector{Float64}` and `where {TV <: AbstractVector}` to `TV::Type{<:AbstractVector}=Vector{Float64}`. This is `[:(x = missing) :(y = 1.0), :(TV::Type{<:AbstractVector}=Vector{Float64})]` in the example above.
-- `args_nt`: an expression constructing a `NamedTuple` of the input arguments, e.g. :((x = x, y = y, TV = TV)) in the example above.
-- `defaults_nt`: an expression constructing a `NamedTuple` of the default values of the input arguments, if any, e.g. :((x = missing, y = 1, TV = Vector{Float64})) in the example above.
-and returns it as a dictionary called `model_info`.
+## Step 1: Break up the model definition
 
-## `replace_tilde!`
+First, the `@model` macro breaks up the user-provided function definition using `DynamicPPL.build_model_info`. This function
+returns a dictionary consisting of:
+- `allargs_exprs`: The expressions of the positional and keyword arguments, without default values.
+- `allargs_syms`: The names of the positional and keyword arguments, e.g., `[:x, :y, :TV]` above.
+- `allargs_namedtuple`: An expression that constructs a `NamedTuple` of the positional and keyword arguments, e.g., `:((x = x, y = y, TV = TV))` above.
+- `defaults_namedtuple`: An expression that constructs a `NamedTuple` of the default positional and keyword arguments, if any, e.g., `:((x = missing, y = 1, TV = Vector{Float64}))` above.
+- `modeldef`: A dictionary with the name, arguments, and function body of the model definition, as returned by `MacroTools.splitdef`.
 
-After some model information have been extracted, `replace_tilde!` replaces the `L ~ R` lines in the model with the output of `Core.tilde(L, R, model_info)` where `L` and `R` are either expressions or symbols. `L` can also be a constant literal. The `replace_tilde!` function also replaces expressions of the form `@. L ~ R` with the output of `dot_tilde(L, R, model_info)`.
+## Step 2: Generate the body of the internal model function
 
-In the above example, `p[1] ~ InverseGamma(2, 3)` is replaced with:
+In a second step, `DynamicPPL.generate_mainbody` generates the main part of the transformed function body using the user-provided function body
+and the provided function arguments, without default values, for figuring out if a variable denotes an observation or a random variable.
+Hereby the function `DynamicPPL.generate_tilde` replaces the `L ~ R` lines in the model and the function `DynamicPPL.generate_dot_tilde` replaces
+the `@. L ~ R` and `L .~ R` lines in the model.
+
+In the above example, `p[1] ~ InverseGamma(2, 3)` is replaced with something similar to
 ```julia
-temp_right = InverseGamma(2, 3)
-Turing.Core.assert_dist(temp_right, msg = ...)
-preprocessed = Turing.Core.@preprocess(Val((:x, :y, :T)), Turing.getmissing(model), p[1])
-if preprocessed isa Tuple
-    vn, inds = preprocessed
-    out = Turing.Inference.tilde(ctx, sampler, temp_right, vn, inds, vi)
-    p[1] = out[1]
-    acclogp!(vi, out[2])
-else
-    lp = Turing.Inference.tilde(ctx, sampler, temp_right, preprocessed, vi)
-    acclogp!(vi, lp)
+#= REPL[25]:6 =#
+begin
+    var"##tmpright#323" = InverseGamma(2, 3)
+    var"##tmpright#323" isa Union{Distribution, AbstractVector{<:Distribution}} || throw(ArgumentError("Right-hand side of a ~ must be subtype of Distribution or a vector of Distributions."))
+    var"##vn#325" = (DynamicPPL.VarName)(:p, ((1,),))
+    var"##inds#326" = ((1,),)
+    p[1] = (DynamicPPL.tilde_assume)(_rng, _context, _sampler, var"##tmpright#323", var"##vn#325", var"##inds#326", _varinfo)
 end
 ```
-where `ctx::AbstractContext`, `sampler::AbstractSampler` and `vi::VarInfo` will be discussed later. `assert_dist` will check that the RHS of `~` is a distribution otherwise an error is thrown. The `@preprocess` macro here checks:
-1. If the symbol on the LHS of `~`, `:p` in this case, is in the arguments to the model, `(:x, :y, :T)`, or not. If it isn't, then `p[1]` will be treated as a random variable. 
-2. If it is in the arguments but was among the arguments with a value of `missing`, obtained using `getmissing(model)`, then `p[1]` is also treated as a random variable.
-3. If neither of the above is true, but the value of `p[1]` is `missing`, then `p[1]` will still be treated as a random variable.
-4. Otherwise, `p[1]` is treated as an observation.
+Here the first line is a so-called line number node that enables more helpful error messages by providing users with the exact location
+of the error in their model definition. Then the right hand side (RHS) of the `~` is assigned to a variable (with an automatically generated name).
+We check that the RHS is a distribution or an array of distributions, otherwise an error is thrown.
+Next we extract a compact representation of the variable with its name and index (or indices). Finally, the `~` expression is replaced with
+a call to `DynamicPPL.tilde_assume` since the compiler figured out that `p[1]` is a random variable using the following
+heuristic:
+1. If the symbol on the LHS of `~`, `:p` in this case, is not among the arguments to the model, `(:x, :y, :T)` in this case, it is a random variable. 
+2. If the symbol on the LHS of `~`, `:p` in this case, is among the arguments to the model but has a value of `missing`, it is a random variable.
+2. If the value of the LHS of `~`, `p[1]` in this case, is `missing`, then it is a random variable.
+4. Otherwise, it is treated as an observation.
 
-If `@preprocess` treats `p[1]` as a random variable, it will return a `2-Tuple` of: 1) a variable identifier `vn::VarName = Turing.@varname p[1]`, and 2) a tuple of tuples of the indices used in `vn`, `((1,),)` in this example. Otherwise, `@preprocess` returns the value of `p[1]`. `Turing.@varname` and `VarName` wil be explained later. The above checks by `@preprocess` were carefully written to make sure that the Julia compiler can compile them away so no checks happen at runtime and only the correct branch is run straight away. 
+The `DynamicPPL.tilde_assume` function takes care of sampling the random variable, if needed, and updating its value and the accumulated log joint
+probability in the `_varinfo` object. If `L ~ R` is an observation, `DynamicPPL.tilde_observe` is called with the same arguments except the
+random number generator `_rng` (since observations are never sampled).
 
-When the output of `@preprocess` is a `Tuple`, i.e. `p[1]` is a random variable, the `Turing.Inference.tilde` function will dispatch to a different method than when the output is of another type, i.e `p[1]` is an observation. In the former case, `Turing.Inference.tilde` returns 2 outputs, the value of the random variable and the `log` probability, while in the latter case, only the `log` probability is returned. The `log` probabilities then get accumulated and if `p[1]` is a random variable, the first returned output by `Turing.Inference.tilde` gets assigned to it.
-
-Note that `Core.tilde` is different from `Inference.tilde`. `Core.tilde` returns the expression block that will be run instead of the `~` line. A part of this expression block is a call to `Inference.tilde` as shown above. `Core.tilde` is defined in the `compiler.jl` file, while `Inference.tilde` is defined in the `Inference.jl` file.
-
-The `dot_tilde!` function does something similar for expressions of the form `@. L ~ R` (and `L .~ R` in Julia 1.1 and above). Let's take `@. x[1:2] ~ Normal(p[2], sqrt(p[1]))` as an example. This expressions replaced with:
+A similar transformation is performed for expressions of the form `@. L ~ R` and `L .~ R`. For instance,
+`@. x[1:2] ~ Normal(p[2], sqrt(p[1]))` is replaced with
 ```julia
-temp_right = Normal(p[2], sqrt(p[1]))
-Turing.Core.assert_dist(temp_right, msg = ...)
-preprocessed = Turing.Core.@preprocess(Val((:x, :y, :T)), Turing.getmissing(model), x[1:2])
-if preprocessed isa Tuple
-    vn, inds = preprocessed
-    temp_left = x[1:2]
-    out = Turing.Inference.dot_tilde(ctx, sampler, temp_right, temp_left, vn, inds, vi)
-    left .= out[1]
-    acclogp!(vi, out[2])
-else
-    temp_left = preprocessed # x[1:2]
-    lp = Turing.Inference.dot_tilde(ctx, sampler, temp_right, temp_left, vi)
-    acclogp!(vi, lp)
-end
-```
-The main difference in the expanded code between `L ~ R` and `@. L ~ R` is that the former doesn't assume `L` to be defined, it can be a new Julia variable in the scope, while the latter assumes `L` already exists. `L` is also always input to the `dot_tilde` function but not the `tilde` function.
-
-## `replace_vi!`, `replace_logpdf!` and `replace_sampler!`
-
-Using `@varinfo()` inside the model body will give the user access to the `vi::VarInfo` object used inside the model. The function `replace_vi!` therefore finds and replaces every use of `@varinfo()` with the handle to the `VarInfo` instance used inside the model. The `@logpdf()` macro will return `vi.logp[]` which is the accumumlated `log` probability that the model is computing. What this means can change depending on the context, `ctx`, used when running the model. Finally, `replace_sampler!` will replace `@sampler()` with the `sampler` input to the model.
-
-## `Turing.Model`
-
-Every `model::Model` can be called as a function with arguments:
-1. `vi::VarInfo`,
-2. `spl::AbstractSampler`, and
-3. `ctx::AbstractContext`.
-`vi` is a data structure that stores information about random variables in `P`. `spl` includes the choice of the MCMC algorithm, e.g. Metropolis-Hastings, importance sampling or Hamiltonian Monte Carlo (HMC). `ctx` is used to modify the behaviour of the `logp` accumulator, accumulating different variants of it. For example, if `ctx isa LikelihoodContext`, only the log likelihood will be accumulated in `vi.logp[]`. By default, `ctx isa DefaultContext` which accumulates the log joint probability of `P` and `D`. The `Inference.tilde` and `Inference.dot_tilde` functions will do something different for different subtypes of `AbstractSampler` to facilitate the sampling process.
-
-The `Model` struct is defined as follows:
-```julia
-struct Model{F, Targs <: NamedTuple, Tmodelgen, Tmissings <: Val}
-    f::F
-    args::Targs
-    modelgen::Tmodelgen
-    missings::Tmissings
-end
-Model(f, args::NamedTuple, modelgen) = Model(f, args, modelgen, getmissing(args))
-(model::Model)(vi) = model(vi, SampleFromPrior())
-(model::Model)(vi, spl) = model(vi, spl, DefaultContext())
-(model::Model)(args...; kwargs...) = model.f(args..., model; kwargs...)
-```
-`model.f` is an internal function that is called when `model` is called, where `model::Model`. When `model` is called, `model` itself is passed as an argument to `model.f` because we need to access `model.args` among other things inside `f`. `model.args` is a `NamedTuple` of all the arguments that were passed to the model generating function when constructing an instance of `Model`. `modelgen` is the instance of `ModelGen` that was used to construct `model`. `missings` is an instance of `Val`, e.g. `Val{(:a, :b)}()`. `getmissings` returns a `Val` instance of all the symbols in `args` with a value `missing`. This is the default definition of `missings`. All variables in `missings` are treated as random variables rather than observations. 
-
-In some non-traditional use-cases, `missings` is defined differently, e.g. when computing the log joint probability of the random variables and only some observations simultaneously, possibly conditioned on the remaining observations. An example using the model above is `logprob"x = rand(3), p = rand(2) | model = gauss, y = nothing"`. To evaluate this, the model argument `x` on the LHS of `|` is treated as a random variable leading to a call to the `assume` or `dot_assume` function in place of the `~` or `.~` expressions, respectively. The model is then run in the `PriorContext` which ignores the `observe` and `dot_observe` functions and only runs the `assume` and `dot_assume` ones. This returns the correct log probability. The reason why a model input argument, such as `x`, cannot be initialized to `missing` when on the LHS of `|` is somewhat subtle. In the model body before calling `~`, sometimes there would be a call to `length(x)` iterating over the elements of `x` in a loop calling `~` on each element of `x`. If `x` is initialized to `missing`, this will error because `length(missing)` is not defined. Moreover, it is not intuitive to require the user to handle the `x === missing` case because the user never assigned `x` to be `missing` in the first place, `missing` is merely an implementation detail in this case that the users need not concern themselves with. Therefore in this case, it makes sense to de-couple the `missings` field from the values of the arguments.
-
-## `build_output`
-
-Now that we have all the information we need in the `@model` macro, we can start building the model generator function. The model generator function `gauss` will be defined as:
-```julia
-function outer_function(;
-    x = missing,
-    y = 1.0,
-    TV::Type{<:AbstractVector} = Vector{Float64},
-)
-    return outer_function(x, y, TV)
-end
-function outer_function(
-    x = missing,
-    y = 1.0,
-    TV::Type{<:AbstractVector} = Vector{Float64},
-)
-    function inner_function(vi::Turing.VarInfo, sampler::Turing.AbstractSampler, ctx::AbstractContext, model)
-        ...
+#= REPL[25]:8 =#
+begin
+    var"##tmpright#331" = Normal.(p[2], sqrt.(p[1]))
+    var"##tmpright#331" isa Union{Distribution, AbstractVector{<:Distribution}} || throw(ArgumentError("Right-hand side of a ~ must be subtype of Distribution or a vector of Distributions."))
+    var"##vn#333" = (DynamicPPL.VarName)(:x, ((1:2,),))
+    var"##inds#334" = ((1:2,),)
+    var"##isassumption#335" = begin
+        let var"##vn#336" = (DynamicPPL.VarName)(:x, ((1:2,),))
+            if !((DynamicPPL.inargnames)(var"##vn#336", _model)) || (DynamicPPL.inmissings)(var"##vn#336", _model)
+                true
+            else
+                x[1:2] === missing
+            end
+        end
     end
-    return Turing.Model(
-        inner_function,
-        (x = x, y = y, TV = TV),
-        Turing.Core.ModelGen{(:x, :y, :TV)}(
-            outer_function,
-            (x = missing, y = 1.0, TV = Vector{Float64}),
-        ),
-    )
-end
-gauss = Turing.Core.ModelGen{(:x, :y, :TV)}(
-            outer_function,
-            (x = missing, y = 1.0, TV = Vector{Float64}),
-        )
-```
-The above 2 methods enable constructing the model using positional or keyword arguments. The second argument to the `Turing.Model` constructor is the expression called `args_nt` stored in `model_info`. The second argument to the `ModelGen` constructor inside `outer_function` and outside is the expression called `defaults_nt` stored in `model_info`. The body of the `inner_function` is explained below.
-
-## `inner_function`
-
-The main method of `inner_function` does some pre-processing defining all the input variables from the model definition, `x`, `y` and `TV` in the example above. Then the rest of the model body is run as normal Julia code with the `L ~ R` and `@. L ~ R` lines replaced with the calls to `Inference.tilde` and `Inference.dot_tilde` respectively as shown earlier.
-```julia
-function inner_function(vi::Turing.VarInfo, sampler::Turing.AbstractSampler, ctx::AbstractContext, model)
-    temp_x = model.args.x
-    xT = typeof(temp_x)
-    if temp_x isa Turing.Core.FloatOrArrayType
-        x = Turing.Core.get_matching_type(sampler, vi, temp_x)
-    elseif Turing.Core.hasmissing(xT)
-        x = Turing.Core.get_matching_type(sampler, vi, xT)(temp_x)
+    if var"##isassumption#335"
+        x[1:2] .= (DynamicPPL.dot_tilde_assume)(_rng, _context, _sampler, var"##tmpright#331", x[1:2], var"##vn#333", var"##inds#334", _varinfo)
     else
-        x = temp_x
+        (DynamicPPL.dot_tilde_observe)(_context, _sampler, var"##tmpright#331", x[1:2], var"##vn#333", var"##inds#334", _varinfo)
     end
-
-    ... # The code above is repeated for the other 2 variables, y and TV
-
-    # Reset the `logp` accumulator
-    resetlogp!(vi)
-
-    ... # Main model body
 end
 ```
-As one can see above, `x`, `y` and `TV` are defined in the method body using an `if`-block followed by the rest of the code. The first branch of this `if`-block is run if the variable is a number or array type, such as `TV = Vector{Float64}`. One of the purposes of `get_matching_type` is to check if `sampler` requires automatic differentiation, and to modify `TV` accordingly. For example, when using `ForwardDiff` for automatic differentiation, `TV` will be defined as some concrete subtype of `Vector{<:ForwardDiff.Dual}`. This same function is also used to replace `Array` with `Libtask.TArray` types when a particle sampler is used.
+The main difference in the expanded code between `L ~ R` and `@. L ~ R` is that the former doesn't assume `L` to be defined, it can be a new Julia variable in the scope, while the latter assumes `L` already exists. Moreover, `DynamicPPL.dot_tilde_assume` and `DynamicPPL.dot_tilde_observe` are called
+instead of `DynamicPPL.tilde_assume` and `DynamicPPL.tilde_observe`.
 
-The second branch of the `if`-block is to handle partially missing data converting the type of the input vector to another type befitting of the sampler used, whether it is for automatic differentiation or for particle samplers. Finally, the third branch is the one that will be run for `x` and `y` above simply assigning these names to `model.args.x` and `model.args.y` respectively. The main model body is then the same model body passed in by the user after replacing `L ~ R`, `@. L ~ R`, `@varinfo()` and `@logpdf()` as explained eariler.
+## Step 3: Replace the user-provided function body
+
+Finally, we replace the user-provided function body using `DynamicPPL.build_output`. This function uses `MacroTools.combinedef` to reassemble
+the user-provided function with a new function body. In the modified function body an anonymous function is created whose function body
+was generated in step 2 above and whose arguments are
+- a random number generator `_rng`,
+- a model `_model`,
+- a datastructure `_varinfo`,
+- a sampler `_sampler`,
+- a sampling context `_context`,
+- and all positional and keyword arguments of the user-provided model function as positional arguments
+without any default values. Finally, in the new function body a `model::Model` with this anonymous function as internal function is returned.
 
 # `VarName`
 

--- a/docs/src/using-turing/advanced.md
+++ b/docs/src/using-turing/advanced.md
@@ -84,7 +84,7 @@ Distributions.logpdf(d::Flat, x::AbstractVector{<:Real}) = zero(x)
 
 ## Update the accumulated log probability in the model definition
 
-Turing accumulates log probabilities internally in an internal datastructure that is accessible through
+Turing accumulates log probabilities internally in an internal data structure that is accessible through
 the internal variable `_varinfo` inside of the model definition (see below for more details about model internals).
 However, since users should not have to deal with internal data structures, a macro `Turing.@addlogprob!` is provided
 that increases the accumulated log probability. For instance, this allows you to
@@ -193,5 +193,4 @@ model = Turing.Model(modelf, (x = [1.5, 2.0],))
 
 
 Turing [copies](https://github.com/JuliaLang/julia/issues/4085) Julia tasks to deliver efficient inference algorithms, but it also provides alternative slower implementation as a fallback. Task copying is enabled by default. Task copying requires us to use the `CTask` facility which is provided by [Libtask](https://github.com/TuringLang/Libtask.jl) to create tasks.
-
 

--- a/docs/src/using-turing/advanced.md
+++ b/docs/src/using-turing/advanced.md
@@ -82,6 +82,55 @@ The vectorization syntax follows `rv ~ [distribution]`, which requires `rand` an
 Distributions.logpdf(d::Flat, x::AbstractVector{<:Real}) = zero(x)
 ```
 
+## Update the accumulated log probability in the model definition
+
+Turing accumulates log probabilities internally in an internal datastructure that is accessible through
+the internal variable `_varinfo` inside of the model definition (see below for more details about model internals).
+However, since users should not have to deal with internal data structures, a macro `Turing.@addlogprob!` is provided
+that increases the accumulated log probability. For instance, this allows you to
+[include arbitrary terms in the likelihood](https://github.com/TuringLang/Turing.jl/issues/1332)
+
+```julia
+using Turing
+
+myloglikelihood(x, μ) = loglikelihood(Normal(μ, 1), x)
+
+@model function demo(x)
+    μ ~ Normal()
+    Turing.@addlogprob! myloglikelihood(x, μ)
+end
+```
+
+and to [reject samples](https://github.com/TuringLang/Turing.jl/issues/1328):
+
+```julia
+using Turing
+using LinearAlgebra
+
+@model function demo(x)
+    m ~ MvNormal(length(x))
+    if dot(m, x) < 0
+        Turing.@addlogprob! -Inf
+        # Exit the model evaluation early
+        return
+    end
+    
+    x ~ MvNormal(m, 1.0)
+    return
+end
+```
+
+Note that `@addlogprob!` always increases the accumulated log probability, regardless of the provided
+sampling context. For instance, if you do not want to apply `Turing.@addlogprob!` when evaluating the
+prior of your model but only when computing the log likelihood and the log joint probability, then you
+should [check the type of the internal variable `_context`](https://github.com/TuringLang/DynamicPPL.jl/issues/154)
+such as
+
+```julia
+if !isa(_context, Turing.PriorContext)
+    Turing.@addlogprob! myloglikelihood(x, μ)
+end
+```
 
 ## Model Internals
 

--- a/docs/src/using-turing/autodiff.md
+++ b/docs/src/using-turing/autodiff.md
@@ -23,7 +23,7 @@ Turing supports intermixed automatic differentiation methods for different varia
 using Turing
 
 # Define a simple Normal model with unknown mean and variance.
-@model gdemo(x, y) = begin
+@model function gdemo(x, y)
     s ~ InverseGamma(2, 3)
     m ~ Normal(0, sqrt(s))
     x ~ Normal(m, sqrt(s))
@@ -37,7 +37,7 @@ c = sample(
     	HMC{Turing.ForwardDiffAD{1}}(0.1, 5, :m),
         HMC{Turing.TrackerAD}(0.1, 5, :s)
     ),
-    1000
+    1000,
 )
 ```
 

--- a/docs/src/using-turing/dynamichmc.md
+++ b/docs/src/using-turing/dynamichmc.md
@@ -20,7 +20,7 @@ Here is a brief example of how to apply `DynamicNUTS`:
 using LogDensityProblems, DynamicHMC, Turing
 
 # Model definition.
-@model gdemo(x, y) = begin
+@model function gdemo(x, y)
   s ~ InverseGamma(2, 3)
   m ~ Normal(0, sqrt(s))
   x ~ Normal(m, sqrt(s))

--- a/docs/src/using-turing/get-started.md
+++ b/docs/src/using-turing/get-started.md
@@ -12,30 +12,22 @@ To use Turing, you need to install Julia first and then install Turing.
 
 ### Install Julia
 
-You will need to install Julia 1.0 or greater, which you can get from [the official Julia website](http://julialang.org/downloads/).
+You will need to install Julia 1.3 or greater, which you can get from [the official Julia website](http://julialang.org/downloads/).
 
 
 ### Install Turing.jl
 
-Turing is an officially registered Julia package, so the following will install a stable version of Turing while inside Julia's package manager (press `]` from the REPL):
-
-
-```julia
-add Turing
-```
-
-
-If you want to use the latest version of Turing with some experimental features, you can try the following instead:
-
+Turing is an officially registered Julia package, so you can install a stable version of Turing by running the following in the Julia REPL:
 
 ```julia
-add Turing#master
-test Turing
+julia> ] add Turing
 ```
 
+You can check if all tests pass by running
 
-If all tests pass, you're ready to start using Turing.
-
+```julia
+julia> ] test Turing
+```
 
 ### Example
 
@@ -47,7 +39,7 @@ using Turing
 using StatsPlots
 
 # Define a simple Normal model with unknown mean and variance.
-@model gdemo(x, y) = begin
+@model function gdemo(x, y)
   s ~ InverseGamma(2, 3)
   m ~ Normal(0, sqrt(s))
   x ~ Normal(m, sqrt(s))
@@ -57,11 +49,10 @@ end
 #  Run sampler, collect results
 chn = sample(gdemo(1.5, 2), HMC(0.1, 5), 1000)
 
-# Summarise results (currently requires the master branch from MCMCChains)
+# Summarise results
 describe(chn)
 
 # Plot and save results
 p = plot(chn)
 savefig("gdemo-plot.png")
 ```
-

--- a/docs/src/using-turing/guide.md
+++ b/docs/src/using-turing/guide.md
@@ -120,9 +120,8 @@ var_1 = mean(chn[:var_1]) # Taking the mean of a variable named var_1.
 
 
 The key (`:var_1`) can be a `Symbol` or a `String`. For example, to fetch `x[1]`, one can use `chn[Symbol("x[1]")` or `chn["x[1]"]`.
-
-
-The benefit of using a `Symbol` to index allows you to retrieve all the parameters associated with that symbol. As an example, if you have the parameters `"x[1]"`, `"x[2]"`, and `"x[3]"`, calling `chn[:x]` will return a new chain with only `"x[1]"`, `"x[2]"`, and `"x[3]"`.
+If you want to retrieve all parameters associated with a specific symbol, you can use `group`. As an example, if you have the
+parameters `"x[1]"`, `"x[2]"`, and `"x[3]"`, calling `group(chn, :x)` or `group(chn, "x")` will return a new chain with only `"x[1]"`, `"x[2]"`, and `"x[3]"`.
 
 
 Turing does not have a declarative form. More generally, the order in which you place the lines of a `@model` macro matters. For example, the following example works:

--- a/docs/src/using-turing/performancetips.md
+++ b/docs/src/using-turing/performancetips.md
@@ -5,7 +5,7 @@ title: Performance Tips
 # Performance Tips
 
 This section briefly summarises a few common techniques to ensure good performance when using Turing.
-We refer to [julialang.org](https://docs.julialang.org/en/v1/manual/performance-tips/index.html) for general techniques to ensure good performance of Julia programs.
+We refer to [the Julia documentation](https://docs.julialang.org/en/v1/manual/performance-tips/index.html) for general techniques to ensure good performance of Julia programs.
 
 
 ## Use multivariate distributions
@@ -15,7 +15,7 @@ It is generally preferable to use multivariate distributions if possible.
 The following example:
 
 ```julia
-@model gmodel(x) = begin
+@model function gmodel(x)
     m ~ Normal()
     for i = 1:length(x)
         x[i] ~ Normal(m, 0.2)
@@ -25,9 +25,11 @@ end
 can be directly expressed more efficiently using a simple transformation:
 
 ```julia
-@model gmodel(x) = begin
+using FillArrays
+
+@model function gmodel(x)
     m ~ Normal()
-    x ~ MvNormal(fill(m, length(x)), 0.2)
+    x ~ MvNormal(Fill(m, length(x)), 0.2)
 end
 ```
 
@@ -45,15 +47,14 @@ This is mainly due to the reverse-mode AD backends `Tracker` and `Zygote` which 
 Avoiding loops can be done using `filldist(dist, N)` and `arraydist(dists)`. `filldist(dist, N)` creates a multivariate distribution that is composed of `N` identical and independent copies of the univariate distribution `dist` if `dist` is univariate, or it creates a matrix-variate distribution composed of `N` identical and idependent copies of the multivariate distribution `dist` if `dist` is multivariate. `filldist(dist, N, M)` can also be used to create a matrix-variate distribution from a univariate distribution `dist`.  `arraydist(dists)` is similar to `filldist` but it takes an array of distributions `dists` as input. Writing a [custom distribution](advanced) with a custom adjoint is another option to avoid loops.
 
 
-## Make your model type-stable
+## Ensure that types in your model can be inferred
 
-For efficient gradient-based inference, e.g. using HMC, NUTS or ADVI, it is important to ensure the model is type-stable.
-We refer to [julialang.org](https://docs.julialang.org/en/v1/manual/performance-tips/index.html#Write-"type-stable"-functions-1) for a general discussion on type-stability.
+For efficient gradient-based inference, e.g. using HMC, NUTS or ADVI, it is important to ensure the types in your model can be inferred.
 
-The following example:
+The following example with abstract types
 
 ```julia
-@model tmodel(x, y) = begin
+@model function tmodel(x, y)
     p,n = size(x)
     params = Vector{Real}(undef, n)
     for i = 1:n
@@ -64,12 +65,13 @@ The following example:
     y ~ MvNormal(a, 1.0)
 end
 ```
-can be transformed into the following type-stable representation:
+
+can be transformed into the following representation with concrete types:
 
 ```julia
-@model tmodel(x, y, ::Type{T}=Vector{Float64}) where {T} = begin
+@model function tmodel(x, y, ::Type{T} = Float64) where {T}
     p,n = size(x)
-    params = T(undef, n)
+    params = Vector{T}(undef, n)
     for i = 1:n
         params[i] ~ truncated(Normal(), 0, Inf)
     end
@@ -79,19 +81,31 @@ can be transformed into the following type-stable representation:
 end
 ```
 
-Note that you can use `@code_warntype` to find type instabilities in your model definition.
-
-For example consider the following simple program
+Alternatively, you could use `filldist` in this example:
 
 ```julia
-@model tmodel(x) = begin
-	p = Vector{Real}(undef, 1); 
-	p[1] ~ Normal()
-	p = p .+ 1
-	x ~ Normal(p[1])
+@model function tmodel(x, y)
+    params = filldist(truncated(Normal(), 0, Inf), size(x, 2))
+    a = x * params
+    y ~ MvNormal(a, 1.0)
 end
 ```
-we can use
+
+Note that you can use `@code_warntype` to find types in your model definition that the compiler cannot infer.
+They are marked in red in the Julia REPL.
+
+For example consider the following simple program:
+
+```julia
+@model function tmodel(x)
+    p = Vector{Real}(undef, 1)
+    p[1] ~ Normal()
+    p = p .+ 1
+    x ~ Normal(p[1])
+end
+```
+
+We can use
 
 ```julia
 using Random
@@ -102,14 +116,15 @@ spl = Turing.SampleFromPrior()
 
 @code_warntype model.f(Random.GLOBAL_RNG, model, varinfo, spl, Turing.DefaultContext())
 ```
-to inspect the type instabilities in the model.
+
+to inspect type inference in the model.
 
 
 ## Reuse Computations in Gibbs Sampling
 
-Often when performing Gibbs sampling, one can save computational time by caching the output of expensive functions. The cached values can then be reused in future Gibbs sub-iterations which do not change the inputs to this expensive function. For example in the following model:
+Often when performing Gibbs sampling, one can save computational time by caching the output of expensive functions. The cached values can then be reused in future Gibbs sub-iterations which do not change the inputs to this expensive function. For example in the following model
 ```julia
-@model demo(x) = begin
+@model function demo(x)
     a ~ Gamma()
     b ~ Normal()
     c = function1(a)
@@ -130,7 +145,7 @@ using Memoization
 ```
 Then define the `Turing` model using the new functions as such:
 ```julia
-@model demo(x) = begin
+@model function demo(x)
     a ~ Gamma()
     b ~ Normal()
     c = memoized_function1(a)

--- a/docs/src/using-turing/performancetips.md
+++ b/docs/src/using-turing/performancetips.md
@@ -111,10 +111,15 @@ We can use
 using Random
 
 model = tmodel(1.0)
-varinfo = Turing.VarInfo(model)
-spl = Turing.SampleFromPrior()
 
-@code_warntype model.f(Random.GLOBAL_RNG, model, varinfo, spl, Turing.DefaultContext())
+@code_warntype model.f(
+    Random.GLOBAL_RNG,
+    model,
+    Turing.VarInfo(model),
+    Turing.SampleFromPrior(),
+    Turing.DefaultContext(),
+    model.args...,
+)
 ```
 
 to inspect type inference in the model.

--- a/docs/src/using-turing/performancetips.md
+++ b/docs/src/using-turing/performancetips.md
@@ -94,7 +94,7 @@ end
 Note that you can use `@code_warntype` to find types in your model definition that the compiler cannot infer.
 They are marked in red in the Julia REPL.
 
-For example consider the following simple program:
+For example, consider the following simple program:
 
 ```julia
 @model function tmodel(x)

--- a/docs/src/using-turing/quick-start.md
+++ b/docs/src/using-turing/quick-start.md
@@ -7,7 +7,7 @@ title: Probablistic Programming in Thirty Seconds
 If you are already well-versed in probabalistic programming and just want to take a quick look at how Turing's syntax works or otherwise just want a model to start with, we have provided a Bayesian coin-flipping model to play with.
 
 
-This example can be run on however you have Julia installed (see [Getting Started]({{site.baseurl}}/docs/using-turing/get-started)), but you will need to install the packages `Turing`, `Distributions`, `MCMCChains`, and `StatsPlots` if you have not done so already.
+This example can be run on however you have Julia installed (see [Getting Started]({{site.baseurl}}/docs/using-turing/get-started)), but you will need to install the packages `Turing` and `StatsPlots` if you have not done so already.
 
 
 This is an excerpt from a more formal example introducing probabalistic programming which can be found in Jupyter notebook form [here](https://nbviewer.jupyter.org/github/TuringLang/TuringTutorials/blob/master/0_Introduction.ipynb) or as part of the documentation website [here]({{site.baseurl}}/tutorials).
@@ -21,14 +21,14 @@ using Turing, StatsPlots, Random
 p_true = 0.5
 
 # Iterate from having seen 0 observations to 100 observations.
-Ns = 0:100;
+Ns = 0:100
 
 # Draw data from a Bernoulli distribution, i.e. draw heads or tails.
 Random.seed!(12)
 data = rand(Bernoulli(p_true), last(Ns))
 
 # Declare our Turing model.
-@model coinflip(y) = begin
+@model function coinflip(y)
     # Our prior belief about the probability of heads in a coin.
     p ~ Beta(1, 1)
 
@@ -38,7 +38,7 @@ data = rand(Bernoulli(p_true), last(Ns))
         # Heads or tails of a coin are drawn from a Bernoulli distribution.
         y[n] ~ Bernoulli(p)
     end
-end;
+end
 
 # Settings of the Hamiltonian Monte Carlo (HMC) sampler.
 iterations = 1000
@@ -46,9 +46,8 @@ iterations = 1000
 τ = 10
 
 # Start sampling.
-chain = sample(coinflip(data), HMC(ϵ, τ), iterations);
+chain = sample(coinflip(data), HMC(ϵ, τ), iterations)
 
 # Plot a summary of the sampling process for the parameter p, i.e. the probability of heads in a coin.
 histogram(chain[:p])
 ```
-


### PR DESCRIPTION
This PR updates the documentation for the upcoming release. Moreover, I tried to use the newer model syntax (`@model function...`) consistently throughout the documentation.

In particular, this PR fixes https://github.com/TuringLang/Turing.jl/issues/1390, https://github.com/TuringLang/Turing.jl/issues/702, https://github.com/TuringLang/DynamicPPL.jl/issues/154, https://github.com/TuringLang/Turing.jl/issues/1332. It addresses https://github.com/TuringLang/DynamicPPL.jl/issues/65 at least partly (maybe some VarInfo or VarName related stuff is still outdated).