### PR TITLE
ModeResult description inconsistency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Turing"
 uuid = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-version = "0.14.0"
+version = "0.14.1"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/modes/ModeEstimation.jl
+++ b/src/modes/ModeEstimation.jl
@@ -216,7 +216,7 @@ end
 
 
 function Base.show(io::IO, ::MIME"text/plain", m::ModeResult)
-    print(io, "ModeResult with minimized lp of ")
+    print(io, "ModeResult with maximized lp of ")
     Printf.@printf(io, "%.2f", m.lp)
     println(io)
     show(io, m.values)


### PR DESCRIPTION
Currently, it says "minimized at ..." but it actually returns the log-density instead of the minus log-density used in optimization, hence inconsistent. Better to change it to "maximized", or report the minus log-density.

In this PR I changed the word to "maximized", but feel free to change it if you think reporting the original "minus log-density" is a better idea. That line is at the end of this file.