### PR TITLE
Fix MLE/MAP with Zygote and ReverseDiff

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Turing"
 uuid = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-version = "0.14.2"
+version = "0.14.3"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/core/ad.jl
+++ b/src/core/ad.jl
@@ -65,7 +65,8 @@ getADbackend(spl::SampleFromPrior) = ADBackend()()
         θ::AbstractVector{<:Real},
         vi::VarInfo,
         model::Model,
-        sampler::AbstractSampler=SampleFromPrior(),
+        sampler::AbstractSampler,
+        ctx::DynamicPPL.AbstractContext = DynamicPPL.DefaultContext()
     )
 
 Computes the value of the log joint of `θ` and its gradient for the model
@@ -89,6 +90,7 @@ gradient_logp(
     vi::VarInfo,
     model::Model,
     sampler::AbstractSampler = SampleFromPrior(),
+    ctx::DynamicPPL.AbstractContext = DynamicPPL.DefaultContext()
 )
 
 Compute the value of the log joint of `θ` and its gradient for the model
@@ -160,7 +162,7 @@ function gradient_logp(
     # Specify objective function.
     function f(θ)
         new_vi = VarInfo(vi, sampler, θ)
-        model(new_vi, sampler)
+        model(new_vi, sampler, context)
         return getlogp(new_vi)
     end
 

--- a/src/core/compat/reversediff.jl
+++ b/src/core/compat/reversediff.jl
@@ -27,7 +27,7 @@ function gradient_logp(
     # Specify objective function.
     function f(θ)
         new_vi = VarInfo(vi, sampler, θ)
-        model(new_vi, sampler)
+        model(new_vi, sampler, context)
         return getlogp(new_vi)
     end
     tp, result = taperesult(f, θ)
@@ -65,7 +65,7 @@ end
         # Specify objective function.
         function f(θ)
             new_vi = VarInfo(vi, sampler, θ)
-            model(new_vi, sampler)
+            model(new_vi, sampler, context)
             return getlogp(new_vi)
         end
         ctp, result = memoized_taperesult(f, θ)

--- a/test/modes/ModeEstimation.jl
+++ b/test/modes/ModeEstimation.jl
@@ -42,31 +42,6 @@ include(dir*"/test/test_utils/AllUtils.jl")
         @test all(isapprox.(m4.values.array - true_value, 0.0, atol=0.01))
     end
 
-    @testset "AD backends" begin
-        Random.seed!(222)
-        true_value = [0.0625, 1.75]
-        
-        Turing.setadbackend(:forwarddiff)
-        m1 = optimize(gdemo_default, MLE())
-        
-        Turing.setadbackend(:reversediff)
-        m2 = optimize(gdemo_default, MLE())
-
-        Turing.setadbackend(:tracker)
-        m3 = optimize(gdemo_default, MLE())
-
-        Turing.setadbackend(:zygote)
-        m4 = optimize(gdemo_default, MLE())
-
-        # Go back to normal forwarddiff for the rest of the tests
-        Turing.setadbackend(:forwarddiff)
-
-        @test all(isapprox.(m1.values.array - true_value, 0.0, atol=0.01))
-        @test all(isapprox.(m2.values.array - true_value, 0.0, atol=0.01))
-        @test all(isapprox.(m3.values.array - true_value, 0.0, atol=0.01))
-        @test all(isapprox.(m4.values.array - true_value, 0.0, atol=0.01))
-    end
-
     @testset "StatsBase integration" begin
         Random.seed!(54321)
         mle_est = optimize(gdemo_default, MLE())

--- a/test/modes/ModeEstimation.jl
+++ b/test/modes/ModeEstimation.jl
@@ -48,19 +48,15 @@ include(dir*"/test/test_utils/AllUtils.jl")
         
         Turing.setadbackend(:forwarddiff)
         m1 = optimize(gdemo_default, MLE())
-        display(m1)
         
         Turing.setadbackend(:reversediff)
         m2 = optimize(gdemo_default, MLE())
-        display(m2)
 
         Turing.setadbackend(:tracker)
         m3 = optimize(gdemo_default, MLE())
-        display(m3)
 
         Turing.setadbackend(:zygote)
         m4 = optimize(gdemo_default, MLE())
-        display(m4)
 
         # Go back to normal forwarddiff for the rest of the tests
         Turing.setadbackend(:forwarddiff)

--- a/test/modes/ModeEstimation.jl
+++ b/test/modes/ModeEstimation.jl
@@ -6,6 +6,7 @@ using NamedArrays
 using ReverseDiff
 using Random
 using LinearAlgebra
+using Zygote
 
 dir = splitdir(splitdir(pathof(Turing))[1])[1]
 include(dir*"/test/test_utils/AllUtils.jl")
@@ -35,6 +36,35 @@ include(dir*"/test/test_utils/AllUtils.jl")
         m3 = optimize(gdemo_default, MAP(), true_value, LBFGS())
         m4 = optimize(gdemo_default, MAP(), true_value)
         
+        @test all(isapprox.(m1.values.array - true_value, 0.0, atol=0.01))
+        @test all(isapprox.(m2.values.array - true_value, 0.0, atol=0.01))
+        @test all(isapprox.(m3.values.array - true_value, 0.0, atol=0.01))
+        @test all(isapprox.(m4.values.array - true_value, 0.0, atol=0.01))
+    end
+
+    @testset "AD backends" begin
+        Random.seed!(222)
+        true_value = [0.0625, 1.75]
+        
+        Turing.setadbackend(:forwarddiff)
+        m1 = optimize(gdemo_default, MLE())
+        display(m1)
+        
+        Turing.setadbackend(:reversediff)
+        m2 = optimize(gdemo_default, MLE())
+        display(m2)
+
+        Turing.setadbackend(:tracker)
+        m3 = optimize(gdemo_default, MLE())
+        display(m3)
+
+        Turing.setadbackend(:zygote)
+        m4 = optimize(gdemo_default, MLE())
+        display(m4)
+
+        # Go back to normal forwarddiff for the rest of the tests
+        Turing.setadbackend(:forwarddiff)
+
         @test all(isapprox.(m1.values.array - true_value, 0.0, atol=0.01))
         @test all(isapprox.(m2.values.array - true_value, 0.0, atol=0.01))
         @test all(isapprox.(m3.values.array - true_value, 0.0, atol=0.01))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,6 +40,10 @@ include("test_utils/AllUtils.jl")
         @testset "variational algorithms : $adbackend" begin
             include("variational/advi.jl")
         end
+
+        @testset "modes" begin
+            include("modes/ModeEstimation.jl")
+        end
     end
     @testset "variational optimisers" begin
         include("variational/optimisers.jl")
@@ -54,9 +58,5 @@ include("test_utils/AllUtils.jl")
     @testset "utilities" begin
         # include("utilities/stan-interface.jl")
         include("inference/utilities.jl")
-    end
-
-    @testset "modes" begin
-        include("modes/ModeEstimation.jl")
     end
 end


### PR DESCRIPTION
MLE/MAP was not being tested with ReverseDiff or Zygote, so I missed the fact that the sampling context was not being passed to `gradient_logp` for those two backends. Thanks to @wupeifan for flagging this.

I added tests for this as well to make sure this doesn't happen in the future. 