### PR TITLE
Rename `turnprogress` to `setprogress!`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Turing"
 uuid = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-version = "0.14.6"
+version = "0.14.7"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/docs/src/using-turing/guide.md
+++ b/docs/src/using-turing/guide.md
@@ -627,7 +627,7 @@ For more information on Turing's automatic differentiation backend, please see t
 
 Turing.jl uses ProgressLogging.jl to log the progress of sampling. Progress
 logging is enabled as default but might slow down inference. It can be turned on
-or off by setting the keyword argument `progress` of `sample` to `true` or `false`, respectively. Moreover, you can enable or disable progress logging globally by calling `turnprogress(true)` or `turnprogress(false)`, respectively.
+or off by setting the keyword argument `progress` of `sample` to `true` or `false`, respectively. Moreover, you can enable or disable progress logging globally by calling `setprogress!(true)` or `setprogress!(false)`, respectively.
 
 Turing uses heuristics to select an appropriate visualization backend. If you
 use [Juno](https://junolab.org/), the progress is displayed with a

--- a/src/Turing.jl
+++ b/src/Turing.jl
@@ -19,10 +19,17 @@ import AdvancedVI
 import DynamicPPL: getspace, NoDist, NamedDist
 
 const PROGRESS = Ref(true)
-function turnprogress(switch::Bool)
-    @info "[Turing]: progress logging is $(switch ? "enabled" : "disabled") globally"
-    PROGRESS[] = switch
-    AdvancedVI.turnprogress(switch)
+
+"""
+    setprogress!(progress::Bool)
+
+Enable progress logging in Turing if `progress` is `true`, and disable it otherwise.
+"""
+function setprogress!(progress::Bool)
+    @info "[Turing]: progress logging is $(progress ? "enabled" : "disabled") globally"
+    PROGRESS[] = progress
+    AdvancedVI.turnprogress(progress)
+    return progress
 end
 
 # Random probability measures.
@@ -109,7 +116,7 @@ export  @model,                 # modelling
         setadbackend,
         setadsafe,
 
-        turnprogress,           # debugging
+        setprogress!,           # debugging
 
         Flat,
         FlatPos,
@@ -126,4 +133,8 @@ export  @model,                 # modelling
         genereated_quantities,
         logprior,
         logjoint
+
+# deprecations
+include("deprecations.jl")
+
 end

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,0 +1,1 @@
+@deprecate turnprogress(progress::Bool) setprogress!(progress)

--- a/src/inference/Inference.jl
+++ b/src/inference/Inference.jl
@@ -612,7 +612,7 @@ and then converts these into a `Chains` object using `AbstractMCMC.bundle_sample
 
 # Example
 ```jldoctest
-julia> using Turing; Turing.turnprogress(false);
+julia> using Turing; setprogress!(false);
 [ Info: [Turing]: progress logging is disabled globally
 
 julia> @model function linear_reg(x, y, σ = 0.1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,12 @@
 ##########################################
 # Master file for running all test cases #
 ##########################################
-using Zygote, ReverseDiff, Memoization, Turing; turnprogress(false)
+using Zygote, ReverseDiff, Memoization, Turing
 using Pkg
 using Random
 using Test
+
+setprogress!(false)
 
 include("test_utils/AllUtils.jl")
 


### PR DESCRIPTION
This PR addresses https://github.com/TuringLang/Turing.jl/issues/1426.

I still think that it might be good to remove the global state (i.e., `Turing.PROGRESS` and hence also `setprogress!`/`turnprogress`) completely.

@phipsgabler @torfjelde 