### PR TITLE
Clear RDCache for MLE and MAP estimation

### DIFF
--- a/src/core/ad.jl
+++ b/src/core/ad.jl
@@ -198,3 +198,7 @@ for F in (:link, :invlink)
         end
     end
 end
+
+# This function will call emptyrdcache only if ReverseDiff & Memoization are loaded
+# See Turing issue #1418
+clearcache(x=nothing) = ()

--- a/src/core/compat/reversediff.jl
+++ b/src/core/compat/reversediff.jl
@@ -50,6 +50,9 @@ end
         return
     end
 
+    # This function will call emptyrdcache only if ReverseDiff & Memoization are loaded
+    clearcache() = emptyrdcache()
+
     function gradient_logp(
         backend::ReverseDiffAD{true},
         θ::AbstractVector{<:Real},

--- a/src/modes/ModeEstimation.jl
+++ b/src/modes/ModeEstimation.jl
@@ -419,6 +419,9 @@ function _optimize(
     # Optimize!
     M = Optim.optimize(Optim.only_fgh!(f), init_vals, optimizer, options, args...; kwargs...)
 
+    # Clear the cache if Memoization & ReverseDiff are loaded.
+    Turing.Core.clearcache()
+
     # Warn the user if the optimization did not converge.
     if !Optim.converged(M)
         @warn "Optimization did not converge! You may need to correct your model or adjust the Optim parameters."


### PR DESCRIPTION
Fixes #1418. The memoization cache is now cleared after each MLE/MAP `optimize` call only if ReverseDiff & Memoization are loaded -- I used a dispatched function called `clearcache` that does nothing if the two named packages aren't loaded, but clears the cache if they are both loaded.

Not sure what the tests here should be?