### PR TITLE
Update EllipticalSliceSampling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Turing"
 uuid = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-version = "0.15.4"
+version = "0.15.5"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
@@ -44,7 +44,7 @@ Distributions = "0.23.3, 0.24"
 DistributionsAD = "0.6"
 DocStringExtensions = "0.8"
 DynamicPPL = "0.10.2"
-EllipticalSliceSampling = "0.3"
+EllipticalSliceSampling = "0.4"
 ForwardDiff = "0.10.3"
 Libtask = "0.4, 0.5"
 LogDensityProblems = "^0.9, 0.10"


### PR DESCRIPTION
This PR updates EllipticalSliceSampling to 0.4. The new version requires fewer user definitions (e.g., no need to define how to compute the proposal) and improves the cache handling (see https://github.com/TuringLang/EllipticalSliceSampling.jl/pull/13 for details).

In particular, it is not necessary anymore to define how to compute the proposal and more naturally we just define the prior and loglikelihood function for the Turing model and pass it to EllipticalSliceSampling.