### PR TITLE
Remove some `@debug` statements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Turing"
 uuid = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-version = "0.15.6"
+version = "0.15.7"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/inference/gibbs.jl
+++ b/src/inference/gibbs.jl
@@ -153,14 +153,10 @@ function AbstractMCMC.step(
     state::GibbsState;
     kwargs...
 )
-    @debug "Gibbs stepping..."
-
     # Iterate through each of the samplers.
     vi = state.vi
     samplers = state.samplers
     states = map(samplers, state.states) do _sampler, _state
-        @debug "$(typeof(_sampler)) stepping..."
-
         # Update state of current sampler with updated `VarInfo` object.
         current_state = gibbs_update_state(_state, vi)
 

--- a/src/inference/hmc.jl
+++ b/src/inference/hmc.jl
@@ -213,7 +213,6 @@ function DynamicPPL.initialstep(
     end
 
     # Update `vi` based on acceptance
-    @debug "decide whether to accept..."
     if t.stat.is_accept
         vi[spl] = t.z.θ
         setlogp!(vi, t.stat.log_density)
@@ -227,7 +226,6 @@ function DynamicPPL.initialstep(
 
     # If a Gibbs component, transform the values back to the constrained space.
     if spl.selector.tag !== :default
-        @debug "R -> X..."
         invlink!(vi, spl)
     end
 
@@ -252,7 +250,6 @@ function AbstractMCMC.step(
 
     # When a Gibbs component, transform values to the unconstrained space.
     if spl.selector.tag !== :default
-        @debug "X-> R..."
         link!(vi, spl)
         model(rng, vi, spl)
     end
@@ -287,7 +284,6 @@ function AbstractMCMC.step(
     end
 
     # Update `vi` based on acceptance
-    @debug "decide whether to accept..."
     if t.stat.is_accept
         vi[spl] = t.z.θ
         setlogp!(vi, t.stat.log_density)
@@ -302,7 +298,6 @@ function AbstractMCMC.step(
 
     # If a Gibbs component, transform the values back to the constrained space.
     if spl.selector.tag !== :default
-        @debug "R -> X..."
         invlink!(vi, spl)
     end
 

--- a/src/variational/advi.jl
+++ b/src/variational/advi.jl
@@ -117,7 +117,6 @@ function AdvancedVI.vi(
     q::Bijectors.TransformedDistribution{<:DistributionsAD.TuringDiagMvNormal};
     optimizer = AdvancedVI.TruncatedADAGrad(),
 )
-    @debug "Optimizing ADVI..."
     # Initial parameters for mean-field approx
     μ, σs = StatsBase.params(q)
     θ = vcat(μ, StatsFuns.invsoftplus.(σs))


### PR DESCRIPTION
As a follow-up to https://github.com/TuringLang/DynamicPPL.jl/pull/206, this PR removes some `@debug` statements that are redundant or do not provide much information. Basically, only the `@debug` statement that reports the current stepsize of HMC is kept.

Fixes https://github.com/TuringLang/Turing.jl/issues/526.