### PR TITLE
Fix dev docs for VarName

### DIFF
--- a/docs/src/for-developers/compiler.md
+++ b/docs/src/for-developers/compiler.md
@@ -184,10 +184,13 @@ without any default values. Finally, in the new function body a `model::Model` w
 
 # `VarName`
 
-In order to track random variables in the sampling process, `Turing` uses the struct `VarName{sym}` which acts as a random variable identifier generated at runtime. The `VarName` of a random variable is generated from the expression on the LHS of a `~` statement when the symbol on the LHS is in `P`. Every `vn::VarName{sym}` has a symbol `sym` which is the symbol of the Julia variable in the model that the random variable belongs to. For example, `x[1] ~ Normal()` will generate an instance of `VarName{:x}` assuming `x` is in `P`. Every `vn::VarName` also has a field `indexing` which stores the indices requires to access the random variable from the Julia variable indicated by `sym`. For example, `x[1] ~ Normal()` will generate a `vn::VarName{:x}` with `vn.indexing == "[1]"`. `VarName` also supports hierarchical arrays and range indexing. Some more examples:
-- `x[1] ~ Normal()` will generate a `VarName{:x}` with `indexing == "[1]"`.
-- `x[:,1] ~ MvNormal(zeros(2))` will generate a `VarName{:x}` with `indexing == "[Colon(),1]"`.
-- `x[:,1][2] ~ Normal()` will generate a `VarName{:x}` with `indexing == "[Colon(),1][2]"`.
+In order to track random variables in the sampling process, `Turing` uses the struct `VarName{sym}` which acts as a random variable identifier generated at runtime. The `VarName` of a random variable is generated from the expression on the LHS of a `~` statement when the symbol on the LHS is in `P`. Every `vn::VarName{sym}` has a symbol `sym` which is the symbol of the Julia variable in the model that the random variable belongs to. For example, `x[1] ~ Normal()` will generate an instance of `VarName{:x}` assuming `x` is in `P`. Every `vn::VarName` also has a field `indexing`, which stores the indices requires to access the random variable from the Julia variable indicated by `sym` as a tuple of tuples.  Each element of the tuple thereby contains the indices of one indexing operation (`VarName` also supports hierarchical arrays and range indexing). Some examples:
+- `x ~ Normal()` will generate a `VarName{:x}` with `indexing == ()`.
+- `x[1] ~ Normal()` will generate a `VarName{:x}` with `indexing == ((1,),)`.
+- `x[:,1] ~ MvNormal(zeros(2))` will generate a `VarName{:x}` with `indexing == ((Colon(), 1),)`.
+- `x[:,1][2] ~ Normal()` will generate a `VarName{:x}` with `indexing == ((Colon(), 1), (2,))`.
+
+The easiest way to manually construct a `VarName` is to use the `@varname` macro on an indexing expression, which will take the `sym` value from the actual variable name, and put the index values appropriately into the constructor.
 
 # `VarInfo`
 

--- a/docs/src/for-developers/compiler.md
+++ b/docs/src/for-developers/compiler.md
@@ -184,11 +184,11 @@ without any default values. Finally, in the new function body a `model::Model` w
 
 # `VarName`
 
-In order to track random variables in the sampling process, `Turing` uses the struct `VarName{sym}` which acts as a random variable identifier generated at runtime. The `VarName` of a random variable is generated from the expression on the LHS of a `~` statement when the symbol on the LHS is in `P`. Every `vn::VarName{sym}` has a symbol `sym` which is the symbol of the Julia variable in the model that the random variable belongs to. For example, `x[1] ~ Normal()` will generate an instance of `VarName{:x}` assuming `x` is in `P`. Every `vn::VarName` also has a field `indexing`, which stores the indices requires to access the random variable from the Julia variable indicated by `sym` as a tuple of tuples.  Each element of the tuple thereby contains the indices of one indexing operation (`VarName` also supports hierarchical arrays and range indexing). Some examples:
-- `x ~ Normal()` will generate a `VarName{:x}` with `indexing == ()`.
-- `x[1] ~ Normal()` will generate a `VarName{:x}` with `indexing == ((1,),)`.
-- `x[:,1] ~ MvNormal(zeros(2))` will generate a `VarName{:x}` with `indexing == ((Colon(), 1),)`.
-- `x[:,1][2] ~ Normal()` will generate a `VarName{:x}` with `indexing == ((Colon(), 1), (2,))`.
+In order to track random variables in the sampling process, `Turing` uses the `VarName` struct which acts as a random variable identifier generated at runtime. The `VarName` of a random variable is generated from the expression on the LHS of a `~` statement when the symbol on the LHS is in the set `P` of unobserved random variables. Every `VarName` instance has a type parameter `sym` which is the symbol of the Julia variable in the model that the random variable belongs to. For example, `x[1] ~ Normal()` will generate an instance of `VarName{:x}` assuming `x` is an unobserved random variable. Every `VarName` also has a field `indexing`, which stores the indices required to access the random variable from the Julia variable indicated by `sym` as a tuple of tuples.  Each element of the tuple thereby contains the indices of one indexing operation (`VarName` also supports hierarchical arrays and range indexing). Some examples:
+- `x ~ Normal()` will generate a `VarName(:x, ())`.
+- `x[1] ~ Normal()` will generate a `VarName(:x, ((1,),))`.
+- `x[:,1] ~ MvNormal(zeros(2))` will generate a `VarName(:x, ((Colon(), 1),))`.
+- `x[:,1][1+1] ~ Normal()` will generate a `VarName(:x, ((Colon(), 1), (2,)))`.
 
 The easiest way to manually construct a `VarName` is to use the `@varname` macro on an indexing expression, which will take the `sym` value from the actual variable name, and put the index values appropriately into the constructor.
 


### PR DESCRIPTION
Parts of this seem to have been written before `indexing` started using tuples.