### PR TITLE
Fixed typo in documentation

### DIFF
--- a/docs/src/using-turing/sampler-viz.md
+++ b/docs/src/using-turing/sampler-viz.md
@@ -114,7 +114,7 @@ plot_sampler(c)
 
 ### HMC
 
-Hamiltonian Monte Carlo (HMC) sampling is a typical sampler to use, as it tends to be fairly good at converging in a efficient manner. It can often be tricky to set the correct parameters for this sampler however, and the `NUTS` sampler is often easier to run if you don't want to spend too much time fiddling with step size and and the number of steps to take. Note however that `HMC` does not explore the positive values μ very well, likely due to the leapfrop and step size parameter settings.
+Hamiltonian Monte Carlo (HMC) sampling is a typical sampler to use, as it tends to be fairly good at converging in a efficient manner. It can often be tricky to set the correct parameters for this sampler however, and the `NUTS` sampler is often easier to run if you don't want to spend too much time fiddling with step size and and the number of steps to take. Note however that `HMC` does not explore the positive values μ very well, likely due to the leapfrog and step size parameter settings.
 
 ```julia
 c = sample(model, HMC(0.01, 10), 1000)

--- a/src/inference/hmc.jl
+++ b/src/inference/hmc.jl
@@ -51,7 +51,7 @@ Hamiltonian Monte Carlo sampler with static trajectory.
 Arguments:
 
 - `ϵ::Float64` : The leapfrog step size to use.
-- `n_leapfrog::Int` : The number of leapfrop steps to use.
+- `n_leapfrog::Int` : The number of leapfrog steps to use.
 
 Usage:
 
@@ -282,7 +282,7 @@ Arguments:
 
 - `n_adapts::Int` : Numbers of samples to use for adaptation.
 - `δ::Float64` : Target acceptance rate. 65% is often recommended.
-- `λ::Float64` : Target leapfrop length.
+- `λ::Float64` : Target leapfrog length.
 - `ϵ::Float64=0.0` : Inital step size; 0 means automatically search by Turing.
 
 For more information, please view the following paper ([arXiv link](https://arxiv.org/abs/1111.4246)):


### PR DESCRIPTION
I noticed a few instances where "leapfrog" was misspelled as "leapfrop" in the docs.