### PR TITLE
Deduplicate packages loading in tests

### DIFF
--- a/src/core/ad.jl
+++ b/src/core/ad.jl
@@ -1,5 +1,3 @@
-# const FDM = FiniteDifferences
-
 ##############################
 # Global variables/constants #
 ##############################

--- a/src/core/ad.jl
+++ b/src/core/ad.jl
@@ -1,3 +1,5 @@
+# const FDM = FiniteDifferences
+
 ##############################
 # Global variables/constants #
 ##############################

--- a/test/contrib/inference/dynamichmc.jl
+++ b/test/contrib/inference/dynamichmc.jl
@@ -1,8 +1,3 @@
-using Turing, Test
-import Random
-
-include(project_root*"/test/test_utils/AllUtils.jl")
-
 @stage_testset "dynamichmc" "dynamichmc.jl" begin
     import DynamicHMC
     Random.seed!(100)

--- a/test/contrib/inference/dynamichmc.jl
+++ b/test/contrib/inference/dynamichmc.jl
@@ -1,8 +1,7 @@
 using Turing, Test
 import Random
 
-dir = splitdir(splitdir(pathof(Turing))[1])[1]
-include(dir*"/test/test_utils/AllUtils.jl")
+include(project_root*"/test/test_utils/AllUtils.jl")
 
 @stage_testset "dynamichmc" "dynamichmc.jl" begin
     import DynamicHMC

--- a/test/contrib/inference/sghmc.jl
+++ b/test/contrib/inference/sghmc.jl
@@ -3,8 +3,7 @@ using LinearAlgebra
 using Random
 using Test
 
-dir = splitdir(splitdir(pathof(Turing))[1])[1]
-include(dir*"/test/test_utils/AllUtils.jl")
+include(project_root*"/test/test_utils/AllUtils.jl")
 
 @testset "sghmc.jl" begin
     @numerical_testset "sghmc inference" begin

--- a/test/contrib/inference/sghmc.jl
+++ b/test/contrib/inference/sghmc.jl
@@ -1,10 +1,3 @@
-using Turing
-using LinearAlgebra
-using Random
-using Test
-
-include(project_root*"/test/test_utils/AllUtils.jl")
-
 @testset "sghmc.jl" begin
     @numerical_testset "sghmc inference" begin
         Random.seed!(125)

--- a/test/core/ad.jl
+++ b/test/core/ad.jl
@@ -13,7 +13,7 @@
         # Hand-written logp
         function logp(x::Vector)
           s = x[2]
-          # s = Turing.invlink(dist_s, s)
+          # s = invlink(dist_s, s)
           m = x[1]
           lik_dist = Normal(m, sqrt(s))
           lp = logpdf(dist_s, s) + logpdf(Normal(0,sqrt(s)), m)
@@ -23,7 +23,7 @@
 
         # Call ForwardDiff's AD
         g = x -> ForwardDiff.gradient(logp, x);
-        # _s = Turing.link(dist_s, _s)
+        # _s = link(dist_s, _s)
         _x = [_m, _s]
         grad_FWAD = sort(g(_x))
 

--- a/test/core/ad.jl
+++ b/test/core/ad.jl
@@ -9,8 +9,7 @@ using StatsFuns: binomlogpdf, logsumexp
 using Test, LinearAlgebra
 const FDM = FiniteDifferences
 
-dir = splitdir(splitdir(pathof(Turing))[1])[1]
-include(dir*"/test/test_utils/AllUtils.jl")
+include(project_root*"/test/test_utils/AllUtils.jl")
 
 @testset "ad.jl" begin
     @turing_testset "adr" begin

--- a/test/core/ad.jl
+++ b/test/core/ad.jl
@@ -2,7 +2,7 @@
     @turing_testset "adr" begin
         ad_test_f = gdemo_default
         vi = Turing.VarInfo(ad_test_f)
-        ad_test_f(vi, Turing.SampleFromPrior())
+        ad_test_f(vi, SampleFromPrior())
         svn = vi.metadata.s.vns[1]
         mvn = vi.metadata.m.vns[1]
         _s = getval(vi, svn)[1]
@@ -27,7 +27,7 @@
         _x = [_m, _s]
         grad_FWAD = sort(g(_x))
 
-        x = map(x->Float64(x), vi[Turing.SampleFromPrior()])
+        x = map(x->Float64(x), vi[SampleFromPrior()])
         ∇E1 = gradient_logp(TrackerAD(), x, vi, ad_test_f)[2]
         @test sort(∇E1) ≈ grad_FWAD atol=1e-9
 

--- a/test/inference/AdvancedSMC.jl
+++ b/test/inference/AdvancedSMC.jl
@@ -1,8 +1,6 @@
 using AdvancedPS: ResampleWithESSThreshold, resample_systematic, resample_multinomial
 
 @testset "SMC" begin
-    getspace = Turing.Inference.getspace
-
     @turing_testset "constructor" begin
         s = SMC()
         @test s.resampler == ResampleWithESSThreshold()
@@ -95,8 +93,6 @@ using AdvancedPS: ResampleWithESSThreshold, resample_systematic, resample_multin
 end
 
 @testset "PG" begin
-    getspace = Turing.Inference.getspace
-
     @turing_testset "constructor" begin
         s = PG(10)
         @test s.nparticles == 10

--- a/test/inference/AdvancedSMC.jl
+++ b/test/inference/AdvancedSMC.jl
@@ -1,11 +1,8 @@
-using Turing, Random, Test
-using Turing.Inference: getspace
 using AdvancedPS: ResampleWithESSThreshold, resample_systematic, resample_multinomial
 
-using Random
-
-
 @testset "SMC" begin
+    getspace = Turing.Inference.getspace
+
     @turing_testset "constructor" begin
         s = SMC()
         @test s.resampler == ResampleWithESSThreshold()
@@ -98,6 +95,8 @@ using Random
 end
 
 @testset "PG" begin
+    getspace = Turing.Inference.getspace
+
     @turing_testset "constructor" begin
         s = PG(10)
         @test s.nparticles == 10

--- a/test/inference/AdvancedSMC.jl
+++ b/test/inference/AdvancedSMC.jl
@@ -4,8 +4,7 @@ using AdvancedPS: ResampleWithESSThreshold, resample_systematic, resample_multin
 
 using Random
 
-dir = splitdir(splitdir(pathof(Turing))[1])[1]
-include(dir*"/test/test_utils/AllUtils.jl")
+include(project_root*"/test/test_utils/AllUtils.jl")
 
 @testset "SMC" begin
     @turing_testset "constructor" begin

--- a/test/inference/AdvancedSMC.jl
+++ b/test/inference/AdvancedSMC.jl
@@ -4,7 +4,6 @@ using AdvancedPS: ResampleWithESSThreshold, resample_systematic, resample_multin
 
 using Random
 
-include(project_root*"/test/test_utils/AllUtils.jl")
 
 @testset "SMC" begin
     @turing_testset "constructor" begin

--- a/test/inference/AdvancedSMC.jl
+++ b/test/inference/AdvancedSMC.jl
@@ -1,5 +1,3 @@
-using AdvancedPS: ResampleWithESSThreshold, resample_systematic, resample_multinomial
-
 @testset "SMC" begin
     @turing_testset "constructor" begin
         s = SMC()

--- a/test/inference/Inference.jl
+++ b/test/inference/Inference.jl
@@ -1,10 +1,3 @@
-using Turing, Random, Test
-using DynamicPPL: getlogp
-import MCMCChains
-
-using Random
-
-
 @testset "io.jl" begin
     # Only test threading if 1.3+.
     if VERSION > v"1.2"

--- a/test/inference/Inference.jl
+++ b/test/inference/Inference.jl
@@ -4,7 +4,6 @@ import MCMCChains
 
 using Random
 
-include(project_root*"/test/test_utils/AllUtils.jl")
 
 @testset "io.jl" begin
     # Only test threading if 1.3+.

--- a/test/inference/Inference.jl
+++ b/test/inference/Inference.jl
@@ -4,8 +4,7 @@ import MCMCChains
 
 using Random
 
-dir = splitdir(splitdir(pathof(Turing))[1])[1]
-include(dir*"/test/test_utils/AllUtils.jl")
+include(project_root*"/test/test_utils/AllUtils.jl")
 
 @testset "io.jl" begin
     # Only test threading if 1.3+.

--- a/test/inference/emcee.jl
+++ b/test/inference/emcee.jl
@@ -1,6 +1,3 @@
-using Turing, Random, Test
-import Turing.Inference
-import AdvancedMH
 
 
 @testset "emcee.jl" begin

--- a/test/inference/emcee.jl
+++ b/test/inference/emcee.jl
@@ -2,7 +2,6 @@ using Turing, Random, Test
 import Turing.Inference
 import AdvancedMH
 
-include(project_root*"/test/test_utils/AllUtils.jl")
 
 @testset "emcee.jl" begin
     @testset "gdemo" begin

--- a/test/inference/emcee.jl
+++ b/test/inference/emcee.jl
@@ -2,8 +2,7 @@ using Turing, Random, Test
 import Turing.Inference
 import AdvancedMH
 
-dir = splitdir(splitdir(pathof(Turing))[1])[1]
-include(dir*"/test/test_utils/AllUtils.jl")
+include(project_root*"/test/test_utils/AllUtils.jl")
 
 @testset "emcee.jl" begin
     @testset "gdemo" begin

--- a/test/inference/ess.jl
+++ b/test/inference/ess.jl
@@ -1,6 +1,3 @@
-using Turing, Random, Test
-
-
 @testset "ESS" begin
     @model demo(x) = begin
         m ~ Normal()

--- a/test/inference/ess.jl
+++ b/test/inference/ess.jl
@@ -1,6 +1,5 @@
 using Turing, Random, Test
 
-include(project_root*"/test/test_utils/AllUtils.jl")
 
 @testset "ESS" begin
     @model demo(x) = begin

--- a/test/inference/ess.jl
+++ b/test/inference/ess.jl
@@ -1,7 +1,6 @@
 using Turing, Random, Test
 
-dir = splitdir(splitdir(pathof(Turing))[1])[1]
-include(dir*"/test/test_utils/AllUtils.jl")
+include(project_root*"/test/test_utils/AllUtils.jl")
 
 @testset "ESS" begin
     @model demo(x) = begin

--- a/test/inference/gibbs.jl
+++ b/test/inference/gibbs.jl
@@ -4,8 +4,7 @@ import MCMCChains
 import Turing.Inference
 using Turing.RandomMeasures
 
-dir = splitdir(splitdir(pathof(Turing))[1])[1]
-include(dir*"/test/test_utils/AllUtils.jl")
+include(project_root*"/test/test_utils/AllUtils.jl")
 
 @testset "gibbs.jl" begin
     @turing_testset "gibbs constructor" begin

--- a/test/inference/gibbs.jl
+++ b/test/inference/gibbs.jl
@@ -1,10 +1,6 @@
-using Random, Turing, Test
-import AbstractMCMC
 import MCMCChains
 import Turing.Inference
-using Turing.RandomMeasures
 
-include(project_root*"/test/test_utils/AllUtils.jl")
 
 @testset "gibbs.jl" begin
     @turing_testset "gibbs constructor" begin

--- a/test/inference/gibbs.jl
+++ b/test/inference/gibbs.jl
@@ -1,7 +1,3 @@
-import MCMCChains
-import Turing.Inference
-
-
 @testset "gibbs.jl" begin
     @turing_testset "gibbs constructor" begin
         N = 500

--- a/test/inference/gibbs_conditional.jl
+++ b/test/inference/gibbs_conditional.jl
@@ -2,7 +2,6 @@ using Random, Turing, Test
 using StatsFuns
 using Clustering
 
-include(project_root*"/test/test_utils/AllUtils.jl")
 
 
 @turing_testset "gibbs conditionals" begin

--- a/test/inference/gibbs_conditional.jl
+++ b/test/inference/gibbs_conditional.jl
@@ -2,8 +2,7 @@ using Random, Turing, Test
 using StatsFuns
 using Clustering
 
-dir = splitdir(splitdir(pathof(Turing))[1])[1]
-include(dir*"/test/test_utils/AllUtils.jl")
+include(project_root*"/test/test_utils/AllUtils.jl")
 
 
 @turing_testset "gibbs conditionals" begin

--- a/test/inference/gibbs_conditional.jl
+++ b/test/inference/gibbs_conditional.jl
@@ -1,9 +1,3 @@
-using Random, Turing, Test
-using StatsFuns
-using Clustering
-
-
-
 @turing_testset "gibbs conditionals" begin
     Random.seed!(100)
 

--- a/test/inference/hmc.jl
+++ b/test/inference/hmc.jl
@@ -5,8 +5,7 @@ using StatsFuns: logistic
 
 using LinearAlgebra
 
-dir = splitdir(splitdir(pathof(Turing))[1])[1]
-include(dir*"/test/test_utils/AllUtils.jl")
+include(project_root*"/test/test_utils/AllUtils.jl")
 
 @testset "hmc.jl" begin
     @numerical_testset "constrained bounded" begin

--- a/test/inference/hmc.jl
+++ b/test/inference/hmc.jl
@@ -1,12 +1,3 @@
-using Turing, Random, Test
-using Turing: Sampler, NUTS
-using MCMCChains: Chains
-using StatsFuns: logistic
-
-using LinearAlgebra
-
-include(project_root*"/test/test_utils/AllUtils.jl")
-
 @testset "hmc.jl" begin
     @numerical_testset "constrained bounded" begin
         # Set a seed

--- a/test/inference/is.jl
+++ b/test/inference/is.jl
@@ -4,8 +4,7 @@ using StatsFuns
 using Random
 using Test
 
-dir = splitdir(splitdir(pathof(Turing))[1])[1]
-include(dir*"/test/test_utils/AllUtils.jl")
+include(project_root*"/test/test_utils/AllUtils.jl")
 
 @turing_testset "is.jl" begin
     function reference(n)

--- a/test/inference/is.jl
+++ b/test/inference/is.jl
@@ -1,10 +1,3 @@
-using Turing
-using StatsFuns
-
-using Random
-using Test
-
-
 @turing_testset "is.jl" begin
     function reference(n)
         as = Vector{Float64}(undef, n)

--- a/test/inference/is.jl
+++ b/test/inference/is.jl
@@ -4,7 +4,6 @@ using StatsFuns
 using Random
 using Test
 
-include(project_root*"/test/test_utils/AllUtils.jl")
 
 @turing_testset "is.jl" begin
     function reference(n)

--- a/test/inference/mh.jl
+++ b/test/inference/mh.jl
@@ -1,8 +1,3 @@
-using Turing, Random, Test
-import Turing.Inference
-import AdvancedMH
-
-
 @testset "mh.jl" begin
     @turing_testset "mh constructor" begin
         Random.seed!(0)

--- a/test/inference/mh.jl
+++ b/test/inference/mh.jl
@@ -2,7 +2,6 @@ using Turing, Random, Test
 import Turing.Inference
 import AdvancedMH
 
-include(project_root*"/test/test_utils/AllUtils.jl")
 
 @testset "mh.jl" begin
     @turing_testset "mh constructor" begin

--- a/test/inference/mh.jl
+++ b/test/inference/mh.jl
@@ -2,8 +2,7 @@ using Turing, Random, Test
 import Turing.Inference
 import AdvancedMH
 
-dir = splitdir(splitdir(pathof(Turing))[1])[1]
-include(dir*"/test/test_utils/AllUtils.jl")
+include(project_root*"/test/test_utils/AllUtils.jl")
 
 @testset "mh.jl" begin
     @turing_testset "mh constructor" begin

--- a/test/inference/utilities.jl
+++ b/test/inference/utilities.jl
@@ -1,5 +1,3 @@
-using Random
-
 @testset "predict" begin
     Random.seed!(100)
 

--- a/test/modes/ModeEstimation.jl
+++ b/test/modes/ModeEstimation.jl
@@ -8,7 +8,6 @@ using Random
 using LinearAlgebra
 using Zygote
 
-include(project_root*"/test/test_utils/AllUtils.jl")
 
 @testset "ModeEstimation.jl" begin
     @testset "MLE" begin

--- a/test/modes/ModeEstimation.jl
+++ b/test/modes/ModeEstimation.jl
@@ -8,8 +8,7 @@ using Random
 using LinearAlgebra
 using Zygote
 
-dir = splitdir(splitdir(pathof(Turing))[1])[1]
-include(dir*"/test/test_utils/AllUtils.jl")
+include(project_root*"/test/test_utils/AllUtils.jl")
 
 @testset "ModeEstimation.jl" begin
     @testset "MLE" begin

--- a/test/modes/ModeEstimation.jl
+++ b/test/modes/ModeEstimation.jl
@@ -1,12 +1,3 @@
-using Turing
-using Optim
-using Test
-using StatsBase
-using NamedArrays
-using ReverseDiff
-using Random
-using LinearAlgebra
-using Zygote
 
 
 @testset "ModeEstimation.jl" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
-
 using AbstractMCMC
+using Clustering
 using Distributions
 using FiniteDifferences
 using ForwardDiff
@@ -7,6 +7,7 @@ using Memoization
 using Random
 using ReverseDiff
 using PDMats
+using StatsFuns
 using Tracker
 using Turing
 using Turing.RandomMeasures
@@ -40,8 +41,8 @@ include("test_utils/AllUtils.jl")
         @testset "inference: $adbackend" begin
             @testset "samplers" begin
                 include("inference/gibbs.jl")
-#                include("inference/gibbs_conditional.jl")
-#                include("inference/hmc.jl")
+                include("inference/gibbs_conditional.jl")
+                include("inference/hmc.jl")
 #                include("inference/is.jl")
 #                include("inference/mh.jl")
 #                include("inference/ess.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,12 +2,17 @@ using AbstractMCMC
 using AdvancedMH
 using Clustering
 using Distributions
+using DistributionsAD
 using FiniteDifferences
 using ForwardDiff
 using MCMCChains
 using Memoization
-using ReverseDiff
+using NamedArrays
+using Optim
 using PDMats
+using ReverseDiff
+using SpecialFunctions
+using StatsBase
 using StatsFuns
 using Tracker
 using Turing
@@ -20,13 +25,17 @@ using Pkg
 using Random
 using Test
 
+using AdvancedPS: ResampleWithESSThreshold, resample_systematic, resample_multinomial
+using AdvancedVI: TruncatedADAGrad, DecayedADAGrad, apply!
 using Distributions: Binomial, logpdf
 using DynamicPPL: getval, getlogp
 using ForwardDiff: Dual
 using MCMCChains: Chains
 using StatsFuns: binomlogpdf, logistic, logsumexp
-using Turing: BinomialLogit, Sampler, SampleFromPrior, NUTS, TrackerAD, ZygoteAD, getspace
+using Turing: BinomialLogit, ForwardDiffAD, Sampler, SampleFromPrior, NUTS, TrackerAD, 
+                Variational, ZygoteAD, getspace, gradient_logp
 using Turing.Core: TuringDenseMvNormal, TuringDiagMvNormal
+using Turing.Variational: TruncatedADAGrad, DecayedADAGrad, AdvancedVI
 
 setprogress!(false)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,12 +1,10 @@
-import AdvancedMH
-import MCMCChains
-import Turing.Inference
-
 using AbstractMCMC
+using AdvancedMH
 using Clustering
 using Distributions
 using FiniteDifferences
 using ForwardDiff
+using MCMCChains
 using Memoization
 using Random
 using ReverseDiff
@@ -14,6 +12,7 @@ using PDMats
 using StatsFuns
 using Tracker
 using Turing
+using Turing.Inference
 using Turing.RandomMeasures
 using Zygote
 
@@ -26,7 +25,7 @@ using DynamicPPL: getval, getlogp
 using ForwardDiff: Dual
 using MCMCChains: Chains
 using StatsFuns: binomlogpdf, logistic, logsumexp
-using Turing: Sampler, SampleFromPrior, NUTS, TrackerAD, ZygoteAD
+using Turing: Sampler, SampleFromPrior, NUTS, TrackerAD, ZygoteAD, getspace
 using Turing.Core: TuringDenseMvNormal, TuringDiagMvNormal
 
 setprogress!(false)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,6 @@ using FiniteDifferences
 using ForwardDiff
 using MCMCChains
 using Memoization
-using Random
 using ReverseDiff
 using PDMats
 using StatsFuns
@@ -16,16 +15,17 @@ using Turing.Inference
 using Turing.RandomMeasures
 using Zygote
 
-# Julia base.
 using LinearAlgebra
 using Pkg
+using Random
 using Test
 
+using Distributions: Binomial, logpdf
 using DynamicPPL: getval, getlogp
 using ForwardDiff: Dual
 using MCMCChains: Chains
 using StatsFuns: binomlogpdf, logistic, logsumexp
-using Turing: Sampler, SampleFromPrior, NUTS, TrackerAD, ZygoteAD, getspace
+using Turing: BinomialLogit, Sampler, SampleFromPrior, NUTS, TrackerAD, ZygoteAD, getspace
 using Turing.Core: TuringDenseMvNormal, TuringDiagMvNormal
 
 setprogress!(false)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,7 +31,7 @@ using Turing.Core: TuringDenseMvNormal, TuringDiagMvNormal
 
 setprogress!(false)
 
-clude("test_utils/AllUtils.jl")
+include("test_utils/AllUtils.jl")
 
 @testset "Turing" begin
     @testset "core" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,8 @@ setprogress!(false)
 
 include("test_utils/AllUtils.jl")
 
+const project_root = basename(basename(pathof(Turing)))
+
 # Begin testing.
 @testset "Turing" begin
     @testset "core" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,16 +1,32 @@
-##########################################
-# Master file for running all test cases #
-##########################################
-using Zygote, ReverseDiff, Memoization, Turing
-using Pkg
+
+using AbstractMCMC
+using Distributions
+using FiniteDifferences
+using ForwardDiff
+using Memoization
 using Random
+using ReverseDiff
+using PDMats
+using Tracker
+using Turing
+using Turing.RandomMeasures
+using Zygote
+
+# Julia base.
+using LinearAlgebra
+using Pkg
 using Test
+
+using DynamicPPL: getval
+using ForwardDiff: Dual
+using MCMCChains: Chains
+using StatsFuns: binomlogpdf, logistic, logsumexp
+using Turing: Sampler, SampleFromPrior, NUTS, TrackerAD, ZygoteAD
+using Turing.Core: TuringDenseMvNormal, TuringDiagMvNormal
 
 setprogress!(false)
 
 include("test_utils/AllUtils.jl")
-
-const project_root = dirname(dirname(pathof(Turing)))
 
 # Begin testing.
 @testset "Turing" begin
@@ -24,39 +40,39 @@ const project_root = dirname(dirname(pathof(Turing)))
         @testset "inference: $adbackend" begin
             @testset "samplers" begin
                 include("inference/gibbs.jl")
-                include("inference/gibbs_conditional.jl")
-                include("inference/hmc.jl")
-                include("inference/is.jl")
-                include("inference/mh.jl")
-                include("inference/ess.jl")
-                include("inference/emcee.jl")
-                include("inference/AdvancedSMC.jl")
-                include("inference/Inference.jl")
-                include("contrib/inference/dynamichmc.jl")
-                include("contrib/inference/sghmc.jl")
+#                include("inference/gibbs_conditional.jl")
+#                include("inference/hmc.jl")
+#                include("inference/is.jl")
+#                include("inference/mh.jl")
+#                include("inference/ess.jl")
+#                include("inference/emcee.jl")
+#                include("inference/AdvancedSMC.jl")
+#                include("inference/Inference.jl")
+#                include("contrib/inference/dynamichmc.jl")
+#                include("contrib/inference/sghmc.jl")
             end
         end
 
-        @testset "variational algorithms : $adbackend" begin
-            include("variational/advi.jl")
-        end
+#        @testset "variational algorithms : $adbackend" begin
+#            include("variational/advi.jl")
+#        end
 
-        @testset "modes" begin
-            include("modes/ModeEstimation.jl")
-        end
+#        @testset "modes" begin
+#            include("modes/ModeEstimation.jl")
+#        end
     end
-    @testset "variational optimisers" begin
-        include("variational/optimisers.jl")
-    end
+#    @testset "variational optimisers" begin
+#        include("variational/optimisers.jl")
+#    end
 
-    Turing.setadbackend(:forwarddiff)
-    @testset "stdlib" begin
-        include("stdlib/distributions.jl")
-        include("stdlib/RandomMeasures.jl")
-    end
+#    Turing.setadbackend(:forwarddiff)
+#    @testset "stdlib" begin
+#        include("stdlib/distributions.jl")
+#        include("stdlib/RandomMeasures.jl")
+#    end
 
-    @testset "utilities" begin
-        # include("utilities/stan-interface.jl")
-        include("inference/utilities.jl")
-    end
+#    @testset "utilities" begin
+#        # include("utilities/stan-interface.jl")
+#        include("inference/utilities.jl")
+#    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,6 @@
+import AdvancedMH
+import Turing.Inference
+
 using AbstractMCMC
 using Clustering
 using Distributions
@@ -43,10 +46,10 @@ include("test_utils/AllUtils.jl")
                 include("inference/gibbs.jl")
                 include("inference/gibbs_conditional.jl")
                 include("inference/hmc.jl")
-#                include("inference/is.jl")
-#                include("inference/mh.jl")
-#                include("inference/ess.jl")
-#                include("inference/emcee.jl")
+                include("inference/is.jl")
+                include("inference/mh.jl")
+                include("inference/ess.jl")
+                include("inference/emcee.jl")
 #                include("inference/AdvancedSMC.jl")
 #                include("inference/Inference.jl")
 #                include("contrib/inference/dynamichmc.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 import AdvancedMH
+import MCMCChains
 import Turing.Inference
 
 using AbstractMCMC
@@ -21,7 +22,7 @@ using LinearAlgebra
 using Pkg
 using Test
 
-using DynamicPPL: getval
+using DynamicPPL: getval, getlogp
 using ForwardDiff: Dual
 using MCMCChains: Chains
 using StatsFuns: binomlogpdf, logistic, logsumexp
@@ -30,9 +31,8 @@ using Turing.Core: TuringDenseMvNormal, TuringDiagMvNormal
 
 setprogress!(false)
 
-include("test_utils/AllUtils.jl")
+clude("test_utils/AllUtils.jl")
 
-# Begin testing.
 @testset "Turing" begin
     @testset "core" begin
         include("core/ad.jl")
@@ -50,33 +50,33 @@ include("test_utils/AllUtils.jl")
                 include("inference/mh.jl")
                 include("inference/ess.jl")
                 include("inference/emcee.jl")
-#                include("inference/AdvancedSMC.jl")
-#                include("inference/Inference.jl")
-#                include("contrib/inference/dynamichmc.jl")
-#                include("contrib/inference/sghmc.jl")
+                include("inference/AdvancedSMC.jl")
+                include("inference/Inference.jl")
+                include("contrib/inference/dynamichmc.jl")
+                include("contrib/inference/sghmc.jl")
             end
         end
 
-#        @testset "variational algorithms : $adbackend" begin
-#            include("variational/advi.jl")
-#        end
+        @testset "variational algorithms : $adbackend" begin
+            include("variational/advi.jl")
+        end
 
-#        @testset "modes" begin
-#            include("modes/ModeEstimation.jl")
-#        end
+        @testset "modes" begin
+            include("modes/ModeEstimation.jl")
+        end
     end
-#    @testset "variational optimisers" begin
-#        include("variational/optimisers.jl")
-#    end
+    @testset "variational optimisers" begin
+        include("variational/optimisers.jl")
+    end
 
-#    Turing.setadbackend(:forwarddiff)
-#    @testset "stdlib" begin
-#        include("stdlib/distributions.jl")
-#        include("stdlib/RandomMeasures.jl")
-#    end
+    Turing.setadbackend(:forwarddiff)
+    @testset "stdlib" begin
+        include("stdlib/distributions.jl")
+        include("stdlib/RandomMeasures.jl")
+    end
 
-#    @testset "utilities" begin
-#        # include("utilities/stan-interface.jl")
-#        include("inference/utilities.jl")
-#    end
+    @testset "utilities" begin
+        # include("utilities/stan-interface.jl")
+        include("inference/utilities.jl")
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,7 @@ setprogress!(false)
 
 include("test_utils/AllUtils.jl")
 
-const project_root = basename(basename(pathof(Turing)))
+const project_root = dirname(dirname(pathof(Turing)))
 
 # Begin testing.
 @testset "Turing" begin

--- a/test/stdlib/RandomMeasures.jl
+++ b/test/stdlib/RandomMeasures.jl
@@ -1,9 +1,3 @@
-using Turing
-using Turing.RandomMeasures
-using Test
-using Random
-
-
 @testset "RandomMeasures.jl" begin
     @testset "Infinite Mixture Model" begin
         @model infiniteGMM(x) = begin

--- a/test/stdlib/RandomMeasures.jl
+++ b/test/stdlib/RandomMeasures.jl
@@ -3,8 +3,7 @@ using Turing.RandomMeasures
 using Test
 using Random
 
-dir = splitdir(splitdir(pathof(Turing))[1])[1]
-include(dir*"/test/test_utils/AllUtils.jl")
+include(project_root*"/test/test_utils/AllUtils.jl")
 
 @testset "RandomMeasures.jl" begin
     @testset "Infinite Mixture Model" begin

--- a/test/stdlib/RandomMeasures.jl
+++ b/test/stdlib/RandomMeasures.jl
@@ -3,7 +3,6 @@ using Turing.RandomMeasures
 using Test
 using Random
 
-include(project_root*"/test/test_utils/AllUtils.jl")
 
 @testset "RandomMeasures.jl" begin
     @testset "Infinite Mixture Model" begin

--- a/test/stdlib/distributions.jl
+++ b/test/stdlib/distributions.jl
@@ -1,9 +1,3 @@
-using Turing, Random, Test
-using Turing: BinomialLogit, NUTS
-using Distributions: Binomial, logpdf
-using StatsFuns: logistic
-
-
 @testset "distributions.jl" begin
     @turing_testset "distributions functions" begin
         ns = 10

--- a/test/stdlib/distributions.jl
+++ b/test/stdlib/distributions.jl
@@ -3,7 +3,6 @@ using Turing: BinomialLogit, NUTS
 using Distributions: Binomial, logpdf
 using StatsFuns: logistic
 
-include(project_root*"/test/test_utils/AllUtils.jl")
 
 @testset "distributions.jl" begin
     @turing_testset "distributions functions" begin

--- a/test/stdlib/distributions.jl
+++ b/test/stdlib/distributions.jl
@@ -3,8 +3,7 @@ using Turing: BinomialLogit, NUTS
 using Distributions: Binomial, logpdf
 using StatsFuns: logistic
 
-dir = splitdir(splitdir(pathof(Turing))[1])[1]
-include(dir*"/test/test_utils/AllUtils.jl")
+include(project_root*"/test/test_utils/AllUtils.jl")
 
 @testset "distributions.jl" begin
     @turing_testset "distributions functions" begin

--- a/test/test_utils/AllUtils.jl
+++ b/test/test_utils/AllUtils.jl
@@ -1,5 +1,3 @@
-using Turing, Random, Test
-
 # Import utility functions and reused models.
 include("staging.jl")
 include("numerical_tests.jl")

--- a/test/test_utils/ad_utils.jl
+++ b/test/test_utils/ad_utils.jl
@@ -1,6 +1,3 @@
-using Turing: gradient_logp, ForwardDiffAD
-using Test
-
 """
     test_reverse_mode_ad(forward, f, ȳ, x...; rtol=1e-6, atol=1e-6)
 

--- a/test/test_utils/random_measure_utils.jl
+++ b/test/test_utils/random_measure_utils.jl
@@ -1,5 +1,3 @@
-using SpecialFunctions
-
 function compute_log_joint(observations, partition, tau0, tau1, sigma, theta)
   n = length(observations)
   k = length(partition)

--- a/test/test_utils/testing_functions.jl
+++ b/test/test_utils/testing_functions.jl
@@ -1,5 +1,3 @@
-using Turing
-
 GKernel(var) = (x) -> Normal(x, sqrt.(var))
 
 function randr(vi::Turing.VarInfo,

--- a/test/utilities/stan-interface.jl
+++ b/test/utilities/stan-interface.jl
@@ -1,7 +1,6 @@
 using Turing, Random, Test
 
-dir = splitdir(splitdir(pathof(Turing))[1])[1]
-include(dir*"/test/test_utils/AllUtils.jl")
+include(project_root*"/test/test_utils/AllUtils.jl")
 
 @stage_testset "stan" "stan-interface.jl" begin
     using CmdStan

--- a/test/utilities/stan-interface.jl
+++ b/test/utilities/stan-interface.jl
@@ -1,6 +1,5 @@
 using Turing, Random, Test
 
-include(project_root*"/test/test_utils/AllUtils.jl")
 
 @stage_testset "stan" "stan-interface.jl" begin
     using CmdStan

--- a/test/utilities/stan-interface.jl
+++ b/test/utilities/stan-interface.jl
@@ -1,6 +1,3 @@
-using Turing, Random, Test
-
-
 @stage_testset "stan" "stan-interface.jl" begin
     using CmdStan
 

--- a/test/variational/advi.jl
+++ b/test/variational/advi.jl
@@ -1,11 +1,3 @@
-using DistributionsAD
-
-using Turing, Random, Test, LinearAlgebra
-using Turing: Variational
-using Turing.Variational: TruncatedADAGrad, DecayedADAGrad, AdvancedVI
-
-include("../test_utils/AllUtils.jl")
-
 @testset "advi.jl" begin
     @turing_testset "advi constructor" begin
         Random.seed!(0)

--- a/test/variational/optimisers.jl
+++ b/test/variational/optimisers.jl
@@ -1,6 +1,3 @@
-using Random, Test, LinearAlgebra, ForwardDiff
-using AdvancedVI: TruncatedADAGrad, DecayedADAGrad, apply!
-
 function test_opt(ADPack, opt)
     θ = randn(10, 10)
     θ_fit = randn(10, 10)


### PR DESCRIPTION
This PR adds
```
const project_root = dirname(dirname(pathof(Turing)))
```
to `test/runtests.jl`. This is then used to reduce code duplication.

Looking back at https://github.com/TuringLang/Turing.jl/pull/804, it might be better to define `project_root` at all files. If that is preferred, let me know and I'll just change
```
splitdir(splitdir(pathof(Turing))[1])[1]
```
to
```
dirname(dirname(pathof(Turing)))
```