### PR TITLE
Make MH proposal generation more sane

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Turing"
 uuid = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-version = "0.15.11"
+version = "0.15.12"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/inference/mh.jl
+++ b/src/inference/mh.jl
@@ -7,7 +7,10 @@ struct MH{space, P} <: InferenceAlgorithm
 end
 
 proposal(p::AdvancedMH.Proposal) = p
+proposal(f::Function) = AdvancedMH.StaticProposal(f)
+proposal(d::Distribution) = AdvancedMH.StaticProposal(d)
 proposal(cov::AbstractMatrix) = AdvancedMH.RandomWalkProposal(MvNormal(cov))
+proposal(x) = error("Proposal type $x not supported")
 
 """
     MH(space...)
@@ -162,14 +165,7 @@ function MH(space...)
             # Check to see whether it's a pair that specifies a kernel
             # or a specific proposal distribution.
             push!(prop_syms, s[1])
-
-            if s[2] isa AMH.Proposal
-                push!(props, s[2])
-            elseif s[2] isa Distribution
-                push!(props, AMH.StaticProposal(s[2]))
-            elseif s[2] isa Function
-                push!(props, AMH.StaticProposal(s[2]))
-            end
+            push!(props, proposal(s[2]))
         elseif length(space) == 1
             # If we hit this block, check to see if it's 
             # a run-of-the-mill proposal or covariance
@@ -178,11 +174,17 @@ function MH(space...)
 
             # Return early, we got a covariance matrix. 
             return MH{(), typeof(prop)}(prop)
+        else
+            # Try to convert it to a proposal anyways, 
+            # throw an error if not acceptable.
+            prop = proposal(s)
+            push!(props, prop)
         end
     end
 
     proposals = NamedTuple{tuple(prop_syms...)}(tuple(props...))
     syms = vcat(syms, prop_syms)
+
     return MH{tuple(syms...), typeof(proposals)}(proposals)
 end
 

--- a/src/inference/mh.jl
+++ b/src/inference/mh.jl
@@ -10,7 +10,7 @@ proposal(p::AdvancedMH.Proposal) = p
 proposal(f::Function) = AdvancedMH.StaticProposal(f)
 proposal(d::Distribution) = AdvancedMH.StaticProposal(d)
 proposal(cov::AbstractMatrix) = AdvancedMH.RandomWalkProposal(MvNormal(cov))
-proposal(x) = error("Proposal type $x not supported")
+proposal(x) = error("proposals of type ", typeof(x), " are not supported")
 
 """
     MH(space...)

--- a/test/inference/gibbs.jl
+++ b/test/inference/gibbs.jl
@@ -127,7 +127,7 @@
             end
         end
         model = imm(randn(100), 1.0);
-        sample(model, Gibbs(MH(10, :z), HMC(0.01, 4, :m)), 100);
+        sample(model, Gibbs(MH(:z), HMC(0.01, 4, :m)), 100);
         sample(model, Gibbs(PG(10, :z), HMC(0.01, 4, :m)), 100);
     end
 end

--- a/test/inference/mh.jl
+++ b/test/inference/mh.jl
@@ -93,6 +93,7 @@
 
         spl1 = MH(prop1)
         spl2 = MH(prop2)
+        spl3 = Gibbs(MH(:m => ones(1,1)), MH(:s => ones(1,1)))
 
         # Test that the two constructors are equivalent.
         @test spl1.proposals.proposal.μ == spl2.proposals.proposal.μ
@@ -101,9 +102,11 @@
         # Test inference.
         chain1 = sample(gdemo_default, spl1, 10000)
         chain2 = sample(gdemo_default, spl2, 10000)
+        chain3 = sample(gdemo_default, spl3, 10000)
 
         check_gdemo(chain1)
         check_gdemo(chain2)
+        check_gdemo(chain3)
     end
 
     @turing_testset "vector of multivariate distributions" begin

--- a/test/inference/mh.jl
+++ b/test/inference/mh.jl
@@ -142,8 +142,8 @@
         chn2 = sample(mod, MH(), 3_000)
 
         # Test that the small variance version is actually smaller.
-        v1 = var(diff(chn["μ[1]"].data, dims=1))
-        v2 = var(diff(chn2["μ[1]"].data, dims=1))
+        v1 = var(diff(Array(chn["μ[1]"]), dims=1))
+        v2 = var(diff(Array(chn2["μ[1]"]), dims=1))
 
         @test v1 < v2
     end

--- a/test/inference/mh.jl
+++ b/test/inference/mh.jl
@@ -93,7 +93,7 @@
 
         spl1 = MH(prop1)
         spl2 = MH(prop2)
-        spl3 = Gibbs(MH(:m => Matrix([1.0])), MH(:s => Matrix([1.0])))
+        spl3 = Gibbs(MH(:m => ones(1,1)), MH(:s => ones(1,1)))
 
         # Test that the two constructors are equivalent.
         @test spl1.proposals.proposal.μ == spl2.proposals.proposal.μ

--- a/test/inference/mh.jl
+++ b/test/inference/mh.jl
@@ -93,7 +93,7 @@
 
         spl1 = MH(prop1)
         spl2 = MH(prop2)
-        spl3 = Gibbs(MH(:m => ones(1,1)), MH(:s => ones(1,1)))
+        spl3 = Gibbs(MH(:m => Matrix([1.0])), MH(:s => Matrix([1.0])))
 
         # Test that the two constructors are equivalent.
         @test spl1.proposals.proposal.μ == spl2.proposals.proposal.μ


### PR DESCRIPTION
Makes it easier to do the kind of thing requested in #1556. Now we handle `proposal` generation more consistently when constructing `MH`, and there's even a helpful error when a proposal type is not supported.

No real functional change here, just a slight bug fix & consistency improvements.