### PR TITLE
Run tests with Julia 1.5 instead of Julia 1.6

### DIFF
--- a/.github/workflows/DynamicHMC.yml
+++ b/.github/workflows/DynamicHMC.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         version:
           - '1.3'
-          - '1'
+          - '1.5'
         os:
           - ubuntu-latest
         arch:

--- a/.github/workflows/Numerical.yml
+++ b/.github/workflows/Numerical.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         version:
           - '1.3'
-          - '1'
+          - '1.5'
         os:
           - ubuntu-latest
         arch:

--- a/.github/workflows/StanCI.yml
+++ b/.github/workflows/StanCI.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         version:
           - '1.3'
-          - '1'
+          - '1.5'
         os:
           - ubuntu-latest
         arch:

--- a/.github/workflows/TuringCI.yml
+++ b/.github/workflows/TuringCI.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         version:
           - '1.3'
-          - '1'
+          - '1.5'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/test/inference/Inference.jl
+++ b/test/inference/Inference.jl
@@ -6,11 +6,13 @@
             @testset "rng" begin
                 model = gdemo_default
 
+                # multithreaded sampling with PG causes segfaults on Julia 1.5.4
+                # https://github.com/TuringLang/Turing.jl/issues/1571
                 samplers = (HMC(0.1, 7),
-                            PG(10),
+                            #PG(10),
                             IS(),
                             MH(),
-                            Gibbs(PG(3, :s), HMC(0.4, 8, :m)),
+                            #Gibbs(PG(3, :s), HMC(0.4, 8, :m)),
                             Gibbs(HMC(0.1, 5, :s), ESS(:m)))
                 for sampler in samplers
                     Random.seed!(5)


### PR DESCRIPTION
Since Turing (or rather Libtask_jll) is not compatible with Julia 1.6 yet (see e.g. https://github.com/TuringLang/Turing.jl/issues/1554 and the explanations there).

I guess it would be good to open an issue that reminds us to revert this change once a compatible version is available.