### PR TITLE
Run tests on Julia 1.6

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Julia
         uses: julia-actions/setup-julia@v1
         with:
-          version: '1.5'
+          version: '1'
       - name: Set up Ruby 2.6
         uses: actions/setup-ruby@v1
         with:

--- a/.github/workflows/DynamicHMC.yml
+++ b/.github/workflows/DynamicHMC.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         version:
           - '1.3'
-          - '1.5'
+          - '1'
         os:
           - ubuntu-latest
         arch:

--- a/.github/workflows/Numerical.yml
+++ b/.github/workflows/Numerical.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         version:
           - '1.3'
-          - '1.5'
+          - '1'
         os:
           - ubuntu-latest
         arch:

--- a/.github/workflows/StanCI.yml
+++ b/.github/workflows/StanCI.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         version:
           - '1.3'
-          - '1.5'
+          - '1'
         os:
           - ubuntu-latest
         arch:

--- a/.github/workflows/TuringCI.yml
+++ b/.github/workflows/TuringCI.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         version:
           - '1.3'
-          - '1.5'
+          - '1'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/test/inference/Inference.jl
+++ b/test/inference/Inference.jl
@@ -8,12 +8,23 @@
 
                 # multithreaded sampling with PG causes segfaults on Julia 1.5.4
                 # https://github.com/TuringLang/Turing.jl/issues/1571
-                samplers = (HMC(0.1, 7),
-                            #PG(10),
-                            IS(),
-                            MH(),
-                            #Gibbs(PG(3, :s), HMC(0.4, 8, :m)),
-                            Gibbs(HMC(0.1, 5, :s), ESS(:m)))
+                samplers = @static if VERSION <= v"1.5.3" || VERSION >= v"1.6.0"
+                    (
+                        HMC(0.1, 7),
+                        PG(10),
+                        IS(),
+                        MH(),
+                        Gibbs(PG(3, :s), HMC(0.4, 8, :m)),
+                        Gibbs(HMC(0.1, 5, :s), ESS(:m)),
+                    )
+                else
+                    (
+                        HMC(0.1, 7),
+                        IS(),
+                        MH(),
+                        Gibbs(HMC(0.1, 5, :s), ESS(:m)),
+                    )
+                end
                 for sampler in samplers
                     Random.seed!(5)
                     chain1 = sample(model, sampler, MCMCThreads(), 1000, 4)


### PR DESCRIPTION
Reverts https://github.com/TuringLang/Turing.jl/pull/1568 since now a version of Libtask_jll is available that is compatible with Julia 1.6 (segfaults caused by multithreading on Julia 1.5.4 require a different version of Libtask_jll which hopefully is available soon).