### PR TITLE
Improve `maybe_link!` for MH sampler

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Turing"
 uuid = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-version = "0.15.13"
+version = "0.15.14"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/inference/mh.jl
+++ b/src/inference/mh.jl
@@ -338,6 +338,13 @@ maybe_link!(varinfo, sampler, proposal) = nothing
 function maybe_link!(varinfo, sampler, proposal::AdvancedMH.RandomWalkProposal)
     link!(varinfo, sampler)
 end
+function maybe_link!(
+    varinfo,
+    sampler,
+    proposal::NamedTuple{names, vals}
+) where {names, vals<:NTuple{<:Any, <:AdvancedMH.RandomWalkProposal}}
+    return link!(varinfo, sampler)
+end
 
 # Make a proposal if we don't have a covariance proposal matrix (the default).
 function propose!(

--- a/src/inference/mh.jl
+++ b/src/inference/mh.jl
@@ -334,16 +334,25 @@ end
 end
 
 # Utility functions to link
-maybe_link!(varinfo, sampler, proposal) = nothing
-function maybe_link!(varinfo, sampler, proposal::AdvancedMH.RandomWalkProposal)
-    link!(varinfo, sampler)
+function should_link(varinfo, sampler, proposal::NamedTuple{(), Tuple{}})
+    # If it's an empty `NamedTuple`, we're using the priors as proposals
+    # in which case we shouldn't link.
+    return false
 end
-function maybe_link!(
+function should_link(varinfo, sampler, proposal::AdvancedMH.RandomWalkProposal)
+    return true
+end
+function should_link(
     varinfo,
     sampler,
     proposal::NamedTuple{names, vals}
 ) where {names, vals<:NTuple{<:Any, <:AdvancedMH.RandomWalkProposal}}
-    return link!(varinfo, sampler)
+    return true
+end
+
+function maybe_link!(varinfo, sampler, proposal)
+    should_link(varinfo, sampler, proposal) && link!(varinfo, sampler)
+    return varinfo
 end
 
 # Make a proposal if we don't have a covariance proposal matrix (the default).

--- a/src/inference/mh.jl
+++ b/src/inference/mh.jl
@@ -334,6 +334,7 @@ end
 end
 
 # Utility functions to link
+should_link(varinfo, sampler, proposal) = false
 function should_link(varinfo, sampler, proposal::NamedTuple{(), Tuple{}})
     # If it's an empty `NamedTuple`, we're using the priors as proposals
     # in which case we shouldn't link.


### PR DESCRIPTION
Fixes issues as discussed in #1579 regarding failing tests by making `maybe_link!` also link if `proposal` is a `NamedTuple` of proposals which *all* should be linked. If only one of the proposals does not require linking, we don't link.

It might be better to not dispatch here, but instead check at runtime and warn the user that there's a mix between proposals that are by default linked but don't link any?