### PR TITLE
Add timing information

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Turing"
 uuid = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-version = "0.15.19"
+version = "0.15.20"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/inference/Inference.jl
+++ b/src/inference/Inference.jl
@@ -323,6 +323,7 @@ function AbstractMCMC.bundle_samples(
     state,
     chain_type::Type{MCMCChains.Chains};
     save_state = false,
+    stats = missing,
     kwargs...
 )
     # Convert transitions to array format.
@@ -344,6 +345,11 @@ function AbstractMCMC.bundle_samples(
         info = (model = model, sampler = spl, samplerstate = state)
     else
         info = NamedTuple()
+    end
+
+    # Merge in the timing info, if available
+    if !ismissing(stats)
+        info = merge(info, (start_time=stats.start, stop_time=stats.stop))
     end
 
     # Conretize the array before giving it to MCMCChains.

--- a/test/inference/utilities.jl
+++ b/test/inference/utilities.jl
@@ -130,3 +130,11 @@
         @test mean(abs2, mean_prediction - y) ≤ 1e-3
     end
 end
+
+@testset "Timer" begin
+    chain = sample(gdemo_default, MH(), 1000)
+
+    @test chain.info.start_time isa Float64
+    @test chain.info.stop_time isa Float64
+    @test chain.info.start_time < chain.info.stop_time
+end


### PR DESCRIPTION
Adds basic timing information to chains. All of the actual calculations and recording is done upstream (https://github.com/TuringLang/MCMCChains.jl/pull/285 and https://github.com/TuringLang/AbstractMCMC.jl/pull/64), all we do here is just forward existing information on to MCMCChains.

Example output:

```
Chains MCMC chain (1000×2×1 Array{Float64, 3}):

Start time        = 2021-05-03T15:51:13.002
Stop time         = 2021-05-03T15:51:20.444
Wall duration     = 7.44 seconds
Iterations        = 1:1000
Thinning interval = 1
Chains            = 1
Samples per chain = 1000
parameters        = m
internals         = lp

Summary Statistics
  parameters      mean       std   naive_se      mcse       ess      rhat   ess_per_sec
      Symbol   Float64   Float64    Float64   Float64   Float64   Float64       Float64

           m   -0.1416    0.1078     0.0034    0.0136   61.9367    1.0001        8.3226

Quantiles
  parameters      2.5%     25.0%     50.0%     75.0%     97.5%
      Symbol   Float64   Float64   Float64   Float64   Float64

           m   -0.3296   -0.2086   -0.1550   -0.0648    0.0729
```