### PR TITLE
Use correct statistical notation in Hello World

### DIFF
--- a/docs/pages/index.html
+++ b/docs/pages/index.html
@@ -20,11 +20,11 @@ code-sample:
   snippet: |
     @model gdemo(x, y) = begin
       # Assumptions
-      σ ~ InverseGamma(2,3)
-      μ ~ Normal(0,sqrt(σ))
+      σ² ~ InverseGamma(2,3)
+      μ ~ Normal(0,sqrt(σ²))
       # Observations
-      x ~ Normal(μ, sqrt(σ))
-      y ~ Normal(μ, sqrt(σ))
+      x ~ Normal(μ, sqrt(σ²))
+      y ~ Normal(μ, sqrt(σ²))
     end
 
 samplers:

--- a/docs/pages/index.html
+++ b/docs/pages/index.html
@@ -18,7 +18,7 @@ code-sample:
   excerpt: "Turing's modelling syntax allows you to specify a model quickly and easily. Straightforward models can be expressed in the same way as complex, hierarchical models with stochastic control flow."
   url: "/docs/using-turing/quick-start"
   snippet: |
-    @model gdemo(x, y) = begin
+    @model function gdemo(x, y)
       # Assumptions
       σ² ~ InverseGamma(2,3)
       μ ~ Normal(0,sqrt(σ²))


### PR DESCRIPTION
The notation here is problematic. `σ` should represent the standard deviation, not the variance. Similarly `σ²` represents the variance in standard statistical notation. If you want to put a prior on the variance, then call it  `σ²`, so that the standard deviation is  `sqrt(σ²)` as expected.

 `sqrt(σ)` would be the square root of the standard deviation, and that's definitely not a common quantity nor a common way to parameterize the normal distribution.