### PR TITLE
replace s with s² for variances in docs

### DIFF
--- a/benchmarks/benchmarks.jl
+++ b/benchmarks/benchmarks.jl
@@ -25,11 +25,11 @@ BenchmarkSuite["dummy"]["dummy"] = @benchmarkable sample(constrained_test($data)
 BenchmarkSuite["gdemo"] = BenchmarkGroup(["gdemo"])
 
 @model gdemo(x, y) = begin
-    s ~ InverseGamma(2, 3)
-    m ~ Normal(0, sqrt(s))
-    x ~ Normal(m, sqrt(s))
-    y ~ Normal(m, sqrt(s))
-    return s, m
+    s² ~ InverseGamma(2, 3)
+    m ~ Normal(0, sqrt(s²))
+    x ~ Normal(m, sqrt(s²))
+    y ~ Normal(m, sqrt(s²))
+    return s², m
 end
 
 BenchmarkSuite["gdemo"]["hmc"] = @benchmarkable sample(gdemo(1.5, 2.0), HMC(0.01, 2), 2000)

--- a/docs/src/using-turing/advanced.md
+++ b/docs/src/using-turing/advanced.md
@@ -114,7 +114,7 @@ using LinearAlgebra
         # Exit the model evaluation early
         return
     end
-    
+
     x ~ MvNormal(m, 1.0)
     return
 end
@@ -142,11 +142,11 @@ using Turing
 
 @model function gdemo(x)
   # Set priors.
-  s ~ InverseGamma(2, 3)
-  m ~ Normal(0, sqrt(s))
+  s² ~ InverseGamma(2, 3)
+  m ~ Normal(0, sqrt(s²))
 
   # Observe each value of x.
-  @. x ~ Normal(m, sqrt(s))
+  @. x ~ Normal(m, sqrt(s²))
 end
 
 model = gdemo([1.5, 2.0])
@@ -160,7 +160,7 @@ using Turing
 # Create the model function.
 function modelf(rng, model, varinfo, sampler, context, x)
     # Assume s has an InverseGamma distribution.
-    s = Turing.DynamicPPL.tilde_assume(
+    s² = Turing.DynamicPPL.tilde_assume(
         rng,
         context,
         sampler,
@@ -169,20 +169,20 @@ function modelf(rng, model, varinfo, sampler, context, x)
         (),
         varinfo,
     )
-    
+
     # Assume m has a Normal distribution.
     m = Turing.DynamicPPL.tilde_assume(
         rng,
         context,
         sampler,
-        Normal(0, sqrt(s)),
+        Normal(0, sqrt(s²)),
         Turing.@varname(m),
         (),
         varinfo,
     )
 
     # Observe each value of x[i] according to a Normal distribution.
-    Turing.DynamicPPL.dot_tilde_observe(context, sampler, Normal(m, sqrt(s)), x, varinfo)
+    Turing.DynamicPPL.dot_tilde_observe(context, sampler, Normal(m, sqrt(s²)), x, varinfo)
 end
 
 # Instantiate a Model object with our data variables.
@@ -193,4 +193,3 @@ model = Turing.Model(modelf, (x = [1.5, 2.0],))
 
 
 Turing [copies](https://github.com/JuliaLang/julia/issues/4085) Julia tasks to deliver efficient inference algorithms, but it also provides alternative slower implementation as a fallback. Task copying is enabled by default. Task copying requires us to use the `CTask` facility which is provided by [Libtask](https://github.com/TuringLang/Libtask.jl) to create tasks.
-

--- a/docs/src/using-turing/autodiff.md
+++ b/docs/src/using-turing/autodiff.md
@@ -24,10 +24,10 @@ using Turing
 
 # Define a simple Normal model with unknown mean and variance.
 @model function gdemo(x, y)
-    s ~ InverseGamma(2, 3)
-    m ~ Normal(0, sqrt(s))
-    x ~ Normal(m, sqrt(s))
-    y ~ Normal(m, sqrt(s))
+    s² ~ InverseGamma(2, 3)
+    m ~ Normal(0, sqrt(s²))
+    x ~ Normal(m, sqrt(s²))
+    y ~ Normal(m, sqrt(s²))
 end
 
 # Sample using Gibbs and varying autodiff backends.
@@ -46,4 +46,3 @@ Generally, `TrackerAD` is faster when sampling from variables of high dimensiona
 
 
 If the differentation method is not specified in this way, Turing will default to using whatever the global AD backend is. Currently, this defaults to `ForwardDiff`.
-

--- a/docs/src/using-turing/dynamichmc.md
+++ b/docs/src/using-turing/dynamichmc.md
@@ -17,10 +17,10 @@ using DynamicHMC, Turing
 
 # Model definition.
 @model function gdemo(x, y)
-  s ~ InverseGamma(2, 3)
-  m ~ Normal(0, sqrt(s))
-  x ~ Normal(m, sqrt(s))
-  y ~ Normal(m, sqrt(s))
+  s² ~ InverseGamma(2, 3)
+  m ~ Normal(0, sqrt(s²))
+  x ~ Normal(m, sqrt(s²))
+  y ~ Normal(m, sqrt(s²))
 end
 
 # Pull 2,000 samples using DynamicNUTS.

--- a/docs/src/using-turing/gen-sampler-viz.jl
+++ b/docs/src/using-turing/gen-sampler-viz.jl
@@ -11,14 +11,14 @@ Random.seed!(0)
 
 # Define a strange model.
 @model gdemo(x) = begin
-    s ~ InverseGamma(2, 3)
-    m ~ Normal(0, sqrt(s))
+    s² ~ InverseGamma(2, 3)
+    m ~ Normal(0, sqrt(s²))
     bumps = sin(m) + cos(m)
     m = m + 5*bumps
     for i in eachindex(x)
-      x[i] ~ Normal(m, sqrt(s))
+      x[i] ~ Normal(m, sqrt(s²))
     end
-    return s, m
+    return s², m
 end
 
 # Define our data points.

--- a/docs/src/using-turing/get-started.md
+++ b/docs/src/using-turing/get-started.md
@@ -40,10 +40,10 @@ using StatsPlots
 
 # Define a simple Normal model with unknown mean and variance.
 @model function gdemo(x, y)
-  s ~ InverseGamma(2, 3)
-  m ~ Normal(0, sqrt(s))
-  x ~ Normal(m, sqrt(s))
-  y ~ Normal(m, sqrt(s))
+  s² ~ InverseGamma(2, 3)
+  m ~ Normal(0, sqrt(s²))
+  x ~ Normal(m, sqrt(s²))
+  y ~ Normal(m, sqrt(s²))
 end
 
 #  Run sampler, collect results

--- a/docs/src/using-turing/guide.md
+++ b/docs/src/using-turing/guide.md
@@ -34,10 +34,10 @@ using StatsPlots
 
 # Define a simple Normal model with unknown mean and variance.
 @model function gdemo(x, y)
-    s ~ InverseGamma(2, 3)
-    m ~ Normal(0, sqrt(s))
-    x ~ Normal(m, sqrt(s))
-    y ~ Normal(m, sqrt(s))
+    s² ~ InverseGamma(2, 3)
+    m ~ Normal(0, sqrt(s²))
+    x ~ Normal(m, sqrt(s²))
+    y ~ Normal(m, sqrt(s²))
 end
 ```
 
@@ -178,11 +178,11 @@ If you wish to perform multithreaded sampling and are running Julia 1.3 or great
 using Turing
 
 @model function gdemo(x)
-    s ~ InverseGamma(2, 3)
-    m ~ Normal(0, sqrt(s))
+    s² ~ InverseGamma(2, 3)
+    m ~ Normal(0, sqrt(s²))
 
     for i in eachindex(x)
-        x[i] ~ Normal(m, sqrt(s))
+        x[i] ~ Normal(m, sqrt(s²))
     end
 end
 
@@ -202,27 +202,27 @@ Process parallel sampling can be done like so:
 
 ```julia
 # Load Distributed to add processes and the @everywhere macro.
-using Distributed 
+using Distributed
 
 # Load Turing.
 using Turing
 
-# Add four processes to use for sampling. 
+# Add four processes to use for sampling.
 addprocs(4)
 
 # Initialize everything on all the processes.
 # Note: Make sure to do this after you've already loaded Turing,
-#       so each process does not have to precompile. 
+#       so each process does not have to precompile.
 #       Parallel sampling may fail silently if you do not do this.
 @everywhere using Turing
 
 # Define a model on all processes.
 @everywhere @model function gdemo(x)
-    s ~ InverseGamma(2, 3)
-    m ~ Normal(0, sqrt(s))
+    s² ~ InverseGamma(2, 3)
+    m ~ Normal(0, sqrt(s²))
 
     for i in eachindex(x)
-        x[i] ~ Normal(m, sqrt(s))
+        x[i] ~ Normal(m, sqrt(s²))
     end
 end
 
@@ -246,10 +246,10 @@ You can also run your model (as if it were a function) from the prior distributi
 
 ```julia
 @model function gdemo(x, y)
-    s ~ InverseGamma(2, 3)
-    m ~ Normal(0, sqrt(s))
-    x ~ Normal(m, sqrt(s))
-    y ~ Normal(m, sqrt(s))
+    s² ~ InverseGamma(2, 3)
+    m ~ Normal(0, sqrt(s²))
+    x ~ Normal(m, sqrt(s²))
+    y ~ Normal(m, sqrt(s²))
     return x, y
 end
 ```
@@ -288,10 +288,10 @@ Inputs to the model that have a value `missing` are treated as parameters, aka r
         # Initialize `x` if missing
         x = Vector{T}(undef, 2)
     end
-    s ~ InverseGamma(2, 3)
-    m ~ Normal(0, sqrt(s))
+    s² ~ InverseGamma(2, 3)
+    m ~ Normal(0, sqrt(s²))
     for i in eachindex(x)
-        x[i] ~ Normal(m, sqrt(s))
+        x[i] ~ Normal(m, sqrt(s²))
     end
 end
 
@@ -308,10 +308,10 @@ Turing also supports mixed `missing` and non-`missing` values in `x`, where the 
 
 ```julia
 @model function gdemo(x)
-    s ~ InverseGamma(2, 3)
-    m ~ Normal(0, sqrt(s))
+    s² ~ InverseGamma(2, 3)
+    m ~ Normal(0, sqrt(s²))
     for i in eachindex(x)
-        x[i] ~ Normal(m, sqrt(s))
+        x[i] ~ Normal(m, sqrt(s²))
     end
 end
 
@@ -334,12 +334,12 @@ using Turing
         # Initialize x when missing
         x = Vector{T}(undef, 10)
     end
-    s ~ InverseGamma(2, 3)
-    m ~ Normal(0, sqrt(s))
+    s² ~ InverseGamma(2, 3)
+    m ~ Normal(0, sqrt(s²))
     for i in 1:length(x)
-        x[i] ~ Normal(m, sqrt(s))
+        x[i] ~ Normal(m, sqrt(s²))
     end
-    return s, m
+    return s², m
 end
 
 m = generative()
@@ -379,10 +379,10 @@ Similarly, when using a particle sampler, the Julia variable used should either 
 Consider the following `gdemo` model:
 ```julia
 @model function gdemo(x, y)
-    s ~ InverseGamma(2, 3)
-    m ~ Normal(0, sqrt(s))
-    x ~ Normal(m, sqrt(s))
-    y ~ Normal(m, sqrt(s))
+    s² ~ InverseGamma(2, 3)
+    m ~ Normal(0, sqrt(s²))
+    x ~ Normal(m, sqrt(s²))
+    y ~ Normal(m, sqrt(s²))
 end
 ```
 
@@ -418,11 +418,11 @@ using Turing
 using Optim
 
 @model function gdemo(x)
-    s ~ InverseGamma(2, 3)
-    m ~ Normal(0, sqrt(s))
+    s² ~ InverseGamma(2, 3)
+    m ~ Normal(0, sqrt(s²))
 
     for i in eachindex(x)
-        x[i] ~ Normal(m, sqrt(s))
+        x[i] ~ Normal(m, sqrt(s²))
     end
 end
 ```

--- a/docs/src/using-turing/sampler-viz.md
+++ b/docs/src/using-turing/sampler-viz.md
@@ -27,14 +27,14 @@ Random.seed!(0)
 
 # Define a strange model.
 @model gdemo(x) = begin
-    s ~ InverseGamma(2, 3)
-    m ~ Normal(0, sqrt(s))
+    s² ~ InverseGamma(2, 3)
+    m ~ Normal(0, sqrt(s²))
     bumps = sin(m) + cos(m)
     m = m + 5*bumps
     for i in eachindex(x)
-      x[i] ~ Normal(m, sqrt(s))
+      x[i] ~ Normal(m, sqrt(s²))
     end
-    return s, m
+    return s², m
 end
 
 # Define our data points.

--- a/src/inference/is.jl
+++ b/src/inference/is.jl
@@ -17,11 +17,11 @@ Example:
 ```julia
 # Define a simple Normal model with unknown mean and variance.
 @model gdemo(x) = begin
-    s ~ InverseGamma(2,3)
+    s² ~ InverseGamma(2,3)
     m ~ Normal(0,sqrt.(s))
     x[1] ~ Normal(m, sqrt.(s))
     x[2] ~ Normal(m, sqrt.(s))
-    return s, m
+    return s², m
 end
 
 sample(gdemo([1.5, 2]), IS(), 1000)

--- a/src/inference/mh.jl
+++ b/src/inference/mh.jl
@@ -2,7 +2,7 @@
 ### Sampler states
 ###
 
-struct MH{space, P} <: InferenceAlgorithm 
+struct MH{space, P} <: InferenceAlgorithm
     proposals::P
 end
 
@@ -15,13 +15,13 @@ proposal(x) = error("proposals of type ", typeof(x), " are not supported")
 """
     MH(space...)
 
-Construct a Metropolis-Hastings algorithm. 
+Construct a Metropolis-Hastings algorithm.
 
-The arguments `space` can be 
+The arguments `space` can be
 
 - Blank (i.e. `MH()`), in which case `MH` defaults to using the prior for each parameter as the proposal distribution.
 - A set of one or more symbols to sample with `MH` in conjunction with `Gibbs`, i.e. `Gibbs(MH(:m), PG(10, :s))`
-- An iterable of pairs or tuples mapping a `Symbol` to a `AdvancedMH.Proposal`, `Distribution`, or `Function` 
+- An iterable of pairs or tuples mapping a `Symbol` to a `AdvancedMH.Proposal`, `Distribution`, or `Function`
   that generates returns a conditional proposal distribution.
 - A covariance matrix to use as for mean-zero multivariate normal proposals.
 
@@ -31,10 +31,10 @@ The default `MH` will use propose samples from the prior distribution using `Adv
 
 ```julia
 @model function gdemo(x, y)
-    s ~ InverseGamma(2,3)
-    m ~ Normal(0, sqrt(s))
-    x ~ Normal(m, sqrt(s))
-    y ~ Normal(m, sqrt(s))
+    s² ~ InverseGamma(2,3)
+    m ~ Normal(0, sqrt(s²))
+    x ~ Normal(m, sqrt(s²))
+    y ~ Normal(m, sqrt(s²))
 end
 
 chain = sample(gdemo(1.5, 2.0), MH(), 1_000)
@@ -46,10 +46,10 @@ from multiple samplers:
 
 ```julia
 @model function gdemo(x, y)
-    s ~ InverseGamma(2,3)
-    m ~ Normal(0, sqrt(s))
-    x ~ Normal(m, sqrt(s))
-    y ~ Normal(m, sqrt(s))
+    s² ~ InverseGamma(2,3)
+    m ~ Normal(0, sqrt(s²))
+    x ~ Normal(m, sqrt(s²))
+    y ~ Normal(m, sqrt(s²))
 end
 
 # Samples s with MH and m with PG
@@ -61,20 +61,20 @@ Using custom distributions defaults to using static MH:
 
 ```julia
 @model function gdemo(x, y)
-    s ~ InverseGamma(2,3)
-    m ~ Normal(0, sqrt(s))
-    x ~ Normal(m, sqrt(s))
-    y ~ Normal(m, sqrt(s))
+    s² ~ InverseGamma(2,3)
+    m ~ Normal(0, sqrt(s²))
+    x ~ Normal(m, sqrt(s²))
+    y ~ Normal(m, sqrt(s²))
 end
 
-# Use a static proposal for s and random walk with proposal 
+# Use a static proposal for s and random walk with proposal
 # standard deviation of 0.25 for m.
 chain = sample(
-    gdemo(1.5, 2.0), 
+    gdemo(1.5, 2.0),
     MH(
         :s => InverseGamma(2, 3),
         :m => Normal(0, 1)
-    ), 
+    ),
     1_000
 )
 mean(chain)
@@ -84,20 +84,20 @@ Specifying explicit proposals using the `AdvancedMH` interface:
 
 ```julia
 @model function gdemo(x, y)
-    s ~ InverseGamma(2,3)
-    m ~ Normal(0, sqrt(s))
-    x ~ Normal(m, sqrt(s))
-    y ~ Normal(m, sqrt(s))
+    s² ~ InverseGamma(2,3)
+    m ~ Normal(0, sqrt(s²))
+    x ~ Normal(m, sqrt(s²))
+    y ~ Normal(m, sqrt(s²))
 end
 
-# Use a static proposal for s and random walk with proposal 
+# Use a static proposal for s and random walk with proposal
 # standard deviation of 0.25 for m.
 chain = sample(
-    gdemo(1.5, 2.0), 
+    gdemo(1.5, 2.0),
     MH(
         :s => AdvancedMH.StaticProposal(InverseGamma(2,3)),
         :m => AdvancedMH.RandomWalkProposal(Normal(0, 0.25))
-    ), 
+    ),
     1_000
 )
 mean(chain)
@@ -107,20 +107,20 @@ Using a custom function to specify a conditional distribution:
 
 ```julia
 @model function gdemo(x, y)
-    s ~ InverseGamma(2,3)
-    m ~ Normal(0, sqrt(s))
-    x ~ Normal(m, sqrt(s))
-    y ~ Normal(m, sqrt(s))
+    s² ~ InverseGamma(2,3)
+    m ~ Normal(0, sqrt(s²))
+    x ~ Normal(m, sqrt(s²))
+    y ~ Normal(m, sqrt(s²))
 end
 
 # Use a static proposal for s and and a conditional proposal for m,
 # where the proposal is centered around the current sample.
 chain = sample(
-    gdemo(1.5, 2.0), 
+    gdemo(1.5, 2.0),
     MH(
         :s => InverseGamma(2, 3),
         :m => x -> Normal(x, 1)
-    ), 
+    ),
     1_000
 )
 mean(chain)
@@ -132,19 +132,19 @@ normal distribution. The provided matrix must be positive semi-definite and squa
 
 ```julia
 @model function gdemo(x, y)
-    s ~ InverseGamma(2,3)
-    m ~ Normal(0, sqrt(s))
-    x ~ Normal(m, sqrt(s))
-    y ~ Normal(m, sqrt(s))
+    s² ~ InverseGamma(2,3)
+    m ~ Normal(0, sqrt(s²))
+    x ~ Normal(m, sqrt(s²))
+    y ~ Normal(m, sqrt(s²))
 end
 
 # Providing a custom variance-covariance matrix
 chain = sample(
-    gdemo(1.5, 2.0), 
+    gdemo(1.5, 2.0),
     MH(
-        [0.25 0.05; 
+        [0.25 0.05;
          0.05 0.50]
-    ), 
+    ),
     1_000
 )
 mean(chain)
@@ -167,15 +167,15 @@ function MH(space...)
             push!(prop_syms, s[1])
             push!(props, proposal(s[2]))
         elseif length(space) == 1
-            # If we hit this block, check to see if it's 
+            # If we hit this block, check to see if it's
             # a run-of-the-mill proposal or covariance
             # matrix.
             prop = proposal(s)
 
-            # Return early, we got a covariance matrix. 
+            # Return early, we got a covariance matrix.
             return MH{(), typeof(prop)}(prop)
         else
-            # Try to convert it to a proposal anyways, 
+            # Try to convert it to a proposal anyways,
             # throw an error if not acceptable.
             prop = proposal(s)
             push!(props, prop)
@@ -265,7 +265,7 @@ end
 # unpack a vector if possible
 unvectorize(dists::AbstractVector) = length(dists) == 1 ? first(dists) : dists
 
-# possibly unpack and reshape samples according to the prior distribution 
+# possibly unpack and reshape samples according to the prior distribution
 reconstruct(dist::Distribution, val::AbstractVector) = DynamicPPL.reconstruct(dist, val)
 function reconstruct(
     dist::AbstractVector{<:UnivariateDistribution},
@@ -316,7 +316,7 @@ end
 end
 
 @generated function _dist_tuple(
-    props::NamedTuple{propnames}, 
+    props::NamedTuple{propnames},
     vi::VarInfo,
     vns::NamedTuple{names}
 ) where {names,propnames}


### PR DESCRIPTION
Following up on #1605 ... I did a quick search and found a few more obvious things. There's also some stuff in the tests, but that's less user facing and will require more time to look through and make sure that the change is appropriate (and when the resulting variables are used further down the line).

Sorry for the trailing whitespace removal.