### PR TITLE
Fix docstring for epsilon named arg in NUTS

### DIFF
--- a/src/inference/hmc.jl
+++ b/src/inference/hmc.jl
@@ -334,7 +334,7 @@ end
 
 
 """
-    NUTS(n_adapts::Int, δ::Float64; max_depth::Int=5, Δ_max::Float64=1000.0, ϵ::Float64=0.0)
+    NUTS(n_adapts::Int, δ::Float64; max_depth::Int=5, Δ_max::Float64=1000.0, init_ϵ::Float64=0.0)
 
 No-U-Turn Sampler (NUTS) sampler.
 


### PR DESCRIPTION
Simplest way to address #1648 (but maybe not the best)

Rather straightforward pull request if this is the route chosen to resolve the issue.