### PR TITLE
Remove comment about dependencies

### DIFF
--- a/src/Turing.jl
+++ b/src/Turing.jl
@@ -1,13 +1,5 @@
 module Turing
 
-##############
-# Dependency #
-########################################################################
-# NOTE: when using anything from external packages,                    #
-#       let's keep the practice of explictly writing Package.something #
-#       to indicate that's not implemented inside Turing.jl            #
-########################################################################
-
 using Requires, Reexport, ForwardDiff
 using DistributionsAD, Bijectors, StatsFuns, SpecialFunctions
 using Statistics, LinearAlgebra


### PR DESCRIPTION
This comment was added in 2017 (b696b57c05d12877d4038dcbd33abc58f5a5aef6). The codebase is not adhering to the comment at all, so it's probably better to remove the comment in order to not confuse readers.