### PR TITLE
New release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Turing"
 uuid = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-version = "0.17.2"
+version = "0.17.3"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
@@ -50,7 +50,7 @@ ForwardDiff = "0.10.3"
 Libtask = "0.4, 0.5.3"
 MCMCChains = "4"
 NamedArrays = "0.9"
-Reexport = "0.2, ~1.0, ~1.1, =1.2.0"
+Reexport = "0.2, 1"
 Requires = "0.5, 1.0"
 SpecialFunctions = "0.7.2, 0.8, 0.9, 0.10, 1"
 StatsBase = "0.32, 0.33"


### PR DESCRIPTION
Reexport 1.2.1 was yanked and 1.2.2 is released, so everything should be fine again 🙂 