### PR TITLE
Reduce and speed up CI

### DIFF
--- a/.github/workflows/DynamicHMC.yml
+++ b/.github/workflows/DynamicHMC.yml
@@ -36,5 +36,7 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
+        with:
+          coverage: false
         env:
           STAGE: dynamichmc

--- a/.github/workflows/Numerical.yml
+++ b/.github/workflows/Numerical.yml
@@ -35,5 +35,7 @@ jobs:
             ${{ runner.os }}-test-
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
+        with:
+          coverage: false
         env:
           STAGE: numerical

--- a/.github/workflows/StanCI.yml
+++ b/.github/workflows/StanCI.yml
@@ -36,5 +36,7 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
+        with:
+          coverage: false
         env:
           STAGE: stan

--- a/.github/workflows/TuringCI.yml
+++ b/.github/workflows/TuringCI.yml
@@ -17,22 +17,23 @@ jobs:
           - '1'
         os:
           - ubuntu-latest
-          - macOS-latest
-          - windows-latest
         arch:
-          - x86
           - x64
         num_threads:
           - 1
           - 2
-        exclude:
-          - os: windows-latest
+        include:
+          - version: '1'
+            os: ubuntu-latest
             arch: x86
-          - os: macOS-latest
-            arch: x86
-          - os: macOS-latest
             num_threads: 2
-          - os: windows-latest
+          - version: '1'
+            os: windows-latest
+            arch: x64
+            num_threads: 2
+          - version: '1'
+            os: macOS-latest
+            arch: x64
             num_threads: 2
     steps:
       - uses: actions/checkout@v2
@@ -52,6 +53,8 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
+        with:
+          coverage: ${{ matrix.version == '1' && matrix.os == 'ubuntu-latest' && matrix.num_threads == 1 }}
         env:
           JULIA_NUM_THREADS: ${{ matrix.num_threads }}
       - uses: julia-actions/julia-processcoverage@v1


### PR DESCRIPTION
Similar to https://github.com/TuringLang/DynamicPPL.jl/pull/317. Julia 1.3 is only tested with Ubuntu, and macOS and Windows are only tested with `JULIA_NUM_THREADS = 2`. Moreover, avoids unnecessary coverage analysis in cases where the result is not uploaded.