### PR TITLE
Set `DropEntry` for CompatHelper

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -25,8 +25,11 @@ jobs:
         shell: julia --color=yes {0}
       - name: "Run CompatHelper"
         run: |
-          import CompatHelper
-          CompatHelper.main(; subdirs = ["", "test"], bump_version=true)
+          using CompatHelper
+          bump_version = true # Whether to bump version when making PR.
+          entry_type = DropEntry() # Don't keep existing compat entry.
+          subdirs = ["", "test"]
+          CompatHelper.main(; bump_version, entry_type, subdirs)
         shell: julia --color=yes {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
When looking through recent PRs, old compat entries are always dropped when updating compat entries. This PR sets  `entry_type=DropEntry()`, so that CompatHelper will drop existing compat entries.