### PR TITLE
Switch to Libtask.TapedTask

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Turing"
 uuid = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-version = "0.20.2"
+version = "0.20.3"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/docs/src/using-turing/advanced.md
+++ b/docs/src/using-turing/advanced.md
@@ -191,5 +191,4 @@ model = Turing.Model(modelf, (x = [1.5, 2.0],))
 
 ## Task Copying
 
-
-Turing [copies](https://github.com/JuliaLang/julia/issues/4085) Julia tasks to deliver efficient inference algorithms, but it also provides alternative slower implementation as a fallback. Task copying is enabled by default. Task copying requires us to use the `CTask` facility which is provided by [Libtask](https://github.com/TuringLang/Libtask.jl) to create tasks.
+Turing [copies](https://github.com/JuliaLang/julia/issues/4085) Julia tasks to deliver efficient inference algorithms, but it also provides alternative slower implementation as a fallback. Task copying is enabled by default. Task copying requires us to use the `TapedTask` facility which is provided by [Libtask](https://github.com/TuringLang/Libtask.jl) to create tasks.

--- a/src/essential/container.jl
+++ b/src/essential/container.jl
@@ -71,10 +71,10 @@ function AdvancedPS.reset_logprob!(f::TracedModel)
     return
 end
 
-function Libtask.CTask(model::TracedModel)
-    return Libtask.CTask(model.evaluator[1], model.evaluator[2:end]...)
+function Libtask.TapedTask(model::TracedModel)
+    return Libtask.TapedTask(model.evaluator[1], model.evaluator[2:end]...)
 end
 
-function Libtask.CTask(model::TracedModel, ::Random.AbstractRNG)
-    return Libtask.CTask(model)
+function Libtask.TapedTask(model::TracedModel, ::Random.AbstractRNG)
+    return Libtask.TapedTask(model)
 end


### PR DESCRIPTION
In response to https://github.com/TuringLang/Libtask.jl/pull/121#issuecomment-1046114428:

> Would be good to evaluate if the alias is needed

Turing and AdvancedPS still rely on CTask so it is still needed currently. This PR will move to the new name.