### PR TITLE
Switch to Libtask 0.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Turing"
 uuid = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-version = "0.20.3"
+version = "0.20.4"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
@@ -48,7 +48,7 @@ DocStringExtensions = "0.8"
 DynamicPPL = "0.17.2"
 EllipticalSliceSampling = "0.4"
 ForwardDiff = "0.10.3"
-Libtask = "0.6.7"
+Libtask = "0.7"
 MCMCChains = "5"
 NamedArrays = "0.9"
 Reexport = "0.2, 1"


### PR DESCRIPTION
Pinning explicitly to Libtask 0.7 to avoid the an abstract field in `TapedTask`. See https://github.com/TuringLang/Libtask.jl/pull/123 for details.