### PR TITLE
Unify notation for variance in the model and chain

### DIFF
--- a/docs/src/using-turing/sampler-viz.md
+++ b/docs/src/using-turing/sampler-viz.md
@@ -48,7 +48,7 @@ vi = Turing.VarInfo(model)
 # Note: We only have to do this here because we are being very hands-on.
 # Turing will handle all of this for you during normal sampling.
 dist = InverseGamma(2,3)
-svn = vi.metadata.s.vns[1]
+svn = vi.metadata.s².vns[1]
 mvn = vi.metadata.m.vns[1]
 setval!(vi, vectorize(dist, Bijectors.link(dist, reconstruct(dist, getval(vi, svn)))), svn)
 settrans!(vi, true, svn)
@@ -64,8 +64,8 @@ end
 
 function plot_sampler(chain; label="")
     # Extract values from chain.
-    val = get(chain, [:s, :m, :lp])
-    ss = link.(Ref(InverseGamma(2, 3)), val.s)
+    val = get(chain, [:s², :m, :lp])
+    ss = link.(Ref(InverseGamma(2, 3)), val.s²)
     ms = val.m
     lps = val.lp
 


### PR DESCRIPTION
The term for variance in the @model call was changed to s², but extracting this value from the resulting changes was left as get(chain, [:s, :m, :lp]. Update this and val.s to val.s², as well as vi.metadata.s.vns[1] to vi.metadata.s².vns[1].