### PR TITLE
Fix minor inconsistency in HMC doc

### DIFF
--- a/src/inference/hmc.jl
+++ b/src/inference/hmc.jl
@@ -334,7 +334,7 @@ end
 
 
 """
-    NUTS(n_adapts::Int, δ::Float64; max_depth::Int=5, Δ_max::Float64=1000.0, init_ϵ::Float64=0.0)
+    NUTS(n_adapts::Int, δ::Float64; max_depth::Int=10, Δ_max::Float64=1000.0, init_ϵ::Float64=0.0)
 
 No-U-Turn Sampler (NUTS) sampler.
 


### PR DESCRIPTION
The actual default max tree depth is 10, see https://github.com/TuringLang/Turing.jl/blob/master/src/inference/hmc.jl#L402

