### PR TITLE
Remove implementations of `logpdf_with_trans` for `NoDist`

### DIFF
--- a/src/stdlib/distributions.jl
+++ b/src/stdlib/distributions.jl
@@ -244,10 +244,3 @@ Distributions.logpdf(d::LogPoisson, k::Real) = _logpdf(d, k)
 
 Base.rand(rng::Random.AbstractRNG, d::LogPoisson) = rand(rng, Poisson(d.λ))
 Distributions.sampler(d::LogPoisson) = sampler(Poisson(d.λ))
-
-Bijectors.logpdf_with_trans(d::NoDist{<:Univariate}, ::Real, ::Bool) = 0
-Bijectors.logpdf_with_trans(d::NoDist{<:Multivariate}, ::AbstractVector{<:Real}, ::Bool) = 0
-function Bijectors.logpdf_with_trans(d::NoDist{<:Multivariate}, x::AbstractMatrix{<:Real}, ::Bool)
-    return zeros(Int, size(x, 2))
-end
-Bijectors.logpdf_with_trans(d::NoDist{<:Matrixvariate}, ::AbstractMatrix{<:Real}, ::Bool) = 0


### PR DESCRIPTION
This should be hidden in stdlib/distributions.jl and at most be defined in DynamicPPL (see https://github.com/TuringLang/DynamicPPL.jl/pull/414#issuecomment-1170516505). I wonder, are they used anywhere and what breaks if we remove them completely?