### PR TITLE
Bump minor version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Turing"
 uuid = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-version = "0.21.14"
+version = "0.22.0"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"


### PR DESCRIPTION
After #1900 we should, IMO, bump the minor version given that we did so in DPPL. _Technically_ this should be non-breaking, but I'm personally worried that there will be some unforeseen consequences OR people are simply using some internal functionality from DPPL (which _did_ have a breaking release). 