### PR TITLE
Insane memory-usage when using `Emcee` with large number of iterations

### DIFF
--- a/src/inference/emcee.jl
+++ b/src/inference/emcee.jl
@@ -124,7 +124,8 @@ function AbstractMCMC.bundle_samples(
     # Extract names & construct param array.
     nms = [nms; extra_params]
     parray = map(x -> hcat(x[1], x[2]), zip(vals_vec, extra_values_vec))
-    parray = cat(parray..., dims=3)
+    # NOTE: Use `reduce` instead of splatting to avoid stack overflow.
+    parray = reduce((x, y) -> cat(x, y; dims=3), parray)
 
     # Get the average or final log evidence, if it exists.
     le = getlogevidence(samples, state, spl)


### PR DESCRIPTION
On this branch:

``` julia
julia> using Turing

julia> @model demo() = x ~ Normal()
demo (generic function with 2 methods)

julia> sample(demo(), Emcee(10), 10_000)
Sampling 100%|██████████████████████████████████████████████████████████████████████████████████████| Time: 0:00:05
Chains MCMC chain (10×2×10000 Array{Float64, 3}):

Iterations        = 1:1:10
Number of chains  = 10000
Samples per chain = 10
parameters        = x
internals         = lp

Summary Statistics
  parameters      mean       std      mcse      ess_bulk      ess_tail      rhat   ess_per_sec 
      Symbol   Float64   Float64   Float64       Float64       Float64   Float64       Missing 

           x   -0.0091    1.0040    0.0026   147424.4897   137431.1963    1.0026       missing

Quantiles
  parameters      2.5%     25.0%     50.0%     75.0%     97.5% 
      Symbol   Float64   Float64   Float64   Float64   Float64 

           x   -1.9819   -0.6879   -0.0095    0.6660    1.9589
```

On master I can't run the above code without blowing up my 32GB mem machine.

All because of one pesky splat.