### PR TITLE
[WIP] Allow usage of `AbstractSampler`

### DIFF
--- a/src/inference/Inference.jl
+++ b/src/inference/Inference.jl
@@ -148,8 +148,8 @@ end
 
 function AbstractMCMC.sample(
     rng::AbstractRNG,
-    model::AbstractModel,
-    sampler::Sampler{<:InferenceAlgorithm},
+    model::DynamicPPL.Model,
+    sampler::AbstractSampler,
     N::Integer;
     chain_type=MCMCChains.Chains,
     resume_from=nothing,
@@ -166,7 +166,7 @@ end
 
 function AbstractMCMC.sample(
     rng::AbstractRNG,
-    model::AbstractModel,
+    model::DynamicPPL.Model,
     alg::Prior,
     N::Integer;
     chain_type=MCMCChains.Chains,
@@ -209,8 +209,8 @@ end
 
 function AbstractMCMC.sample(
     rng::AbstractRNG,
-    model::AbstractModel,
-    sampler::Sampler{<:InferenceAlgorithm},
+    model::DynamicPPL.Model,
+    sampler::AbstractSampler,
     ensemble::AbstractMCMC.AbstractMCMCEnsemble,
     N::Integer,
     n_chains::Integer;
@@ -224,7 +224,7 @@ end
 
 function AbstractMCMC.sample(
     rng::AbstractRNG,
-    model::AbstractModel,
+    model::DynamicPPL.Model,
     alg::Prior,
     ensemble::AbstractMCMC.AbstractMCMCEnsemble,
     N::Integer,
@@ -322,8 +322,8 @@ getlogevidence(transitions, sampler, state) = missing
 # This is type piracy (at least for SampleFromPrior).
 function AbstractMCMC.bundle_samples(
     ts::Vector,
-    model::AbstractModel,
-    spl::Union{Sampler{<:InferenceAlgorithm},SampleFromPrior},
+    model::DynamicPPL.Model,
+    spl::AbstractMCMC.AbstractSampler,
     state,
     chain_type::Type{MCMCChains.Chains};
     save_state = false,
@@ -379,8 +379,8 @@ end
 # This is type piracy (for SampleFromPrior).
 function AbstractMCMC.bundle_samples(
     ts::Vector,
-    model::AbstractModel,
-    spl::Union{Sampler{<:InferenceAlgorithm},SampleFromPrior},
+    model::DynamicPPL.Model,
+    spl::AbstractMCMC.AbstractSampler,
     state,
     chain_type::Type{Vector{NamedTuple}};
     kwargs...
@@ -432,6 +432,7 @@ include("gibbs_conditional.jl")
 include("gibbs.jl")
 include("../contrib/inference/sghmc.jl")
 include("emcee.jl")
+include("hmc_new.jl")
 
 ################
 # Typing tools #

--- a/src/inference/hmc_new.jl
+++ b/src/inference/hmc_new.jl
@@ -1,0 +1,87 @@
+struct TuringState{S,F}
+    state::S
+    logdensity::F
+end
+
+function state_to_turing(f::DynamicPPL.LogDensityFunction, state::AdvancedHMC.HMCState)
+    return TuringState(state, f)
+end
+
+function transition_to_turing(f::DynamicPPL.LogDensityFunction, transition::AdvancedHMC.Transition)
+    varinfo = DynamicPPL.unflatten(f.varinfo, transition.z.θ)
+    # TODO: `deepcopy` is overkill; make more efficient.
+    varinfo = DynamicPPL.invlink!!(deepcopy(varinfo), f.model)
+    return HMCTransition(varinfo, transition)
+end
+
+function AbstractMCMC.step(
+    rng::Random.AbstractRNG,
+    model::DynamicPPL.Model,
+    sampler::AdvancedHMC.HMCSampler;
+    kwargs...
+)
+    # Create a log-density function.
+    f = DynamicPPL.LogDensityFunction(model)
+
+    # Link the varinfo.
+    DynamicPPL.Setfield.@set! f.varinfo = link!!(f.varinfo, model)
+
+    # Then just call `AdvancedHMC.step` with the right arguments.
+    transition_inner, state_inner = AbstractMCMC.step(rng, AbstractMCMC.LogDensityModel(f), sampler; kwargs...)
+
+    # Update the `state`
+    return transition_to_turing(f, transition_inner), state_to_turing(f, state_inner)
+end
+
+function AbstractMCMC.step(
+    rng::Random.AbstractRNG,
+    model::DynamicPPL.Model,
+    sampler::AdvancedHMC.HMCSampler,
+    state::TuringState;
+    kwargs...
+)
+    f = state.logdensity
+
+    # Then just call `AdvancedHMC.step` with the right arguments.
+    transition_inner, state_inner = AbstractMCMC.step(rng, AbstractMCMC.LogDensityModel(f), sampler, state.state; kwargs...)
+
+    # Update the `state`
+    return transition_to_turing(f, transition_inner), state_to_turing(f, state_inner)
+end
+
+# TODO: This needs to be replaced by something much better.
+# We can probably re-use a lot from `DynamicPPL.initialstep`.
+function initialize_nuts(f::DynamicPPL.LogDensityFunction)
+    needs_linking = !istrans(f.varinfo)
+    if needs_linking
+        DynamicPPL.link!!(f.varinfo, f.model)
+    end
+    
+    # Choose parameter dimensionality and initial parameter value
+    D = LogDensityProblems.dimension(f)
+    initial_θ = rand(D)
+
+    # Define a Hamiltonian system
+    metric = AdvancedHMC.DiagEuclideanMetric(D)
+    hamiltonian = AdvancedHMC.Hamiltonian(metric, f)
+
+    # Define a leapfrog solver, with initial step size chosen heuristically
+    initial_ϵ = AdvancedHMC.find_good_stepsize(hamiltonian, initial_θ)
+    integrator = AdvancedHMC.Leapfrog(initial_ϵ)
+
+    # Define an HMC sampler, with the following components
+    #   - multinomial sampling scheme,
+    #   - generalised No-U-Turn criteria, and
+    #   - windowed adaption for step-size and diagonal mass matrix
+    proposal = AdvancedHMC.NUTS{AdvancedHMC.MultinomialTS,AdvancedHMC.GeneralisedNoUTurn}(integrator)
+    adaptor = AdvancedHMC.StanHMCAdaptor(
+        AdvancedHMC.MassMatrixAdaptor(metric),
+        AdvancedHMC.StepSizeAdaptor(0.8, integrator)
+    )
+
+    if needs_linking
+        DynamicPPL.invlink!!(f.varinfo, f.model)
+    end
+
+    return AdvancedHMC.HMCSampler(proposal, metric, adaptor)
+end


### PR DESCRIPTION
This is a very rough idea of how we could go about supporting `AbstractMCMC.AbstractSampler` to reduce the necessary glue code.