### PR TITLE
Fixed broken `Turing.Inference.named_values`

### DIFF
--- a/src/inference/Inference.jl
+++ b/src/inference/Inference.jl
@@ -297,23 +297,23 @@ function names_values(extra_data::AbstractVector{<:NamedTuple{names}}) where nam
     return collect(names), values
 end
 
-function names_values(extra_data::AbstractVector{<:NamedTuple})
+function names_values(xs::AbstractVector{<:NamedTuple})
     # Obtain all parameter names.
-    names_set = Set(Symbol[])
-    for data in extra_data
-        for name in names(data)
-            push!(extra_names_set, name)
+    names_set = Set{Symbol}()
+    for x in xs
+        for k in keys(x)
+            push!(names_set, k)
         end
     end
-    extra_names = collect(extra_names_set)
+    names_unique = collect(names_set)
 
     # Extract all values as matrix.
     values = [
-        hasfield(data, name) ? missing : getfield(data, name)
-        for data in extra_data, name in extra_names
+        haskey(x, name) ? x[name] : missing
+        for x in xs, name in names_unique
     ]
 
-    return extra_names, values
+    return names_unique, values
 end
 
 getlogevidence(transitions, sampler, state) = missing

--- a/test/inference/Inference.jl
+++ b/test/inference/Inference.jl
@@ -523,4 +523,14 @@
         vdemo3kw(; T) = vdemo3(T)
         sample(vdemo3kw(; T=Vector{Float64}), alg, 250)
     end
+
+    @testset "names_values" begin
+        ks, xs = Turing.Inference.names_values([
+            (a=1,),
+            (b=2,),
+            (a=3, b=4)
+        ])
+        @test all(xs[:, 1] .=== [1, missing, 3])
+        @test all(xs[:, 2] .=== [missing, 2, 4])
+    end
 end


### PR DESCRIPTION
I came across this method:

https://github.com/TuringLang/Turing.jl/blob/970abacfc0f1017c03b5a41984ccae0979b9247b/src/inference/Inference.jl#L300-L317

which is very buggy in many ways. _But_ it doesn't _seem_ to be used anywhere (since otherwise we would have had complaints)! The reason is because we have the following implementation too:

https://github.com/TuringLang/Turing.jl/blob/970abacfc0f1017c03b5a41984ccae0979b9247b/src/inference/Inference.jl#L295-L298

So we should either a) fix it and test it (as in this PR), or b) just straight up delete it.

I'm slightly in favour of keeping it and adding a test, just because it is _technically_ a method that could be hit (for example, if I tried to use MCMCTempering.jl + #2008, I'd end up hitting it).