### PR TITLE
Unify transition also in external samplers

### DIFF
--- a/src/contrib/inference/abstractmcmc.jl
+++ b/src/contrib/inference/abstractmcmc.jl
@@ -3,20 +3,8 @@ struct TuringState{S,F}
     logdensity::F
 end
 
-struct TuringTransition{T,NT<:NamedTuple,F<:AbstractFloat}
-    θ::T
-    lp::F
-    stat::NT
-end
-
-function TuringTransition(vi::AbstractVarInfo, t)
-    theta = tonamedtuple(vi)
-    lp = getlogp(vi)
-    return TuringTransition(theta, lp, getstats(t))
-end
-
-metadata(t::TuringTransition) = merge((lp = t.lp,), t.stat)
-DynamicPPL.getlogp(t::TuringTransition) = t.lp
+metadata(t::Transition) = merge((lp = t.lp,), t.stat)
+DynamicPPL.getlogp(t::Transition) = t.lp
 
 state_to_turing(f::DynamicPPL.LogDensityFunction, state) = TuringState(state, f)
 function transition_to_turing(f::DynamicPPL.LogDensityFunction, transition)
@@ -24,7 +12,7 @@ function transition_to_turing(f::DynamicPPL.LogDensityFunction, transition)
     varinfo = DynamicPPL.unflatten(f.varinfo, θ)
     # TODO: `deepcopy` is overkill; make more efficient.
     varinfo = DynamicPPL.invlink!!(deepcopy(varinfo), f.model)
-    return TuringTransition(varinfo, transition)
+    return Transition(varinfo, transition)
 end
 
 # NOTE: Only thing that depends on the underlying sampler.


### PR DESCRIPTION
We no longer need `TuringTransition`