### PR TITLE
Extract Priors

### DIFF
--- a/src/inference/mh.jl
+++ b/src/inference/mh.jl
@@ -188,6 +188,16 @@ function MH(space...)
     return MH{tuple(syms...), typeof(proposals)}(proposals)
 end
 
+function StaticMH(model::Model)
+    priors = extract_priors(model)
+    return AMH.MetropolisHastings(AMH.StaticProposal(priors))
+end
+
+function RWMH(model::Model)
+    priors = extract_priors(model)
+    return AMH.MetropolisHastings(AMH.RandomWalkProposal(priors))
+end
+
 #####################
 # Utility functions #
 #####################


### PR DESCRIPTION
Implements the tool to extract the priors from a model proposed by @torfjelde in #2009 and applies to create a constructor for AdvancedMH samplers based on the model priors like:
```Julia
function StaticMH(model::Model)
    priors = extract_priors(model)
    return AMH.MetropolisHastings(AMH.StaticProposal(priors))
end

function RWMH(model::Model)
    priors = extract_priors(model)
    return AMH.MetropolisHastings(AMH.RandomWalkProposal(priors))
end
```
Where `extract_priors` is a new method defined in `infernece/inference.jl`