### PR TITLE
Re-add AdvancedMH compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -39,6 +39,7 @@ Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 [compat]
 AbstractMCMC = "4"
 AdvancedHMC = "0.3.0, 0.4"
+AdvancedMH = "0.6.8, 0.7"
 AdvancedPS = "0.4"
 AdvancedVI = "0.2"
 BangBang = "0.3"


### PR DESCRIPTION
Seems this was removed in #2030 by accident.