### PR TITLE
Fix redundant definition of `getstats(t::Any)`

### DIFF
--- a/src/inference/Inference.jl
+++ b/src/inference/Inference.jl
@@ -125,7 +125,7 @@ end
 ######################
 # Default
 # Extended in contrib/inference/abstractmcmc.jl
-getstats(t) = nothing
+function getstats end
 
 struct Transition{T, F<:AbstractFloat, S<:Union{NamedTuple, Nothing}}
     θ     :: T


### PR DESCRIPTION
The `getstats(t::Any)` is defined twice in the following lines:

https://github.com/TuringLang/Turing.jl/blob/e1d3fef4633096e1e73872967b1281c31eee0f0b/src/inference/Inference.jl#L128

https://github.com/TuringLang/Turing.jl/blob/e1d3fef4633096e1e73872967b1281c31eee0f0b/src/contrib/inference/abstractmcmc.jl#L22