### PR TITLE
bump compat of AdvancedHMC

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -38,7 +38,7 @@ Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 
 [compat]
 AbstractMCMC = "4"
-AdvancedHMC = "0.3.0, 0.4"
+AdvancedHMC = "0.3.0, 0.4, 5"
 AdvancedMH = "0.6.8, 0.7"
 AdvancedPS = "0.4"
 AdvancedVI = "0.2"


### PR DESCRIPTION
Bump compatibility of AdvancedHMC to include the latest version that includes the interface with external samplers. 