### PR TITLE
Remove some obsolete utility exports. 

### DIFF
--- a/src/utilities/Utilities.jl
+++ b/src/utilities/Utilities.jl
@@ -6,14 +6,7 @@ using Distributions, Bijectors
 using StatsFuns, SpecialFunctions
 import Distributions: sample
 
-export  vectorize,
-        reconstruct,
-        reconstruct!,
-        Sample,
-        Chain,
-        init,
-        set_resume!,
-        FlattenIterator
+export FlattenIterator
 
 include("helper.jl")
 


### PR DESCRIPTION
The `Turing.Utilities` submodule can be safely transferred into `DynamicPPL`, which can be done in a separate PR. 