### PR TITLE
Bringback old getparams

### DIFF
--- a/src/mcmc/Inference.jl
+++ b/src/mcmc/Inference.jl
@@ -293,6 +293,7 @@ end
 
 Return a named tuple of parameters.
 """
+getparams(t) = t.θ
 getparams(model, t) = t.θ
 function getparams(model::DynamicPPL.Model, vi::DynamicPPL.VarInfo)
     # Want the end-user to receive parameters in constrained space, so we `link`.


### PR DESCRIPTION
`getparams(t) = t.θ` is extremely useful to connect external samplers to Turing while 
```
# NOTE: Only thing that depends on the underlying sampler.
# Something similar should be part of AbstractMCMC at some point:
# https://github.com/TuringLang/AbstractMCMC.jl/pull/86
getparams(transition::AdvancedHMC.Transition) = transition.z.θ
getstats(transition::AdvancedHMC.Transition) = transition.stat

getparams(transition::AdvancedMH.Transition) = transition.params

getvarinfo(f::DynamicPPL.LogDensityFunction) = f.varinfo
getvarinfo(f::LogDensityProblemsAD.ADGradientWrapper) = getvarinfo(parent(f))

setvarinfo(f::DynamicPPL.LogDensityFunction, varinfo) = Setfield.@set f.varinfo = varinfo
setvarinfo(f::LogDensityProblemsAD.ADGradientWrapper, varinfo) = setvarinfo(parent(f), varinfo)
```
get properly pushed into abstractmcmc.