### PR TITLE
Partial fix for #2095

### DIFF
--- a/src/mcmc/hmc.jl
+++ b/src/mcmc/hmc.jl
@@ -132,13 +132,13 @@ function DynamicPPL.initialstep(
     rng::AbstractRNG,
     model::AbstractModel,
     spl::Sampler{<:Hamiltonian},
-    vi::AbstractVarInfo;
+    vi_original::AbstractVarInfo;
     init_params=nothing,
     nadapts=0,
     kwargs...
 )
     # Transform the samples to unconstrained space and compute the joint log probability.
-    vi = link!!(vi, spl, model)
+    vi = DynamicPPL.link(vi_original, spl, model)
 
     # Extract parameters.
     theta = vi[spl]


### PR DESCRIPTION
This is a partial fix for #2095. Currently, HMC won't work with vectors, etc. of variables which have differently sized support in the transformed space, e.g.

``` julia
@model function vector_of_dirichlet(::Type{TV}=Vector{Float64}) where {TV}
    xs = Vector{TV}(undef, 3)
    for i = 1:3
        xs[i] ~ Dirichlet(ones(5))
    end
end

model = vector_of_dirichlet()
sample(model, NUTS(), 1000)
```

breaks with a similar error to that mentioned in #2095.

This occurs because `unflatten`, which is used in `DynamicPPL.LogDensityFunction`, attempts to reconstruct using a `VarInfo` which has a much larger vector for underlying storage than the one provided as input, e.g. `varinfo` is working with 3 x 5 dimensional `xs` but is only using a subset of the indexes, while the provided vector will be (3 - 1) x 5 dimensional since it's in linked space.

We can fix this by simply using the immutable `DynamicPPL.link`, which results in the "underlying" `varinfo` also using (3 - 1) x 5 dimensional storage for `xs`.