### PR TITLE
Fix for CI

### DIFF
--- a/test/optimisation/OptimInterface.jl
+++ b/test/optimisation/OptimInterface.jl
@@ -151,6 +151,9 @@ end
             DynamicPPL.TestUtils.demo_dot_assume_observe_submodel,
             DynamicPPL.TestUtils.demo_dot_assume_dot_observe_matrix,
             DynamicPPL.TestUtils.demo_dot_assume_matrix_dot_observe_matrix,
+            DynamicPPL.TestUtils.demo_assume_submodel_observe_index_literal,
+            DynamicPPL.TestUtils.demo_dot_assume_observe_index_literal,
+            DynamicPPL.TestUtils.demo_assume_matrix_dot_observe_matrix
         ]
         @testset "MLE for $(model.f)" for model in DynamicPPL.TestUtils.DEMO_MODELS
             result_true = DynamicPPL.TestUtils.likelihood_optima(model)


### PR DESCRIPTION
We've added some new models to `DynamicPPL.TestUtils.DEMO_MODELS` at some point, and these are also examples where optimization might terminate early because of insane values (as noted before, this is because the parameters include variances for each data point, hence, when performing MLE, these should be 0).