### PR TITLE
Fix deprecations and default ADTypes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Turing"
 uuid = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-version = "0.30.1"
+version = "0.30.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/Turing.jl
+++ b/src/Turing.jl
@@ -44,7 +44,6 @@ ForwardDiff.checktag(::Type{ForwardDiff.Tag{TuringTag, V}}, ::Base.Fix1{typeof(L
 include("stdlib/distributions.jl")
 include("stdlib/RandomMeasures.jl")
 include("essential/Essential.jl")
-Base.@deprecate_binding Core Essential false
 using .Essential
 include("mcmc/Inference.jl")  # inference algorithms
 using .Inference
@@ -131,11 +130,7 @@ export  @model,                 # modelling
         get_parameter_bounds,
         optim_objective,
         optim_function,
-        optim_problem,
-
-        setbackend,           # deprecated
-        setchunksize,
-        setadsafe
+        optim_problem
 
 if !isdefined(Base, :get_extension)
     using Requires

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,4 +1,6 @@
-function setbackend(::Union{Symbol, Val})
+export setadbackend, setchunksize, setadsafe
+
+function setadbackend(::Union{Symbol, Val})
     Base.depwarn("`ADBACKEND` and `setbackend` are deprecated. Please specify the chunk size directly in the sampler constructor, e.g., `HMC(0.1, 5; adtype=AutoForwardDiff(; chunksize=0))`.\n This function has no effects.", :setbackend; force=true)
     nothing
 end
@@ -8,7 +10,7 @@ function setchunksize(::Int)
     nothing
 end
 
-function setrdcache(::Bool)
+function setrdcache(::Union{Bool, Val})
     Base.depwarn("`RDCACHE` and `setrdcache` are deprecated. Please specify if you wish to use compiled tape for ReverseDiff directly in the sampler constructor, e.g., `HMC(0.1, 5; adtype=AutoReverseDiff(false))`.\n This function has no effects.", :setrdcache; force=true)
     nothing
 end
@@ -17,3 +19,5 @@ function setadsafe(::Bool)
     Base.depwarn("`ADSAFE` and `setadsafe` are outdated and no longer in use.", :setadsafe; force=true)
     nothing
 end
+
+Base.@deprecate_binding Core Essential false

--- a/src/mcmc/hmc.jl
+++ b/src/mcmc/hmc.jl
@@ -67,7 +67,7 @@ struct HMC{AD, space, metricT <: AHMC.AbstractMetric} <: StaticHamiltonian
     adtype::AD
 end
 
-function HMC(ϵ::Float64, n_leapfrog::Int, ::Type{metricT}, space::Tuple; adtype::ADTypes.AbstractADType=AutoForwardDiff(; chunksize=0)) where {metricT<:AHMC.AbstractMetric}
+function HMC(ϵ::Float64, n_leapfrog::Int, ::Type{metricT}, space::Tuple; adtype::ADTypes.AbstractADType=ADTypes.AutoForwardDiff(; chunksize=0)) where {metricT<:AHMC.AbstractMetric}
     return HMC{typeof(adtype),space,metricT}(ϵ, n_leapfrog, adtype)
 end
 function HMC(
@@ -75,7 +75,7 @@ function HMC(
     n_leapfrog::Int,
     space::Symbol...;
     metricT=AHMC.UnitEuclideanMetric,
-    adtype::ADTypes.AbstractADType=AutoForwardDiff(; chunksize=0),
+    adtype::ADTypes.AbstractADType=ADTypes.AutoForwardDiff(; chunksize=0),
 )
     return HMC(ϵ, n_leapfrog, metricT, space; adtype = adtype)
 end
@@ -316,7 +316,7 @@ struct HMCDA{AD, space, metricT <: AHMC.AbstractMetric} <: AdaptiveHamiltonian
     adtype::AD
 end
 
-function HMCDA(n_adapts::Int, δ::Float64, λ::Float64, ϵ::Float64, ::Type{metricT}, space::Tuple; adtype::ADTypes.AbstractADType=AutoForwardDiff(; chunksize=0)) where {metricT<:AHMC.AbstractMetric}
+function HMCDA(n_adapts::Int, δ::Float64, λ::Float64, ϵ::Float64, ::Type{metricT}, space::Tuple; adtype::ADTypes.AbstractADType=ADTypes.AutoForwardDiff(; chunksize=0)) where {metricT<:AHMC.AbstractMetric}
     return HMCDA{typeof(adtype),space,metricT}(n_adapts, δ, λ, ϵ, adtype)
 end
 
@@ -325,7 +325,7 @@ function HMCDA(
     λ::Float64;
     init_ϵ::Float64=0.0,
     metricT=AHMC.UnitEuclideanMetric,
-    adtype::ADTypes.AbstractADType=AutoForwardDiff(; chunksize=0),
+    adtype::ADTypes.AbstractADType=ADTypes.AutoForwardDiff(; chunksize=0),
 )
     return HMCDA(-1, δ, λ, init_ϵ, metricT, (); adtype = adtype)
 end
@@ -347,7 +347,7 @@ function HMCDA(
     space::Symbol...;
     init_ϵ::Float64=0.0,
     metricT=AHMC.UnitEuclideanMetric,
-    adtype::ADTypes.AbstractADType=AutoForwardDiff(; chunksize=0),
+    adtype::ADTypes.AbstractADType=ADTypes.AutoForwardDiff(; chunksize=0),
 )
     return HMCDA(n_adapts, δ, λ, init_ϵ, metricT, space; adtype = adtype)
 end
@@ -393,7 +393,7 @@ function NUTS(
     ϵ::Float64,
     ::Type{metricT},
     space::Tuple;
-    adtype::ADTypes.AbstractADType=AutoForwardDiff(; chunksize=0),
+    adtype::ADTypes.AbstractADType=ADTypes.AutoForwardDiff(; chunksize=0),
 ) where {metricT}
     return NUTS{typeof(adtype),space,metricT}(n_adapts, δ, max_depth, Δ_max, ϵ, adtype)
 end
@@ -415,7 +415,7 @@ function NUTS(
     Δ_max::Float64=1000.0,
     init_ϵ::Float64=0.0,
     metricT=AHMC.DiagEuclideanMetric,
-    adtype::ADTypes.AbstractADType=AutoForwardDiff(; chunksize=0),
+    adtype::ADTypes.AbstractADType=ADTypes.AutoForwardDiff(; chunksize=0),
 )
     NUTS(n_adapts, δ, max_depth, Δ_max, init_ϵ, metricT, space; adtype=adtype)
 end
@@ -426,7 +426,7 @@ function NUTS(
     Δ_max::Float64=1000.0,
     init_ϵ::Float64=0.0,
     metricT=AHMC.DiagEuclideanMetric,
-    adtype::ADTypes.AbstractADType=AutoForwardDiff(; chunksize=0),
+    adtype::ADTypes.AbstractADType=ADTypes.AutoForwardDiff(; chunksize=0),
 )
     NUTS(-1, δ, max_depth, Δ_max, init_ϵ, metricT, (); adtype=adtype)
 end

--- a/src/mcmc/sghmc.jl
+++ b/src/mcmc/sghmc.jl
@@ -41,7 +41,7 @@ function SGHMC(
     space::Symbol...;
     learning_rate::Real,
     momentum_decay::Real,
-    adtype::ADTypes.AbstractADType=AutoForwardDiff(; chunksize=0),
+    adtype::ADTypes.AbstractADType=ADTypes.AutoForwardDiff(; chunksize=0),
 )
     _learning_rate, _momentum_decay = promote(learning_rate, momentum_decay)
     return SGHMC{typeof(adtype),space,typeof(_learning_rate)}(_learning_rate, _momentum_decay, adtype)
@@ -184,7 +184,7 @@ See also: [`PolynomialStepsize`](@ref)
 function SGLD(
     space::Symbol...;
     stepsize = PolynomialStepsize(0.01),
-    adtype::ADTypes.AbstractADType = AutoForwardDiff(; chunksize=0),
+    adtype::ADTypes.AbstractADType = ADTypes.AutoForwardDiff(; chunksize=0),
 )
     return SGLD{typeof(adtype),space,typeof(stepsize)}(stepsize, adtype)
 end


### PR DESCRIPTION
Some of the default ADType settings for NUTS are not qualified which causes test errors in DynamicPPL. Additionally, this PR fixes the deprecation of `setadbackend` which was deprecated as `setbackend`.

Fixes #2155.