### PR TITLE
Fix error TuringOptimExt.jl with information matrix/vcov

### DIFF
--- a/ext/TuringOptimExt.jl
+++ b/ext/TuringOptimExt.jl
@@ -86,7 +86,7 @@ function StatsBase.informationmatrix(m::ModeResult; hessian_function=ForwardDiff
     # Calculate the Hessian.
     varnames = StatsBase.coefnames(m)
     H = hessian_function(m.f, m.values.array[:, 1])
-    info = inv(H)
+    info = -H
 
     # Link it back if we invlinked it.
     if linked
@@ -99,7 +99,7 @@ end
 StatsBase.coef(m::ModeResult) = m.values
 StatsBase.coefnames(m::ModeResult) = names(m.values)[1]
 StatsBase.params(m::ModeResult) = StatsBase.coefnames(m)
-StatsBase.vcov(m::ModeResult) = StatsBase.informationmatrix(m)
+StatsBase.vcov(m::ModeResult) = inv(StatsBase.informationmatrix(m))
 StatsBase.loglikelihood(m::ModeResult) = m.lp
 
 ####################


### PR DESCRIPTION
I've been using the MLE/MAP estimation functionality ([defined here](https://github.com/TuringLang/Turing.jl/blob/master/ext/TuringOptimExt.jl)) with some Turing models, and I've come across an error in the `informationmatrix` function, extended from StatsBase.

In the function definition, the Hessian of the log likelihood or joint is first calculated on the unconstrained scale. Then that matrix is inverted and returned as the observed Fisher information matrix for the MLE/MAP. `StatsBase.vcov` is then extended to basically just be an alias for `informationmatrix`.

This seems to be incorrect. [According to Wikipedia](https://en.wikipedia.org/wiki/Observed_information), the observed information matrix is just the negative of the Hessian (not the inverse), and the variance-covariance matrix is the inverse of the information matrix. This pull request fixes these two spots in the code.