### PR TITLE
Change Optimization kwarg `autoad` to `adtype`

### DIFF
--- a/src/optimisation/Optimisation.jl
+++ b/src/optimisation/Optimisation.jl
@@ -283,17 +283,17 @@ function optim_function(
     model::Model,
     estimator::Union{MLE, MAP};
     constrained::Bool=true,
-    autoad::Union{Nothing, AbstractADType}=NoAD(),
+    adtype::Union{Nothing, AbstractADType}=NoAD(),
 )
-    if autoad === nothing
-        Base.depwarn("the use of `autoad=nothing` is deprecated, please use `autoad=SciMLBase.NoAD()`", :optim_function)
+    if adtype === nothing
+        Base.depwarn("the use of `adtype=nothing` is deprecated, please use `adtype=SciMLBase.NoAD()`", :optim_function)
     end
 
     obj, init, t = optim_objective(model, estimator; constrained=constrained)
     
     l(x, _) = obj(x)
-    f = if autoad isa AbstractADType && autoad !== NoAD()
-        OptimizationFunction(l, autoad)
+    f = if adtype isa AbstractADType && adtype !== NoAD()
+        OptimizationFunction(l, adtype)
     else
         OptimizationFunction(
             l;
@@ -310,10 +310,10 @@ function optim_problem(
     estimator::Union{MAP, MLE};
     constrained::Bool=true,
     init_theta=nothing,
-    autoad::Union{Nothing, AbstractADType}=NoAD(),
+    adtype::Union{Nothing, AbstractADType}=NoAD(),
     kwargs...,
 )
-    f, init, transform = optim_function(model, estimator; constrained=constrained, autoad=autoad)
+    f, init, transform = optim_function(model, estimator; constrained=constrained, adtype=adtype)
 
     u0 = init_theta === nothing ? init() : init(init_theta)
     prob = OptimizationProblem(f, u0; kwargs...)


### PR DESCRIPTION
Changing the name of this keyword argument to `optim_problem` and related functions from `autoad` to `adtype`, so that it matches the interface used for constructing samplers and in Optimization.jl.  

In addition to just making things more consistent, this also fixes a bug where `adtype` is mistaken for a generic kwarg and ends up passed to `Optim.Options`, where it causes an error:

```julia
# Turing v0.30.3
using Turing
using Optimization, OptimizationOptimJL
using ReverseDiff

@model function example(x, y)
    a ~ Normal()
    b ~ Normal()
    σ ~ Gamma()

    μ = a .+ b .* x
    y ~ MvNormal(μ, σ)
end

x = rand(10)
y = 1 .+ 2x + randn(10)

m = example(x, y)
prob = optim_problem(m, MAP(), adtype=AutoReverseDiff())
solve(prob.prob, LBFGS())

ERROR: MethodError: no method matching Optim.Options(; extended_trace::Bool, adtype::AutoReverseDiff, callback::OptimizationOptimJL.var"#_cb#12"{…})

Closest candidates are:
  Optim.Options(; x_tol, f_tol, g_tol, x_abstol, x_reltol, f_abstol, f_reltol, g_abstol, g_reltol, outer_x_tol, outer_f_tol, outer_g_tol, outer_x_abstol, outer_x_reltol, outer_f_abstol, outer_f_reltol, outer_g_abstol, outer_g_reltol, f_calls_limit, g_calls_limit, h_calls_limit, allow_f_increases, allow_outer_f_increases, successive_f_tol, iterations, outer_iterations, store_trace, trace_simplex, show_trace, extended_trace, show_warnings, show_every, callback, time_limit) got unsupported keyword argument "adtype"
   @ Optim C:\Users\...\.julia\packages\Optim\EJwLF\src\types.jl:75
  Optim.Options(::T, ::T, ::T, ::T, ::T, ::T, ::T, ::T, ::T, ::T, ::T, ::T, ::Int64, ::Int64, ::Int64, ::Bool, ::Bool, ::Int64, ::Int64, ::Int64, ::Bool, ::Bool, ::Bool, ::Bool, ::Bool, ::Int64, ::TCallback, ::Float64) where {T, TCallback} got unsupported keyword arguments "extended_trace", "adtype", "callback"
   @ Optim C:\Users\...\.julia\packages\Optim\EJwLF\src\types.jl:45

Stacktrace:
 [1] kwerr(kw::@NamedTuple{…}, args::Type)
   @ Base .\error.jl:165
 [2] __map_optimizer_args(cache::OptimizationCache{…}, opt::LBFGS{…}; callback::Function, maxiters::Nothing, local_maxiters::Nothing, maxtime::Nothing, abstol::Nothing, reltol::Nothing, kwargs::@Kwargs{…})
   @ OptimizationOptimJL C:\Users\...\.julia\packages\OptimizationOptimJL\yMF3E\src\OptimizationOptimJL.jl:65
 [3] __solve(cache::OptimizationCache{…})
   @ OptimizationOptimJL C:\Users\...\.julia\packages\OptimizationOptimJL\yMF3E\src\OptimizationOptimJL.jl:204
 [4] solve!(cache::OptimizationCache{…})
   @ SciMLBase C:\Users\...\.julia\packages\SciMLBase\OK4PC\src\solve.jl:179
 [5] solve(::OptimizationProblem{…}, ::LBFGS{…}; kwargs::@Kwargs{})
   @ SciMLBase C:\Users\...\.julia\packages\SciMLBase\OK4PC\src\solve.jl:96
 [6] solve(::OptimizationProblem{…}, ::LBFGS{…})
   @ SciMLBase C:\Users\...\.julia\packages\SciMLBase\OK4PC\src\solve.jl:93

```