### PR TITLE
`Prior` should use `PriorContext`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Turing"
 uuid = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-version = "0.30.3"
+version = "0.30.4"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/mcmc/Inference.jl
+++ b/src/mcmc/Inference.jl
@@ -115,18 +115,6 @@ DynamicPPL.unflatten(vi::SimpleVarInfo, θ::NamedTuple) = SimpleVarInfo(θ, vi.l
 # Algorithm for sampling from the prior
 struct Prior <: InferenceAlgorithm end
 
-function make_prior_model(model::DynamicPPL.Model)
-    # Update the context of `model`.
-    return DynamicPPL.contextualize(
-        model,
-        # Update the leaf context to be a `PriorContext`.
-        DynamicPPL.setleafcontext(
-            model.context,
-            DynamicPPL.PriorContext()
-        )
-    )
-end
-
 function AbstractMCMC.step(
     rng::Random.AbstractRNG,
     model::DynamicPPL.Model,

--- a/src/mcmc/Inference.jl
+++ b/src/mcmc/Inference.jl
@@ -127,6 +127,23 @@ function make_prior_model(model::DynamicPPL.Model)
     )
 end
 
+function AbstractMCMC.step(
+    rng::Random.AbstractRNG,
+    model::DynamicPPL.Model,
+    sampler::DynamicPPL.Sampler{<:Prior},
+    state=nothing;
+    kwargs...,
+)
+    vi = last(DynamicPPL.evaluate!!(
+        model,
+        VarInfo(),
+        SamplingContext(
+            rng, DynamicPPL.SampleFromPrior(), DynamicPPL.PriorContext()
+        )
+    ))
+    return vi, nothing
+end
+
 """
     mh_accept(logp_current::Real, logp_proposal::Real, log_proposal_ratio::Real)
 
@@ -240,38 +257,6 @@ function AbstractMCMC.sample(
 )
     return AbstractMCMC.mcmcsample(rng, model, sampler, ensemble, N, n_chains;
                                    chain_type=chain_type, progress=progress, kwargs...)
-end
-
-function AbstractMCMC.sample(
-    rng::AbstractRNG,
-    model::AbstractModel,
-    alg::Prior,
-    ensemble::AbstractMCMC.AbstractMCMCEnsemble,
-    N::Integer,
-    n_chains::Integer;
-    chain_type=DynamicPPL.default_chain_type(alg),
-    progress=PROGRESS[],
-    kwargs...
-)
-    prior_model = make_prior_model(model)
-    return AbstractMCMC.sample(rng, prior_model, SampleFromPrior(), ensemble, N, n_chains;
-                                    chain_type, progress, kwargs...)
-end
-
-function AbstractMCMC.sample(
-    rng::AbstractRNG,
-    model::AbstractModel,
-    alg::Prior,
-    N::Integer;
-    chain_type=DynamicPPL.default_chain_type(alg),
-    resume_from=nothing,
-    initial_state=DynamicPPL.loadstate(resume_from),
-    progress=PROGRESS[],
-    kwargs...
-)
-    prior_model = make_prior_model(model)
-    return AbstractMCMC.mcmcsample(rng, prior_model, SampleFromPrior(), N;
-                                    chain_type, initial_state, progress, kwargs...)
 end
 
 ##########################

--- a/test/mcmc/Inference.jl
+++ b/test/mcmc/Inference.jl
@@ -140,6 +140,21 @@
         @test all(haskey(x, :lp) for x in chains)
         @test mean(x[:s][1] for x in chains) ≈ 3 atol=0.1
         @test mean(x[:m][1] for x in chains) ≈ 0 atol=0.1
+
+        @testset "#2169" begin
+            # Not exactly the same as the issue, but similar.
+            @model function issue2169_model()
+                if DynamicPPL.leafcontext(__context__) isa DynamicPPL.PriorContext
+                    x ~ Normal(0, 1)
+                else
+                    x ~ Normal(1000, 1)
+                end
+            end
+
+            model = issue2169_model()
+            chain = sample(model, Prior(), 10)
+            @test all(mean(chain[:x]) .< 5)
+        end
     end
 
     @testset "chain ordering" begin


### PR DESCRIPTION
The `Prior` sampler should use the `PriorContext` when sampling, not `DefaultContext`.

This fixes #2169.