### PR TITLE
Bugfix for Optim.jl on models with different linked dimensionality

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Turing"
 uuid = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-version = "0.30.7"
+version = "0.30.8"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/ext/TuringOptimExt.jl
+++ b/ext/TuringOptimExt.jl
@@ -228,7 +228,7 @@ function _optimize(
     # Convert the initial values, since it is assumed that users provide them
     # in the constrained space.
     Setfield.@set! f.varinfo = DynamicPPL.unflatten(f.varinfo, init_vals)
-    Setfield.@set! f.varinfo = DynamicPPL.link!!(f.varinfo, model)
+    Setfield.@set! f.varinfo = DynamicPPL.link(f.varinfo, model)
     init_vals = DynamicPPL.getparams(f)
 
     # Optimize!
@@ -242,9 +242,9 @@ function _optimize(
     # Get the VarInfo at the MLE/MAP point, and run the model to ensure
     # correct dimensionality.
     Setfield.@set! f.varinfo = DynamicPPL.unflatten(f.varinfo, M.minimizer)
-    Setfield.@set! f.varinfo = DynamicPPL.invlink!!(f.varinfo, model)
+    Setfield.@set! f.varinfo = DynamicPPL.invlink(f.varinfo, model)
     vals = DynamicPPL.getparams(f)
-    Setfield.@set! f.varinfo = DynamicPPL.link!!(f.varinfo, model)
+    Setfield.@set! f.varinfo = DynamicPPL.link(f.varinfo, model)
 
     # Make one transition to get the parameter names.
     ts = [Turing.Inference.Transition(

--- a/test/optimisation/OptimInterface.jl
+++ b/test/optimisation/OptimInterface.jl
@@ -225,4 +225,12 @@ end
             @test Turing.OptimLogDensity(m1, ctx)(w) == Turing.OptimLogDensity(m2, ctx)(w)
         end
     end
+
+    # Issue: https://discourse.julialang.org/t/turing-mixture-models-with-dirichlet-weightings/112910
+    @testset "with different linked dimensionality" begin
+        @model demo_dirichlet() = x ~ Dirichlet(ones(3))
+        model = demo()
+        result = optimize(model, MAP())
+        @test result.values ≈ fill(1/3, 3) atol=0.2
+    end
 end


### PR DESCRIPTION
See the test for an example that is currently breaking.

TL;DR: immutable versions of `invlink` and `link` avoid the issues of changing dimensionality between linked and invlinked reps that was causing this issue.

Probably related: https://github.com/TuringLang/DynamicPPL.jl/pull/525

NOTE: The Optim.jl interface and everything is due a rewrite IMO, but that is beyond the scope of this PR (because time is finite :pray:)