### PR TITLE
Improvements to `externalsampler`

### DIFF
--- a/src/Turing.jl
+++ b/src/Turing.jl
@@ -18,6 +18,10 @@ import StatsBase
 import Printf
 import Random
 
+using ADTypes: ADTypes
+
+default_adtype() = ADTypes.AutoForwardDiff(; chunksize=0)
+
 const PROGRESS = Ref(true)
 
 # TODO: remove `PROGRESS` and this function in favour of `AbstractMCMC.PROGRESS`

--- a/src/mcmc/Inference.jl
+++ b/src/mcmc/Inference.jl
@@ -129,11 +129,11 @@ end
 
 
 getADType(spl::Sampler) = getADType(spl.alg)
-getADType(::SampleFromPrior) = AutoForwardDiff(; chunksize=0)
+getADType(::SampleFromPrior) = Turing.default_adtype()
 
 getADType(ctx::DynamicPPL.SamplingContext) = getADType(ctx.sampler)
 getADType(ctx::DynamicPPL.AbstractContext) = getADType(DynamicPPL.NodeTrait(ctx), ctx)
-getADType(::DynamicPPL.IsLeaf, ctx::DynamicPPL.AbstractContext) = AutoForwardDiff(; chunksize=0)
+getADType(::DynamicPPL.IsLeaf, ctx::DynamicPPL.AbstractContext) = Turing.default_adtype()
 getADType(::DynamicPPL.IsParent, ctx::DynamicPPL.AbstractContext) = getADType(DynamicPPL.childcontext(ctx))
 
 getADType(alg::Hamiltonian) = alg.adtype

--- a/src/mcmc/hmc.jl
+++ b/src/mcmc/hmc.jl
@@ -67,7 +67,7 @@ struct HMC{AD, space, metricT <: AHMC.AbstractMetric} <: StaticHamiltonian
     adtype::AD
 end
 
-function HMC(ϵ::Float64, n_leapfrog::Int, ::Type{metricT}, space::Tuple; adtype::ADTypes.AbstractADType=ADTypes.AutoForwardDiff(; chunksize=0)) where {metricT<:AHMC.AbstractMetric}
+function HMC(ϵ::Float64, n_leapfrog::Int, ::Type{metricT}, space::Tuple; adtype::ADTypes.AbstractADType=Turing.default_adtype()) where {metricT<:AHMC.AbstractMetric}
     return HMC{typeof(adtype),space,metricT}(ϵ, n_leapfrog, adtype)
 end
 function HMC(
@@ -75,7 +75,7 @@ function HMC(
     n_leapfrog::Int,
     space::Symbol...;
     metricT=AHMC.UnitEuclideanMetric,
-    adtype::ADTypes.AbstractADType=ADTypes.AutoForwardDiff(; chunksize=0),
+    adtype::ADTypes.AbstractADType=Turing.default_adtype(),
 )
     return HMC(ϵ, n_leapfrog, metricT, space; adtype = adtype)
 end
@@ -316,7 +316,7 @@ struct HMCDA{AD, space, metricT <: AHMC.AbstractMetric} <: AdaptiveHamiltonian
     adtype::AD
 end
 
-function HMCDA(n_adapts::Int, δ::Float64, λ::Float64, ϵ::Float64, ::Type{metricT}, space::Tuple; adtype::ADTypes.AbstractADType=ADTypes.AutoForwardDiff(; chunksize=0)) where {metricT<:AHMC.AbstractMetric}
+function HMCDA(n_adapts::Int, δ::Float64, λ::Float64, ϵ::Float64, ::Type{metricT}, space::Tuple; adtype::ADTypes.AbstractADType=Turing.default_adtype()) where {metricT<:AHMC.AbstractMetric}
     return HMCDA{typeof(adtype),space,metricT}(n_adapts, δ, λ, ϵ, adtype)
 end
 
@@ -325,7 +325,7 @@ function HMCDA(
     λ::Float64;
     init_ϵ::Float64=0.0,
     metricT=AHMC.UnitEuclideanMetric,
-    adtype::ADTypes.AbstractADType=ADTypes.AutoForwardDiff(; chunksize=0),
+    adtype::ADTypes.AbstractADType=Turing.default_adtype(),
 )
     return HMCDA(-1, δ, λ, init_ϵ, metricT, (); adtype = adtype)
 end
@@ -347,7 +347,7 @@ function HMCDA(
     space::Symbol...;
     init_ϵ::Float64=0.0,
     metricT=AHMC.UnitEuclideanMetric,
-    adtype::ADTypes.AbstractADType=ADTypes.AutoForwardDiff(; chunksize=0),
+    adtype::ADTypes.AbstractADType=Turing.default_adtype(),
 )
     return HMCDA(n_adapts, δ, λ, init_ϵ, metricT, space; adtype = adtype)
 end
@@ -393,7 +393,7 @@ function NUTS(
     ϵ::Float64,
     ::Type{metricT},
     space::Tuple;
-    adtype::ADTypes.AbstractADType=ADTypes.AutoForwardDiff(; chunksize=0),
+    adtype::ADTypes.AbstractADType=Turing.default_adtype(),
 ) where {metricT}
     return NUTS{typeof(adtype),space,metricT}(n_adapts, δ, max_depth, Δ_max, ϵ, adtype)
 end
@@ -415,7 +415,7 @@ function NUTS(
     Δ_max::Float64=1000.0,
     init_ϵ::Float64=0.0,
     metricT=AHMC.DiagEuclideanMetric,
-    adtype::ADTypes.AbstractADType=ADTypes.AutoForwardDiff(; chunksize=0),
+    adtype::ADTypes.AbstractADType=Turing.default_adtype(),
 )
     NUTS(n_adapts, δ, max_depth, Δ_max, init_ϵ, metricT, space; adtype=adtype)
 end
@@ -426,7 +426,7 @@ function NUTS(
     Δ_max::Float64=1000.0,
     init_ϵ::Float64=0.0,
     metricT=AHMC.DiagEuclideanMetric,
-    adtype::ADTypes.AbstractADType=ADTypes.AutoForwardDiff(; chunksize=0),
+    adtype::ADTypes.AbstractADType=Turing.default_adtype(),
 )
     NUTS(-1, δ, max_depth, Δ_max, init_ϵ, metricT, (); adtype=adtype)
 end

--- a/src/mcmc/sghmc.jl
+++ b/src/mcmc/sghmc.jl
@@ -41,7 +41,7 @@ function SGHMC(
     space::Symbol...;
     learning_rate::Real,
     momentum_decay::Real,
-    adtype::ADTypes.AbstractADType=ADTypes.AutoForwardDiff(; chunksize=0),
+    adtype::ADTypes.AbstractADType=Turing.default_adtype(),
 )
     _learning_rate, _momentum_decay = promote(learning_rate, momentum_decay)
     return SGHMC{typeof(adtype),space,typeof(_learning_rate)}(_learning_rate, _momentum_decay, adtype)
@@ -184,7 +184,7 @@ See also: [`PolynomialStepsize`](@ref)
 function SGLD(
     space::Symbol...;
     stepsize = PolynomialStepsize(0.01),
-    adtype::ADTypes.AbstractADType = ADTypes.AutoForwardDiff(; chunksize=0),
+    adtype::ADTypes.AbstractADType = Turing.default_adtype(),
 )
     return SGLD{typeof(adtype),space,typeof(stepsize)}(stepsize, adtype)
 end


### PR DESCRIPTION
Currently there's no way of choosing an ad backend for `externalsampler`, nor to specify whether it requires constrained or unconstrained parameters. This PR adds those options.

In addition, the PR adds a `default_adtype` method to be more consistent across the codebase.