### PR TITLE
Optimization improvements

### DIFF
--- a/src/optimisation/Optimisation.jl
+++ b/src/optimisation/Optimisation.jl
@@ -24,6 +24,21 @@ export  constrained_space,
         optim_function,
         optim_problem
 
+
+# TODO(torfjelde): Make these two methods work.
+function maximum_a_posteriori(model::DynamicPPL.Model, solver; kwargs...)
+    # NOTE: Don't know why we need the `init` and `transform` here.
+    prob, init, transform = optim_problem(model, MAP(); kwargs...)
+    return SciMLBase.solve(prob, solver)
+end
+
+function maximum_likelihood(model::DynamicPPL.Model, solver; kwargs...)
+    # NOTE: Don't know why we need the `init` and `transform` here.
+    prob, init, transform = optim_problem(model, MLE(); kwargs...)
+    return SciMLBase.solve(prob, solver)
+end
+
+# TODO(torfjelde): Don't think we need this constrained space struct?
 struct constrained_space{x} end 
 
 struct MLE end


### PR DESCRIPTION
IMO the current optimization we provide is quite lacking. In particular, it _seems_ (I couldn't get it to work with constrained models) as if we support the Optimizations.jl interface through SciMLBase, but it's not really exposed nor documented. Moreover, it's exposed through this `optim_problem` (which is also exported btw) that returns several things that might not be obvious to the user.

I suggest the following:
1. Clean up the `src/optimization` module.
2. Define two methods `maximum_a_posteriori(model, solver; kwargs...)` and `maximum_likelihood(model, solver; kwargs...)`, where the `solver` is whatever Optimizations.jl accepts (and similarly the kwargs).
3. Fix whatever is going on with the constrained models not working.
4. Make `adtype` have some default type. Currently, if you try to use something like `Optim.Newton`, it will error with some obscure message which really just comes down to the fact that `adtype=SciMLBase.NoAD()` (which is contrary to everything else we do in Turing.jl, which is all "ad is enabled by default", no?)