### PR TITLE
Re-export certain functionality from DynamicPPL

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Turing"
 uuid = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-version = "0.31.4"
+version = "0.31.5"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/Turing.jl
+++ b/src/Turing.jl
@@ -61,7 +61,7 @@ include("deprecated.jl") # to be removed in the next minor version release
 # Exports #
 ###########
 # `using` statements for stuff to re-export
-using DynamicPPL: pointwise_loglikelihoods, generated_quantities, logprior, logjoint
+using DynamicPPL: pointwise_loglikelihoods, generated_quantities, logprior, logjoint, condition, decondition, fix, unfix, OrderedDict
 using StatsBase: predict
 
 # Turing essentials - modelling macros and inference algorithms
@@ -114,7 +114,8 @@ export  @model,                 # modelling
         BernoulliLogit,         # Part of Distributions >= 0.25.77
         OrderedLogistic,
         LogPoisson,
-        NamedDist,
+
+        NamedDist,              # Exports from DynamicPPL
         filldist,
         arraydist,
 
@@ -126,6 +127,12 @@ export  @model,                 # modelling
         logjoint,
         LogDensityFunction,
 
+        condition,
+        decondition,
+        fix,
+        unfix,
+        OrderedDict,
+    
         constrained_space,            # optimisation interface
         MAP,
         MLE,


### PR DESCRIPTION
Given that Turing.jl has become a "public-facing" shell package, I think it's worth exporting some functionality commonly used with models from DynamicPPL.jl, so the end-user doesn't have to see DynamicPPL to be able to use these.

Amongst these I think the following should be included:
- `condition`
- `decondition`
- `fix`
- `unfix`
- `OrderedDict` (the only reliable way to call many methods, e.g. `rand`)
- `conditioned` / `observations` (though probably just one of these?)

Any objections? @yebai @devmotion