### PR TITLE
Fix for `optimize` and `:=`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Turing"
 uuid = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-version = "0.31.4"
+version = "0.31.5"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/ext/TuringOptimExt.jl
+++ b/ext/TuringOptimExt.jl
@@ -247,11 +247,9 @@ function _optimize(
     f = Accessors.@set f.varinfo = DynamicPPL.link(f.varinfo, model)
 
     # Make one transition to get the parameter names.
-    ts = [Turing.Inference.Transition(
-        Turing.Inference.getparams(model, f.varinfo),
-        DynamicPPL.getlogp(f.varinfo)
-    )]
-    varnames = map(Symbol, first(Turing.Inference._params_to_array(model, ts)))
+    vns_vals_iter = Turing.Inference.getparams(model, f.varinfo)
+    varnames = map(Symbol ∘ first, vns_vals_iter)
+    vals = map(last, vns_vals_iter)
 
     # Store the parameters and their names in an array.
     vmat = NamedArrays.NamedArray(vals, varnames)

--- a/test/optimisation/OptimInterface.jl
+++ b/test/optimisation/OptimInterface.jl
@@ -224,6 +224,17 @@ end
             ctx = Turing.OptimizationContext(DynamicPPL.DefaultContext())
             @test Turing.OptimLogDensity(m1, ctx)(w) == Turing.OptimLogDensity(m2, ctx)(w)
         end
+
+        @testset "with :=" begin
+            @model function demo_track()
+                x ~ Normal()
+                y := 100 + x
+            end
+            model = demo_track()
+            result = optimize(model, MAP())
+            @test result.values[:x] ≈ 0 atol=1e-1
+            @test result.values[:y] ≈ 100 atol=1e-1
+        end
     end
 
     # Issue: https://discourse.julialang.org/t/turing-mixture-models-with-dirichlet-weightings/112910


### PR DESCRIPTION
`using Optim; optimize(model, MAP())` will currently result in an error if the model includes `:=`.

This PR fixes this.