### PR TITLE
Use new style kwarg constructor for AutoReverseDiff

### DIFF
--- a/benchmarks/benchmarks_suite.jl
+++ b/benchmarks/benchmarks_suite.jl
@@ -84,5 +84,5 @@ BenchmarkSuite["mnormal"]["forwarddiff"] = @benchmarkable sample(
 
 # ReverseDiff
 BenchmarkSuite["mnormal"]["reversediff"] = @benchmarkable sample(
-    $(mdemo(d, 1)), $(HMC(0.1, 5; adtype=AutoReverseDiff(false))), 5000
+    $(mdemo(d, 1)), $(HMC(0.1, 5; adtype=AutoReverseDiff(; compile=false))), 5000
 )

--- a/test/essential/ad.jl
+++ b/test/essential/ad.jl
@@ -154,22 +154,22 @@ end
             return theta ~ Dirichlet(1 ./ fill(4, 4))
         end
         sample(dir(), HMC(0.01, 1; adtype=AutoZygote()), 1000)
-        sample(dir(), HMC(0.01, 1; adtype=AutoReverseDiff(false)), 1000)
-        sample(dir(), HMC(0.01, 1; adtype=AutoReverseDiff(true)), 1000)
+        sample(dir(), HMC(0.01, 1; adtype=AutoReverseDiff(; compile=false)), 1000)
+        sample(dir(), HMC(0.01, 1; adtype=AutoReverseDiff(; compile=true)), 1000)
     end
     @testset "PDMatDistribution AD" begin
         @model function wishart()
             return theta ~ Wishart(4, Matrix{Float64}(I, 4, 4))
         end
 
-        sample(wishart(), HMC(0.01, 1; adtype=AutoReverseDiff(false)), 1000)
+        sample(wishart(), HMC(0.01, 1; adtype=AutoReverseDiff(; compile=false)), 1000)
         sample(wishart(), HMC(0.01, 1; adtype=AutoZygote()), 1000)
 
         @model function invwishart()
             return theta ~ InverseWishart(4, Matrix{Float64}(I, 4, 4))
         end
 
-        sample(invwishart(), HMC(0.01, 1; adtype=AutoReverseDiff(false)), 1000)
+        sample(invwishart(), HMC(0.01, 1; adtype=AutoReverseDiff(; compile=false)), 1000)
         sample(invwishart(), HMC(0.01, 1; adtype=AutoZygote()), 1000)
     end
     @testset "Hessian test" begin
@@ -231,7 +231,9 @@ end
         for i in 1:5
             d = Normal(0.0, i)
             data = rand(d, N)
-            chn = sample(demo(data), NUTS(0.65; adtype=AutoReverseDiff(true)), 1000)
+            chn = sample(
+                demo(data), NUTS(0.65; adtype=AutoReverseDiff(; compile=true)), 1000
+            )
             @test mean(Array(chn[:sigma])) ≈ std(data) atol = 0.5
         end
     end

--- a/test/mcmc/Inference.jl
+++ b/test/mcmc/Inference.jl
@@ -14,7 +14,7 @@ import ReverseDiff
 using Test: @test, @test_throws, @testset
 using Turing
 
-@testset "Testing inference.jl with $adbackend" for adbackend in (AutoForwardDiff(; chunksize=0), AutoReverseDiff(false))
+@testset "Testing inference.jl with $adbackend" for adbackend in (AutoForwardDiff(; chunksize=0), AutoReverseDiff(; compile=false))
     # Only test threading if 1.3+.
     if VERSION > v"1.2"
         @testset "threaded sampling" begin

--- a/test/mcmc/gibbs.jl
+++ b/test/mcmc/gibbs.jl
@@ -13,7 +13,7 @@ using Turing: Inference
 using Turing.RandomMeasures: ChineseRestaurantProcess, DirichletProcess
 
 @testset "Testing gibbs.jl with $adbackend" for adbackend in (
-    AutoForwardDiff(; chunksize=0), AutoReverseDiff(false)
+    AutoForwardDiff(; chunksize=0), AutoReverseDiff(; compile=false)
 )
     @testset "gibbs constructor" begin
         N = 500

--- a/test/mcmc/gibbs_conditional.jl
+++ b/test/mcmc/gibbs_conditional.jl
@@ -15,7 +15,7 @@ using Test: @test, @testset
 using Turing
 
 @testset "Testing gibbs conditionals.jl with $adbackend" for adbackend in (
-    AutoForwardDiff(; chunksize=0), AutoReverseDiff(false)
+    AutoForwardDiff(; chunksize=0), AutoReverseDiff(; compile=false)
 )
     Random.seed!(1000)
     rng = StableRNG(123)

--- a/test/mcmc/hmc.jl
+++ b/test/mcmc/hmc.jl
@@ -16,7 +16,7 @@ using StatsFuns: logistic
 using Test: @test, @test_logs, @testset
 using Turing
 
-@testset "Testing hmc.jl with $adbackend" for adbackend in (AutoForwardDiff(; chunksize=0), AutoReverseDiff(false))
+@testset "Testing hmc.jl with $adbackend" for adbackend in (AutoForwardDiff(; chunksize=0), AutoReverseDiff(; compile=false))
     # Set a seed
     rng = StableRNG(123)
     @testset "constrained bounded" begin

--- a/test/mcmc/sghmc.jl
+++ b/test/mcmc/sghmc.jl
@@ -10,7 +10,7 @@ using StableRNGs: StableRNG
 using Test: @test, @testset
 using Turing
 
-@testset "Testing sghmc.jl with $adbackend" for adbackend in (AutoForwardDiff(; chunksize=0), AutoReverseDiff(false))
+@testset "Testing sghmc.jl with $adbackend" for adbackend in (AutoForwardDiff(; chunksize=0), AutoReverseDiff(; compile=false))
     @testset "sghmc constructor" begin
         alg = SGHMC(; learning_rate=0.01, momentum_decay=0.1, adtype=adbackend)
         @test alg isa SGHMC
@@ -36,7 +36,7 @@ using Turing
     end
 end
 
-@testset "Testing sgld.jl with $adbackend" for adbackend in (AutoForwardDiff(; chunksize=0), AutoReverseDiff(false))
+@testset "Testing sgld.jl with $adbackend" for adbackend in (AutoForwardDiff(; chunksize=0), AutoReverseDiff(; compile=false))
     @testset "sgld constructor" begin
         alg = SGLD(; stepsize=PolynomialStepsize(0.25), adtype=adbackend)
         @test alg isa SGLD


### PR DESCRIPTION
ADTypes v1.5 changes the AutoReverseDiff constructor (https://github.com/SciML/ADTypes.jl/issues/65), which is causing our CI to fail. This PR starts using the new style constructor. The new style was valid before too, so we remain compatible with older ADTypes versions.