### PR TITLE
Check that the correct AD backend is being used

### DIFF
--- a/test/mcmc/hmc.jl
+++ b/test/mcmc/hmc.jl
@@ -1,6 +1,7 @@
 module HMCTests
 
 using ..Models: gdemo_default
+using ..ADUtils: ADTypeCheckContext
 #using ..Models: gdemo
 using ..NumericalTests: check_gdemo, check_numerical
 using Distributions: Bernoulli, Beta, Categorical, Dirichlet, Normal, Wishart, sample
@@ -320,6 +321,15 @@ using Turing
         # The discrepancies in the chains are in the tails, so we can't just compare the mean, etc.
         # KS will compare the empirical CDFs, which seems like a reasonable thing to do here.
         @test pvalue(ApproximateTwoSampleKSTest(vec(results), vec(results_prior))) > 0.001
+    end
+
+    @testset "Check ADType" begin
+        alg = HMC(0.1, 10; adtype=adbackend)
+        m = DynamicPPL.contextualize(
+            gdemo_default, ADTypeCheckContext(adbackend, gdemo_default.context)
+        )
+        # These will error if the adbackend being used is not the one set.
+        sample(rng, m, alg, 10)
     end
 end
 

--- a/test/optimisation/Optimisation.jl
+++ b/test/optimisation/Optimisation.jl
@@ -623,6 +623,7 @@ using Turing
             m = DynamicPPL.contextualize(
                 gdemo_default, ADTypeCheckContext(adbackend, gdemo_default.context)
             )
+            # These will error if the adbackend being used is not the one set.
             maximum_likelihood(m; adtype=adbackend)
             maximum_a_posteriori(m; adtype=adbackend)
         end

--- a/test/optimisation/Optimisation.jl
+++ b/test/optimisation/Optimisation.jl
@@ -1,6 +1,7 @@
 module OptimisationTests
 
 using ..Models: gdemo, gdemo_default
+using ..ADUtils: ADTypeCheckContext
 using Distributions
 using Distributions.FillArrays: Zeros
 using DynamicPPL: DynamicPPL
@@ -140,7 +141,6 @@ using Turing
                 gdemo_default, OptimizationOptimJL.LBFGS(); initial_params=true_value
             )
             m3 = maximum_likelihood(gdemo_default, OptimizationOptimJL.Newton())
-            # TODO(mhauru) How can we check that the adtype is actually AutoReverseDiff?
             m4 = maximum_likelihood(
                 gdemo_default, OptimizationOptimJL.BFGS(); adtype=AutoReverseDiff()
             )
@@ -615,6 +615,17 @@ using Turing
         @assert get_b[:b] == get_ab[:b]
         @assert vcat(get_a[:a], get_b[:b]) == result.values.array
         @assert get(result, :c) == (; :c => Array{Float64}[])
+    end
+
+    @testset "ADType" begin
+        Random.seed!(222)
+        for adbackend in (AutoReverseDiff(), AutoForwardDiff(), AutoTracker())
+            m = DynamicPPL.contextualize(
+                gdemo_default, ADTypeCheckContext(adbackend, gdemo_default.context)
+            )
+            maximum_likelihood(m; adtype=adbackend)
+            maximum_a_posteriori(m; adtype=adbackend)
+        end
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ import Turing
 
 include(pkgdir(Turing) * "/test/test_utils/models.jl")
 include(pkgdir(Turing) * "/test/test_utils/numerical_tests.jl")
+include(pkgdir(Turing) * "/test/test_utils/ad_utils.jl")
 
 Turing.setprogress!(false)
 

--- a/test/test_utils/ad_utils.jl
+++ b/test/test_utils/ad_utils.jl
@@ -96,7 +96,7 @@ end
 """
     valid_eltypes(context::ADTypeCheckContext)
 
-Return the element types that are valid for the ADType of `context`.
+Return the element types that are valid for the ADType of `context` as a tuple.
 """
 function valid_eltypes(context::ADTypeCheckContext)
     context_at = adtype(context)
@@ -116,7 +116,7 @@ Check that the element types in `vi` are compatible with the ADType of `context`
 
 Throw an `IncompatibleADTypeError` if an incompatible element type is encountered.
 """
-function check_adtype(context::ADTypeCheckContext, vi::DynamicPPL.VarInfo)
+function check_adtype(context::ADTypeCheckContext, vi::DynamicPPL.AbstractVarInfo)
     valids = valid_eltypes(context)
     for val in vi[:]
         valtype = typeof(val)
@@ -182,6 +182,14 @@ end
 function DynamicPPL.dot_tilde_observe(context::ADTypeCheckContext, right, left, vi)
     logp, vi = DynamicPPL.dot_tilde_observe(
         DynamicPPL.childcontext(context), right, left, vi
+    )
+    check_adtype(context, vi)
+    return logp, vi
+end
+
+function DynamicPPL.dot_tilde_observe(context::ADTypeCheckContext, sampler, right, left, vi)
+    logp, vi = DynamicPPL.dot_tilde_observe(
+        DynamicPPL.childcontext(context), sampler, right, left, vi
     )
     check_adtype(context, vi)
     return logp, vi

--- a/test/test_utils/ad_utils.jl
+++ b/test/test_utils/ad_utils.jl
@@ -1,0 +1,205 @@
+module ADUtils
+
+import ForwardDiff
+import ReverseDiff
+import Test
+import Tracker
+import Turing
+import Turing: DynamicPPL
+import Zygote
+
+export ADTypeCheckContext
+
+"""Element types that are always valid for a VarInfo regardless of ADType."""
+const always_valid_eltypes = (AbstractFloat, AbstractIrrational, Integer, Rational)
+
+"""A dictionary mapping ADTypes to the element types they use."""
+const eltypes_by_adtype = Dict(
+    Turing.AutoForwardDiff => (ForwardDiff.Dual,),
+    Turing.AutoReverseDiff => (
+        ReverseDiff.TrackedArray,
+        ReverseDiff.TrackedMatrix,
+        ReverseDiff.TrackedReal,
+        ReverseDiff.TrackedStyle,
+        ReverseDiff.TrackedType,
+        ReverseDiff.TrackedVecOrMat,
+        ReverseDiff.TrackedVector,
+    ),
+    # TODO(mhauru) Zygote.Dual is actually the same as ForwardDiff.Dual, so can't
+    # distinguish between the two.
+    Turing.AutoZygote => (Zygote.Dual,),
+    Turing.AutoTracker => (
+        Tracker.Tracked,
+        Tracker.TrackedArray,
+        Tracker.TrackedMatrix,
+        Tracker.TrackedReal,
+        Tracker.TrackedStyle,
+        Tracker.TrackedVecOrMat,
+        Tracker.TrackedVector,
+    ),
+)
+
+"""
+    IncompatibleADTypeError
+
+An error thrown when an element type is encountered that is unexpected for the given ADType.
+"""
+struct IncompatibleADTypeError <: Exception
+    valtype::Type
+    adtype::Type
+end
+
+function Base.showerror(io::IO, e::IncompatibleADTypeError)
+    return print(
+        io,
+        "Incompatible ADType: Did not expect element of type $(e.valtype) with $(e.adtype)",
+    )
+end
+
+"""
+    ADTypeCheckContext{ADType,ChildContext}
+
+A context for checking that the expected ADType is being used.
+
+Evaluating a model with this context will check that the types of values in a `VarInfo` are
+compatible with the ADType of the context. If the check fails, an `IncompatibleADTypeError`
+is thrown.
+
+For instance, evaluating a model with
+`ADTypeCheckContext(AutoForwardDiff(), child_context)`
+would throw an error if within the model a type associated with e.g. ReverseDiff was
+encountered.
+
+As a current short-coming, this context can not distinguish between ForwardDiff and Zygote.
+"""
+struct ADTypeCheckContext{ADType,ChildContext<:DynamicPPL.AbstractContext} <:
+       DynamicPPL.AbstractContext
+    child::ChildContext
+
+    function ADTypeCheckContext(adbackend, child)
+        adtype = adbackend isa Type ? adbackend : typeof(adbackend)
+        if !any(adtype .<: keys(eltypes_by_adtype))
+            throw(ArgumentError("Unsupported ADType: $adtype"))
+        end
+        return new{adtype,typeof(child)}(child)
+    end
+end
+
+adtype(_::ADTypeCheckContext{ADType}) where {ADType} = ADType
+
+DynamicPPL.NodeTrait(::ADTypeCheckContext) = DynamicPPL.IsParent()
+DynamicPPL.childcontext(c::ADTypeCheckContext) = c.child
+function DynamicPPL.setchildcontext(c::ADTypeCheckContext, child)
+    return ADTypeCheckContext(adtype(c), child)
+end
+
+"""
+    valid_eltypes(context::ADTypeCheckContext)
+
+Return the element types that are valid for the ADType of `context`.
+"""
+function valid_eltypes(context::ADTypeCheckContext)
+    context_at = adtype(context)
+    for at in keys(eltypes_by_adtype)
+        if context_at <: at
+            return (eltypes_by_adtype[at]..., always_valid_eltypes...)
+        end
+    end
+    # This should never be reached due to the check in the inner constructor.
+    throw(ArgumentError("Unsupported ADType: $(adtype(context))"))
+end
+
+"""
+    check_adtype(context::ADTypeCheckContext, vi::DynamicPPL.VarInfo)
+
+Check that the element types in `vi` are compatible with the ADType of `context`.
+
+Throw an `IncompatibleADTypeError` if an incompatible element type is encountered.
+"""
+function check_adtype(context::ADTypeCheckContext, vi::DynamicPPL.VarInfo)
+    valids = valid_eltypes(context)
+    for val in vi[:]
+        valtype = typeof(val)
+        if !any(valtype .<: valids)
+            throw(IncompatibleADTypeError(valtype, adtype(context)))
+        end
+    end
+    return nothing
+end
+
+# A bunch of tilde_assume/tilde_observe methods that just call the same method on the child
+# context, and then call check_adtype on the result before returning the results from the
+# child context.
+
+function DynamicPPL.tilde_assume(context::ADTypeCheckContext, right, vn, vi)
+    value, logp, vi = DynamicPPL.tilde_assume(
+        DynamicPPL.childcontext(context), right, vn, vi
+    )
+    check_adtype(context, vi)
+    return value, logp, vi
+end
+
+function DynamicPPL.tilde_assume(rng, context::ADTypeCheckContext, sampler, right, vn, vi)
+    value, logp, vi = DynamicPPL.tilde_assume(
+        rng, DynamicPPL.childcontext(context), sampler, right, vn, vi
+    )
+    check_adtype(context, vi)
+    return value, logp, vi
+end
+
+function DynamicPPL.tilde_observe(context::ADTypeCheckContext, right, left, vi)
+    logp, vi = DynamicPPL.tilde_observe(DynamicPPL.childcontext(context), right, left, vi)
+    check_adtype(context, vi)
+    return logp, vi
+end
+
+function DynamicPPL.tilde_observe(context::ADTypeCheckContext, sampler, right, left, vi)
+    logp, vi = DynamicPPL.tilde_observe(
+        DynamicPPL.childcontext(context), sampler, right, left, vi
+    )
+    check_adtype(context, vi)
+    return logp, vi
+end
+
+function DynamicPPL.dot_tilde_assume(context::ADTypeCheckContext, right, left, vn, vi)
+    value, logp, vi = DynamicPPL.dot_tilde_assume(
+        DynamicPPL.childcontext(context), right, left, vn, vi
+    )
+    check_adtype(context, vi)
+    return value, logp, vi
+end
+
+function DynamicPPL.dot_tilde_assume(
+    rng, context::ADTypeCheckContext, sampler, right, left, vn, vi
+)
+    value, logp, vi = DynamicPPL.dot_tilde_assume(
+        rng, DynamicPPL.childcontext(context), sampler, right, left, vn, vi
+    )
+    check_adtype(context, vi)
+    return value, logp, vi
+end
+
+function DynamicPPL.dot_tilde_observe(context::ADTypeCheckContext, right, left, vi)
+    logp, vi = DynamicPPL.dot_tilde_observe(
+        DynamicPPL.childcontext(context), right, left, vi
+    )
+    check_adtype(context, vi)
+    return logp, vi
+end
+
+# Check that the ADTypeCheckContext works as expected.
+Test.@testset "ADTypeCheckContext" begin
+    Turing.@model test_model() = x ~ Turing.Normal(0, 1)
+    tm = test_model()
+    contextualised_tm = DynamicPPL.contextualize(
+        tm, ADTypeCheckContext(Turing.AutoForwardDiff(), tm.context)
+    )
+    # This should not throw an error since we are using ForwardDiff as expected.
+    Turing.sample(contextualised_tm, Turing.NUTS(; adtype=Turing.AutoForwardDiff()), 100)
+    # Using ReverseDiff when ForwardDiff is expected should throw an error.
+    Test.@test_throws IncompatibleADTypeError Turing.sample(
+        contextualised_tm, Turing.NUTS(; adtype=Turing.AutoReverseDiff()), 100
+    )
+end
+
+end

--- a/test/test_utils/ad_utils.jl
+++ b/test/test_utils/ad_utils.jl
@@ -1,12 +1,12 @@
 module ADUtils
 
-import ForwardDiff
-import ReverseDiff
-import Test
-import Tracker
-import Turing
-import Turing: DynamicPPL
-import Zygote
+using ForwardDiff: ForwardDiff
+using ReverseDiff: ReverseDiff
+using Test: Test
+using Tracker: Tracker
+using Turing: Turing
+using Turing: DynamicPPL
+using Zygote: Zygote
 
 export ADTypeCheckContext
 


### PR DESCRIPTION
Introduces tests that check that the ADType we specify is actually the one being used. This alleviates my worry that we might mess up passing the ADType around and accidentally fall back on the default.

I've added tests for calling `sample` and `maximum_likelihood/maximum_a_posteriori`. Any other user-facing functions we should check to make sure they, too, use their `adtype` arguments correctly?

Closes #2235