### PR TITLE
Resolve ADTypeCheckContext method ambiguity

### DIFF
--- a/test/test_utils/ad_utils.jl
+++ b/test/test_utils/ad_utils.jl
@@ -1,6 +1,7 @@
 module ADUtils
 
 using ForwardDiff: ForwardDiff
+using Random: Random
 using ReverseDiff: ReverseDiff
 using Test: Test
 using Tracker: Tracker
@@ -174,7 +175,9 @@ function DynamicPPL.tilde_assume(context::ADTypeCheckContext, right, vn, vi)
     return value, logp, vi
 end
 
-function DynamicPPL.tilde_assume(rng, context::ADTypeCheckContext, sampler, right, vn, vi)
+function DynamicPPL.tilde_assume(
+    rng::Random.AbstractRNG, context::ADTypeCheckContext, sampler, right, vn, vi
+)
     value, logp, vi = DynamicPPL.tilde_assume(
         rng, DynamicPPL.childcontext(context), sampler, right, vn, vi
     )
@@ -205,7 +208,7 @@ function DynamicPPL.dot_tilde_assume(context::ADTypeCheckContext, right, left, v
 end
 
 function DynamicPPL.dot_tilde_assume(
-    rng, context::ADTypeCheckContext, sampler, right, left, vn, vi
+    rng::Random.AbstractRNG, context::ADTypeCheckContext, sampler, right, left, vn, vi
 )
     value, logp, vi = DynamicPPL.dot_tilde_assume(
         rng, DynamicPPL.childcontext(context), sampler, right, left, vn, vi


### PR DESCRIPTION
Should fix the issue in https://github.com/TuringLang/DynamicPPL.jl/pull/638. I'm a bit bothered by way the method ambiguity did not come up in Turing's own CI, but only in DPPL's. Also, I _think_ this will fix the issue, but might need to run DPPL's tests to see.