### PR TITLE
Bump patch

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Turing"
 uuid = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-version = "0.34.0"
+version = "0.34.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
I've just realised that we didn't bump the patch version when the Tapir.jl compatibility stuff was merged, meaning that we can't tag a release.

If there's not a reason for that, can we please merge this and tag a release?