### PR TITLE
Remove redundant code in `hmc.jl`

### DIFF
--- a/src/mcmc/hmc.jl
+++ b/src/mcmc/hmc.jl
@@ -17,16 +17,6 @@ struct HMCState{
     adaptor::TAdapt
 end
 
-##########################
-# Hamiltonian Transition #
-##########################
-
-function Transition(model::DynamicPPL.Model, vi::AbstractVarInfo, t::AHMC.Transition)
-    theta = getparams(model, vi)
-    lp = getlogp(vi)
-    return Transition(theta, lp, t.stat)
-end
-
 ###
 ### Hamiltonian Monte Carlo samplers.
 ###


### PR DESCRIPTION
The removed lines should be covered by the combination of 

https://github.com/TuringLang/Turing.jl/blob/b3a13a158126ee88b8ad4f4b17e20263b33dd730/src/mcmc/abstractmcmc.jl#L38-L39 and https://github.com/TuringLang/Turing.jl/blob/b3a13a158126ee88b8ad4f4b17e20263b33dd730/src/mcmc/Inference.jl#L225-L230