### PR TITLE
Disable Tapir on Julia 1.11

### DIFF
--- a/src/essential/Essential.jl
+++ b/src/essential/Essential.jl
@@ -26,8 +26,8 @@ export @model,
     @logprob_str,
     @prob_str
 
-# AutoTapir is only supported by ADTypes v1.0 and above.
-@static if VERSION >= v"1.10" && pkgversion(ADTypes) >= v"1"
+# AutoTapir is only supported on Julia 1.10 and by ADTypes v1.0 and above.
+@static if (v"1.10" <= VERSION < v"1.11") && pkgversion(ADTypes) >= v"1"
     using ADTypes: AutoTapir
     export AutoTapir
 end

--- a/test/test_utils/ad_utils.jl
+++ b/test/test_utils/ad_utils.jl
@@ -284,7 +284,7 @@ adbackends = [
     Turing.AutoForwardDiff(; chunksize=0), Turing.AutoReverseDiff(; compile=false)
 ]
 
-# Tapir isn't supported for older Julia versions, hence the check.
+# Tapir isn't supported for older Julia versions or for 1.11, hence the check.
 install_tapir = isdefined(Turing, :AutoTapir)
 if install_tapir
     # TODO(mhauru) Is there a better way to install optional dependencies like this?


### PR DESCRIPTION
Tapir doesn't work with Julia 1.11. In fact, it will _never_ work with 1.11, since the package has been renamed (unless Mooncake updates are backported to Tapir). This PR disables Tapir as an AD backend on Julia 1.11.