### PR TITLE
Change GHA macOS architecture to aarch64

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -59,7 +59,7 @@ jobs:
           # macOS
           - version: '1'
             os: macos-latest
-            arch: x64
+            arch: aarch64
             num_threads: 1
           # Minimum supported Julia version
           - version: 'min'


### PR DESCRIPTION
A few months ago (I think) GitHub updated their `macos-latest` runners to use Apple Silicon.

Since then, we've apparently been testing x64 Julia on an ARM runner which basically runs Julia via Rosetta emulation.

cf. https://github.com/JuliaLang/www.julialang.org/pull/2196 https://github.com/JuliaLang/julia/issues/55878