### PR TITLE
Add PR auto assign workflow

### DIFF
--- a/.github/workflows/PRAssign.yml
+++ b/.github/workflows/PRAssign.yml
@@ -1,0 +1,15 @@
+name: Automatically assign PR authors
+
+on:
+  pull_request:
+    types:
+      - opened
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: TuringLang/actions/PRAssign@main


### PR DESCRIPTION
As discussed in meeting of 7 April - this workflow makes PR authors also assignees.