### PR TITLE
Refactor HMC initialisation code

### DIFF
--- a/src/mcmc/hmc.jl
+++ b/src/mcmc/hmc.jl
@@ -138,6 +138,36 @@ function AbstractMCMC.sample(
     end
 end
 
+function find_initial_params(
+    rng::Random.AbstractRNG,
+    model::DynamicPPL.Model,
+    varinfo::DynamicPPL.AbstractVarInfo,
+    hamiltonian::AHMC.Hamiltonian;
+    max_attempts::Int=1000,
+)
+    varinfo = deepcopy(varinfo)  # Don't mutate
+
+    for attempts in 1:max_attempts
+        theta = varinfo[:]
+        z = AHMC.phasepoint(rng, theta, hamiltonian)
+        isfinite(z) && return varinfo, z
+
+        attempts == 10 &&
+            @warn "failed to find valid initial parameters in $(attempts) tries; consider providing explicit initial parameters using the `initial_params` keyword"
+
+        # Resample and try again.
+        # NOTE: varinfo has to be linked to make sure this samples in unconstrained space
+        varinfo = last(
+            DynamicPPL.evaluate!!(model, rng, varinfo, DynamicPPL.SampleFromUniform())
+        )
+    end
+
+    # if we failed to find valid initial parameters, error
+    return error(
+        "failed to find valid initial parameters in $(max_attempts) tries. This may indicate an error with the model or AD backend; please open an issue at https://github.com/TuringLang/Turing.jl/issues",
+    )
+end
+
 function DynamicPPL.initialstep(
     rng::AbstractRNG,
     model::AbstractModel,
@@ -170,33 +200,14 @@ function DynamicPPL.initialstep(
     lp_grad_func = Base.Fix1(LogDensityProblems.logdensity_and_gradient, ldf)
     hamiltonian = AHMC.Hamiltonian(metric, lp_func, lp_grad_func)
 
-    # Compute phase point z.
-    z = AHMC.phasepoint(rng, theta, hamiltonian)
-
     # If no initial parameters are provided, resample until the log probability
-    # and its gradient are finite.
-    if initial_params === nothing
-        init_attempt_count = 1
-        while !isfinite(z)
-            if init_attempt_count == 10
-                @warn "failed to find valid initial parameters in $(init_attempt_count) tries; consider providing explicit initial parameters using the `initial_params` keyword"
-            end
-            if init_attempt_count == 1000
-                error(
-                    "failed to find valid initial parameters in $(init_attempt_count) tries. This may indicate an error with the model or AD backend; please open an issue at https://github.com/TuringLang/Turing.jl/issues",
-                )
-            end
-
-            # NOTE: This will sample in the unconstrained space.
-            vi = last(DynamicPPL.evaluate!!(model, rng, vi, SampleFromUniform()))
-            theta = vi[:]
-
-            hamiltonian = AHMC.Hamiltonian(metric, lp_func, lp_grad_func)
-            z = AHMC.phasepoint(rng, theta, hamiltonian)
-
-            init_attempt_count += 1
-        end
+    # and its gradient are finite. Otherwise, just use the existing parameters.
+    vi, z = if initial_params === nothing
+        find_initial_params(rng, model, vi, hamiltonian)
+    else
+        vi, AHMC.phasepoint(rng, theta, hamiltonian)
     end
+    theta = vi[:]
 
     # Cache current log density.
     log_density_old = getlogp(vi)


### PR DESCRIPTION
I'm really wary of #2566 becoming very big, so I'm trying to break off smaller bits.

This is a really basic bit of refactoring that I think just makes things easier to read.

Anyway, I've tested before and after with

```julia
using Turing, Random
@model f() = x ~ Normal()
sample(Xoshiro(468), f(), NUTS(), 1000)
```

and the exact numerical result is unchanged, so I'm pretty sure that there isn't actually any code change — hence the lack of a version bump.

```
┌ Info: Found initial step size
└   ϵ = 3.2
Sampling 100%|██████████████████████████████████████████████████████████████████| Time: 0:00:03
Chains MCMC chain (1000×13×1 Array{Float64, 3}):

Iterations        = 501:1:1500
Number of chains  = 1
Samples per chain = 1000
Wall duration     = 4.59 seconds
Compute duration  = 4.59 seconds
parameters        = x
internals         = lp, n_steps, is_accept, acceptance_rate, log_density, hamiltonian_energy, hamiltonian_energy_error, max_hamiltonian_energy_error, tree_depth, numerical_error, step_size, nom_step_size

Summary Statistics
  parameters      mean       std      mcse   ess_bulk   ess_tail      rhat   ess_per_sec
      Symbol   Float64   Float64   Float64    Float64    Float64   Float64       Float64

           x   -0.0338    0.9883    0.0494   396.8876   699.6500    1.0029       86.5433

Quantiles
  parameters      2.5%     25.0%     50.0%     75.0%     97.5%
      Symbol   Float64   Float64   Float64   Float64   Float64

           x   -1.9956   -0.6683   -0.0578    0.6140    1.9267
```