### PR TITLE
Bump tag for GHA

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# Release 0.39.1
+
+No changes from 0.39.0 — this patch is released just to re-trigger a Documenter.jl run.
+
 # Release 0.39.0
 
 ## Update to the AdvancedVI interface

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Turing"
 uuid = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-version = "0.39.0"
+version = "0.39.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
Documenter failed to run on 0.39.0 because GitHub had an outage. There's no easy way to retroactively fix this (believe me - I tried - you'd basically have to run deploydocs locally and I don't want to do that) so we're just going to release a no-op patch so that it can run again.