### PR TITLE
Set minimum of OrderedLogistic distribution to 1

### DIFF
--- a/src/stdlib/distributions.jl
+++ b/src/stdlib/distributions.jl
@@ -126,7 +126,7 @@ function OrderedLogistic(η, cutpoints::AbstractVector)
     return OrderedLogistic{typeof(η),typeof(cutpoints)}(η, cutpoints)
 end
 
-Base.minimum(d::OrderedLogistic) = 0
+Base.minimum(d::OrderedLogistic) = 1
 Base.maximum(d::OrderedLogistic) = length(d.cutpoints) + 1
 
 function Distributions.logpdf(d::OrderedLogistic, k::Real)


### PR DESCRIPTION
The minimum of the OrderedLogistic distribution is supposed to be 1, not 0. This is consistent with the documentation, and the behavior of the distribution when using rand().

Fixes bug #2602 