### PR TITLE
Update logp in varinfo when external samplers are used

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,8 @@
 # 0.39.5
 
-Fixed a bug where sampling with an `externalsampler` would not correctly set the log probability density inside the resulting chain.
+Fixed a bug where sampling with an `externalsampler` would not set the log probability density inside the resulting chain.
+Note that there are still potentially bugs with the log-Jacobian term not being correctly included.
+A fix is being worked on.
 
 # 0.39.4
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 0.39.5
+
+Fixed a bug where sampling with an `externalsampler` would not correctly set the log probability density inside the resulting chain.
+
 # 0.39.4
 
 Bumped compatibility of AbstractPPL to include 0.12.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Turing"
 uuid = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-version = "0.39.4"
+version = "0.39.5"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/mcmc/external_sampler.jl
+++ b/src/mcmc/external_sampler.jl
@@ -19,7 +19,7 @@ In particular, it must implement:
 
 There are a few more optional functions which you can implement to improve the integration with Turing.jl:
 
-- `Turing.Inference.isgibbscomponent(::MySampler)`: If you want your sampler to function as a component in Turing's Gibbs sampler, you should make this to `true`.
+- `Turing.Inference.isgibbscomponent(::MySampler)`: If you want your sampler to function as a component in Turing's Gibbs sampler, you should make this evaluate to `true`.
 
 - `Turing.Inference.requires_unconstrained_space(::MySampler)`: If your sampler requires unconstrained space, you should return `true`. This tells Turing to perform linking on the VarInfo before evaluation, and ensures that the parameter values passed to your sampler will always be in unconstrained (Euclidean) space.
 

--- a/src/mcmc/gibbs.jl
+++ b/src/mcmc/gibbs.jl
@@ -20,6 +20,7 @@ isgibbscomponent(spl::RepeatSampler) = isgibbscomponent(spl.sampler)
 isgibbscomponent(spl::ExternalSampler) = isgibbscomponent(spl.sampler)
 isgibbscomponent(::AdvancedHMC.HMC) = true
 isgibbscomponent(::AdvancedMH.MetropolisHastings) = true
+isgibbscomponent(spl) = false
 
 function can_be_wrapped(ctx::DynamicPPL.AbstractContext)
     return DynamicPPL.NodeTrait(ctx) isa DynamicPPL.IsLeaf

--- a/src/mcmc/gibbs.jl
+++ b/src/mcmc/gibbs.jl
@@ -18,7 +18,7 @@ isgibbscomponent(::PG) = true
 isgibbscomponent(spl::RepeatSampler) = isgibbscomponent(spl.sampler)
 
 isgibbscomponent(spl::ExternalSampler) = isgibbscomponent(spl.sampler)
-isgibbscomponent(::AdvancedHMC.HMC) = true
+isgibbscomponent(::AdvancedHMC.AbstractHMCSampler) = true
 isgibbscomponent(::AdvancedMH.MetropolisHastings) = true
 isgibbscomponent(spl) = false
 
@@ -562,7 +562,7 @@ function setparams_varinfo!!(
     new_inner_state = setparams_varinfo!!(
         AbstractMCMC.LogDensityModel(logdensity), sampler, state.state, params
     )
-    return TuringState(new_inner_state, logdensity)
+    return TuringState(new_inner_state, params, logdensity)
 end
 
 function setparams_varinfo!!(

--- a/test/mcmc/external_sampler.jl
+++ b/test/mcmc/external_sampler.jl
@@ -168,6 +168,7 @@ end
                 end
             end
         end
+
         # NOTE: Broken because MH doesn't really follow the `logdensity` interface, but calls
         # it with `NamedTuple` instead of `AbstractVector`.
         # @testset "MH with prior proposal" begin

--- a/test/mcmc/external_sampler.jl
+++ b/test/mcmc/external_sampler.jl
@@ -56,6 +56,14 @@ function initialize_mh_rw(model)
     return AdvancedMH.RWMH(MvNormal(Zeros(d), 0.1 * I))
 end
 
+function check_logp_correct(sampler)
+    @testset "logp is set correctly" begin
+        @model logp_check() = x ~ Normal()
+        chn = sample(logp_check(), Gibbs(@varname(x) => sampler), 100)
+        @test logpdf.(Normal(), chn[:x]) == chn[:lp]
+    end
+end
+
 # TODO: Should this go somewhere else?
 # Convert a model into a `Distribution` to allow usage as a proposal in AdvancedMH.jl.
 struct ModelDistribution{M<:DynamicPPL.Model,V<:DynamicPPL.VarInfo} <:
@@ -140,6 +148,8 @@ end
                     sample_kwargs...,
                 )
             end
+
+            check_logp_correct(sampler_ext)
         end
     end
 
@@ -166,6 +176,7 @@ end
                         sampler_name="AdvancedMH",
                     )
                 end
+                check_logp_correct(sampler_ext)
             end
         end
 

--- a/test/mcmc/external_sampler.jl
+++ b/test/mcmc/external_sampler.jl
@@ -60,7 +60,7 @@ function check_logp_correct(sampler)
     @testset "logp is set correctly" begin
         @model logp_check() = x ~ Normal()
         chn = sample(logp_check(), Gibbs(@varname(x) => sampler), 100)
-        @test logpdf.(Normal(), chn[:x]) == chn[:lp]
+        @test isapprox(logpdf.(Normal(), chn[:x]), chn[:lp])
     end
 end
 
@@ -148,9 +148,9 @@ end
                     sample_kwargs...,
                 )
             end
-
-            check_logp_correct(sampler_ext)
         end
+
+        check_logp_correct(sampler_ext)
     end
 
     @testset "AdvancedMH.jl" begin
@@ -176,8 +176,9 @@ end
                         sampler_name="AdvancedMH",
                     )
                 end
-                check_logp_correct(sampler_ext)
             end
+
+            check_logp_correct(sampler_ext)
         end
 
         # NOTE: Broken because MH doesn't really follow the `logdensity` interface, but calls

--- a/test/mcmc/gibbs.jl
+++ b/test/mcmc/gibbs.jl
@@ -829,7 +829,7 @@ end
             @testset "logp is set correctly" begin
                 @model logp_check() = x ~ Normal()
                 chn = sample(logp_check(), Gibbs(@varname(x) => sampler), 100)
-                @test logpdf.(Normal(), chn[:x]) == chn[:lp]
+                @test isapprox(logpdf.(Normal(), chn[:x]), chn[:lp])
             end
         end
 

--- a/test/mcmc/gibbs.jl
+++ b/test/mcmc/gibbs.jl
@@ -825,6 +825,14 @@ end
     end
 
     @testset "externalsampler" begin
+        function check_logp_correct(sampler)
+            @testset "logp is set correctly" begin
+                @model f() = x ~ Normal()
+                chn = sample(f(), Gibbs(@varname(x) => sampler), 100)
+                @test logpdf.(Normal(), chn[:x]) == chn[:lp]
+            end
+        end
+
         @model function demo_gibbs_external()
             m1 ~ Normal()
             m2 ~ Normal()
@@ -851,6 +859,7 @@ end
                 model, sampler, 1000; discard_initial=1000, thinning=10, n_adapts=0
             )
             check_numerical(chain, [:m1, :m2], [-0.2, 0.6]; atol=0.1)
+            check_logp_correct(sampler_inner)
         end
     end
 

--- a/test/mcmc/gibbs.jl
+++ b/test/mcmc/gibbs.jl
@@ -827,8 +827,8 @@ end
     @testset "externalsampler" begin
         function check_logp_correct(sampler)
             @testset "logp is set correctly" begin
-                @model f() = x ~ Normal()
-                chn = sample(f(), Gibbs(@varname(x) => sampler), 100)
+                @model logp_check() = x ~ Normal()
+                chn = sample(logp_check(), Gibbs(@varname(x) => sampler), 100)
                 @test logpdf.(Normal(), chn[:x]) == chn[:lp]
             end
         end


### PR DESCRIPTION
Closes #2583, where the logp from `externalsampler` was not being correctly set in `varinfo` and hence the chain.

Plots shown below:  
Before = logp was never updated, so logp is just a flat line.  
After = logp changes with the parameters.

These were run using AdvancedMH. I've tested with AdvancedHMC and SliceSampling (cf. https://github.com/TuringLang/SliceSampling.jl/issues/15) and similar improvements are observed.

```julia
using Turing, Plots, AdvancedMH

@model function test_model(y)
    a ~ Normal(0, 1)
    y ~ Normal(a, 1)
end

y = rand(Normal(0.5, 1), 100)
model = test_model(y)

chain_1 = sample(model, externalsampler(AdvancedMH.RWMH(1)), 100);

plot(chain_1, [:a, :lp], seriestype = :traceplot)
```

## Before

<img width="493" height="481" alt="Screenshot 2025-07-14 at 15 39 09" src="https://github.com/user-attachments/assets/b0c47a8b-41f6-4c07-9b9d-95b91e109a8f" />


## After

<img width="495" height="489" alt="Screenshot 2025-07-14 at 15 39 48" src="https://github.com/user-attachments/assets/94ea468e-997f-43c6-95df-ea74b795b76d" />
