### PR TITLE
Fix missing closing parenthesis in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## 🚀 Get started
 
-Install Julia (see [the official Julia website](https://julialang.org/install/); you will need at least Julia 1.10 will be required for the latest version of Turing.jl.
+Install Julia (see [the official Julia website](https://julialang.org/install/); you will need at least Julia 1.10 will be required for the latest version of Turing.jl).
 Then, launch a Julia REPL and run:
 
 ```julia


### PR DESCRIPTION
## Summary
• Fixed a missing closing parenthesis in the README.md installation instructions

## Test plan
• Verified the markdown syntax is now correct
• No functional changes, only documentation formatting fix

🤖 Generated with [Claude Code](https://claude.ai/code)