### PR TITLE
"Fixes" for PG-in-Gibbs

### DIFF
--- a/src/mcmc/particle_mcmc.jl
+++ b/src/mcmc/particle_mcmc.jl
@@ -580,3 +580,97 @@ function Libtask.might_produce(
     return true
 end
 Libtask.might_produce(::Type{<:Tuple{<:DynamicPPL.Model,Vararg}}) = true
+
+"""
+    ProduceLogLikelihoodAccumulator{T<:Real} <: AbstractAccumulator
+
+Exactly like `LogLikelihoodAccumulator`, but calls `Libtask.produce` on every increase.
+
+# Fields
+$(TYPEDFIELDS)
+"""
+struct ProduceLogLikelihoodAccumulator{T<:Real} <: DynamicPPL.AbstractAccumulator
+    "the scalar log likelihood value"
+    logp::T
+end
+
+"""
+    ProduceLogLikelihoodAccumulator{T}()
+
+Create a new `ProduceLogLikelihoodAccumulator` accumulator with the log likelihood of zero.
+"""
+ProduceLogLikelihoodAccumulator{T}() where {T<:Real} =
+    ProduceLogLikelihoodAccumulator(zero(T))
+function ProduceLogLikelihoodAccumulator()
+    return ProduceLogLikelihoodAccumulator{DynamicPPL.LogProbType}()
+end
+
+Base.copy(acc::ProduceLogLikelihoodAccumulator) = acc
+
+function Base.show(io::IO, acc::ProduceLogLikelihoodAccumulator)
+    return print(io, "ProduceLogLikelihoodAccumulator($(repr(acc.logp)))")
+end
+
+function Base.:(==)(
+    acc1::ProduceLogLikelihoodAccumulator, acc2::ProduceLogLikelihoodAccumulator
+)
+    return acc1.logp == acc2.logp
+end
+
+function Base.isequal(
+    acc1::ProduceLogLikelihoodAccumulator, acc2::ProduceLogLikelihoodAccumulator
+)
+    return isequal(acc1.logp, acc2.logp)
+end
+
+function Base.hash(acc::ProduceLogLikelihoodAccumulator, h::UInt)
+    return hash((ProduceLogLikelihoodAccumulator, acc.logp), h)
+end
+
+# Note that this uses the same name as `LogLikelihoodAccumulator`. Thus only one of the two
+# can be used in a given VarInfo.
+DynamicPPL.accumulator_name(::Type{<:ProduceLogLikelihoodAccumulator}) = :LogLikelihood
+
+function DynamicPPL.split(::ProduceLogLikelihoodAccumulator{T}) where {T}
+    return ProduceLogLikelihoodAccumulator(zero(T))
+end
+
+function DynamicPPL.combine(
+    acc::ProduceLogLikelihoodAccumulator, acc2::ProduceLogLikelihoodAccumulator
+)
+    return ProduceLogLikelihoodAccumulator(acc.logp + acc2.logp)
+end
+
+function Base.:+(
+    acc1::ProduceLogLikelihoodAccumulator, acc2::DynamicPPL.LogLikelihoodAccumulator
+)
+    Libtask.produce(acc2.logp)
+    return ProduceLogLikelihoodAccumulator(acc1.logp + acc2.logp)
+end
+
+function Base.zero(acc::ProduceLogLikelihoodAccumulator)
+    return ProduceLogLikelihoodAccumulator(zero(acc.logp))
+end
+
+function DynamicPPL.accumulate_assume!!(
+    acc::ProduceLogLikelihoodAccumulator, val, logjac, vn, right
+)
+    return acc
+end
+function DynamicPPL.accumulate_observe!!(
+    acc::ProduceLogLikelihoodAccumulator, right, left, vn
+)
+    return acc +
+           DynamicPPL.LogLikelihoodAccumulator(Distributions.loglikelihood(right, left))
+end
+
+function Base.convert(
+    ::Type{ProduceLogLikelihoodAccumulator{T}}, acc::ProduceLogLikelihoodAccumulator
+) where {T}
+    return ProduceLogLikelihoodAccumulator(convert(T, acc.logp))
+end
+function DynamicPPL.convert_eltype(
+    ::Type{T}, acc::ProduceLogLikelihoodAccumulator
+) where {T}
+    return ProduceLogLikelihoodAccumulator(convert(T, acc.logp))
+end

--- a/src/mcmc/particle_mcmc.jl
+++ b/src/mcmc/particle_mcmc.jl
@@ -11,6 +11,12 @@ Set the "del" flag for all variables in the VarInfo `vi`, thus marking them for
 resampling.
 """
 function set_all_del!(vi::AbstractVarInfo)
+    # TODO(penelopeysm): Instead of being a 'del' flag on the VarInfo, we
+    # could either:
+    # - keep a boolean 'resample' flag on the trace, or
+    # - modify the model context appropriately.
+    # However, this refactoring will have to wait until InitContext is
+    # merged into DPPL.
     for vn in keys(vi)
         DynamicPPL.set_flag!(vi, vn, "del")
     end
@@ -59,13 +65,6 @@ end
 function AdvancedPS.advance!(
     trace::AdvancedPS.Trace{<:AdvancedPS.LibtaskModel{<:TracedModel}}, isref::Bool=false
 )
-    # We want to increment num produce for the VarInfo stored in the trace. The trace is
-    # mutable, so we create a new model with the incremented VarInfo and set it in the trace
-    model = trace.model
-    model = Accessors.@set model.f.varinfo = DynamicPPL.increment_num_produce!!(
-        model.f.varinfo
-    )
-    trace.model = model
     # Make sure we load/reset the rng in the new replaying mechanism
     isref ? AdvancedPS.load_state!(trace.rng) : AdvancedPS.save_state!(trace.rng)
     score = consume(trace.model.ctask)
@@ -73,23 +72,23 @@ function AdvancedPS.advance!(
 end
 
 function AdvancedPS.delete_retained!(trace::TracedModel)
-    # TODO(DPPL0.37/penelopeysm): Explain this a bit better.
-    #
     # This method is called if, during a CSMC update, we perform a resampling
     # and choose the reference particle as the trajectory to carry on from.
     # In such a case, we need to ensure that when we continue sampling (i.e.
     # the next time we hit tilde_assume), we don't use the values in the 
     # reference particle but rather sample new values.
-    # In this implementation, we indiscriminately set the 'del' flag for all
-    # variables in the VarInfo. This is slightly overkill: it is not necessary
-    # to set the 'del' flag for variables that were already sampled. However,
-    # it allows us to avoid using DynamicPPL.set_retained_vns_del!.
+    #
+    # Here, we indiscriminately set the 'del' flag for all variables in the
+    # VarInfo. This is slightly overkill: it is not necessary to set the 'del'
+    # flag for variables that were already sampled. However, it allows us to
+    # avoid keeping track of which variables were sampled, which leads to many
+    # simplifications in the VarInfo data structure.
     set_all_del!(trace.varinfo)
     return trace
 end
 
 function AdvancedPS.reset_model(trace::TracedModel)
-    return Accessors.@set trace.varinfo = DynamicPPL.reset_num_produce!!(trace.varinfo)
+    return trace
 end
 
 function Libtask.TapedTask(taped_globals, model::TracedModel; kwargs...)
@@ -213,7 +212,6 @@ function DynamicPPL.initialstep(
 )
     # Reset the VarInfo.
     vi = DynamicPPL.setacc!!(vi, ProduceLogLikelihoodAccumulator())
-    vi = DynamicPPL.reset_num_produce!!(vi)
     set_all_del!(vi)
     vi = DynamicPPL.resetlogp!!(vi)
     vi = DynamicPPL.empty!!(vi)
@@ -344,7 +342,6 @@ function DynamicPPL.initialstep(
 )
     vi = DynamicPPL.setacc!!(vi, ProduceLogLikelihoodAccumulator())
     # Reset the VarInfo before new sweep
-    vi = DynamicPPL.reset_num_produce!!(vi)
     set_all_del!(vi)
     vi = DynamicPPL.resetlogp!!(vi)
 
@@ -366,11 +363,6 @@ function DynamicPPL.initialstep(
 
     # Compute the first transition.
     _vi = reference.model.f.varinfo
-    # Unset any 'del' flags before we actually construct the transition.
-    # This is necessary because the model will be re-evaluated and we
-    # want to make sure we do use the values in the reference particle
-    # instead of resampling them.
-    unset_all_del!(_vi)
     transition = PGTransition(model, _vi, logevidence)
 
     return transition, PGState(_vi, reference.rng)
@@ -382,10 +374,10 @@ function AbstractMCMC.step(
     # Reset the VarInfo before new sweep.
     vi = state.vi
     vi = DynamicPPL.setacc!!(vi, ProduceLogLikelihoodAccumulator())
-    vi = DynamicPPL.reset_num_produce!!(vi)
     vi = DynamicPPL.resetlogp!!(vi)
 
     # Create reference particle for which the samples will be retained.
+    unset_all_del!(vi)
     reference = AdvancedPS.forkr(AdvancedPS.Trace(model, spl, vi, state.rng))
 
     # For all other particles, do not retain the variables but resample them.
@@ -412,11 +404,6 @@ function AbstractMCMC.step(
 
     # Compute the transition.
     _vi = newreference.model.f.varinfo
-    # Unset any 'del' flags before we actually construct the transition.
-    # This is necessary because the model will be re-evaluated and we
-    # want to make sure we do use the values in the reference particle
-    # instead of resampling them.
-    unset_all_del!(_vi)
     transition = PGTransition(model, _vi, logevidence)
 
     return transition, PGState(_vi, newreference.rng)
@@ -499,12 +486,11 @@ function DynamicPPL.assume(
         vi = push!!(vi, vn, r, dist)
     elseif DynamicPPL.is_flagged(vi, vn, "del")
         DynamicPPL.unset_flag!(vi, vn, "del") # Reference particle parent
-        r = rand(trng, dist)
-        vi[vn] = DynamicPPL.tovec(r)
         # TODO(mhauru):
         # The below is the only line that differs from assume called on SampleFromPrior.
-        # Could we just call assume on SampleFromPrior and then `setorder!!` after that?
-        vi = DynamicPPL.setorder!!(vi, vn, DynamicPPL.get_num_produce(vi))
+        # Could we just call assume on SampleFromPrior with a specific rng?
+        r = rand(trng, dist)
+        vi[vn] = DynamicPPL.tovec(r)
     else
         r = vi[vn]
     end
@@ -546,8 +532,6 @@ function AdvancedPS.Trace(
     rng::AdvancedPS.TracedRNG,
 )
     newvarinfo = deepcopy(varinfo)
-    newvarinfo = DynamicPPL.reset_num_produce!!(newvarinfo)
-
     tmodel = TracedModel(model, sampler, newvarinfo, rng)
     newtrace = AdvancedPS.Trace(tmodel, rng)
     return newtrace

--- a/src/mcmc/particle_mcmc.jl
+++ b/src/mcmc/particle_mcmc.jl
@@ -545,67 +545,20 @@ Exactly like `LogLikelihoodAccumulator`, but calls `Libtask.produce` on change o
 # Fields
 $(TYPEDFIELDS)
 """
-struct ProduceLogLikelihoodAccumulator{T<:Real} <: DynamicPPL.AbstractAccumulator
+struct ProduceLogLikelihoodAccumulator{T<:Real} <: DynamicPPL.LogProbAccumulator{T}
     "the scalar log likelihood value"
     logp::T
-end
-
-"""
-    ProduceLogLikelihoodAccumulator{T}()
-
-Create a new `ProduceLogLikelihoodAccumulator` accumulator with the log likelihood of zero.
-"""
-ProduceLogLikelihoodAccumulator{T}() where {T<:Real} =
-    ProduceLogLikelihoodAccumulator(zero(T))
-function ProduceLogLikelihoodAccumulator()
-    return ProduceLogLikelihoodAccumulator{DynamicPPL.LogProbType}()
-end
-
-Base.copy(acc::ProduceLogLikelihoodAccumulator) = acc
-
-function Base.show(io::IO, acc::ProduceLogLikelihoodAccumulator)
-    return print(io, "ProduceLogLikelihoodAccumulator($(repr(acc.logp)))")
-end
-
-function Base.:(==)(
-    acc1::ProduceLogLikelihoodAccumulator, acc2::ProduceLogLikelihoodAccumulator
-)
-    return acc1.logp == acc2.logp
-end
-
-function Base.isequal(
-    acc1::ProduceLogLikelihoodAccumulator, acc2::ProduceLogLikelihoodAccumulator
-)
-    return isequal(acc1.logp, acc2.logp)
-end
-
-function Base.hash(acc::ProduceLogLikelihoodAccumulator, h::UInt)
-    return hash((ProduceLogLikelihoodAccumulator, acc.logp), h)
 end
 
 # Note that this uses the same name as `LogLikelihoodAccumulator`. Thus only one of the two
 # can be used in a given VarInfo.
 DynamicPPL.accumulator_name(::Type{<:ProduceLogLikelihoodAccumulator}) = :LogLikelihood
+DynamicPPL.logp(acc::ProduceLogLikelihoodAccumulator) = acc.logp
 
-function DynamicPPL.split(::ProduceLogLikelihoodAccumulator{T}) where {T}
-    return ProduceLogLikelihoodAccumulator(zero(T))
-end
-
-function DynamicPPL.combine(
-    acc::ProduceLogLikelihoodAccumulator, acc2::ProduceLogLikelihoodAccumulator
-)
-    return ProduceLogLikelihoodAccumulator(acc.logp + acc2.logp)
-end
-
-function Base.:+(
-    acc1::ProduceLogLikelihoodAccumulator, acc2::DynamicPPL.LogLikelihoodAccumulator
-)
-    Libtask.produce(acc2.logp)
-    return ProduceLogLikelihoodAccumulator(acc1.logp + acc2.logp)
-end
-
-function Base.zero(acc::ProduceLogLikelihoodAccumulator)
-    return ProduceLogLikelihoodAccumulator(zero(acc.logp))
+function DynamicPPL.acclogp(acc1::ProduceLogLikelihoodAccumulator, val)
+    # The below line is the only difference from `LogLikelihoodAccumulator`.
+    Libtask.produce(val)
+    return ProduceLogLikelihoodAccumulator(acc1.logp + val)
 end
 
 function DynamicPPL.accumulate_assume!!(
@@ -616,19 +569,7 @@ end
 function DynamicPPL.accumulate_observe!!(
     acc::ProduceLogLikelihoodAccumulator, right, left, vn
 )
-    return acc +
-           DynamicPPL.LogLikelihoodAccumulator(Distributions.loglikelihood(right, left))
-end
-
-function Base.convert(
-    ::Type{ProduceLogLikelihoodAccumulator{T}}, acc::ProduceLogLikelihoodAccumulator
-) where {T}
-    return ProduceLogLikelihoodAccumulator(convert(T, acc.logp))
-end
-function DynamicPPL.convert_eltype(
-    ::Type{T}, acc::ProduceLogLikelihoodAccumulator
-) where {T}
-    return ProduceLogLikelihoodAccumulator(convert(T, acc.logp))
+    return DynamicPPL.acclogp(acc, Distributions.loglikelihood(right, left))
 end
 
 # We need to tell Libtask which calls may have `produce` calls within them. In practice most

--- a/src/mcmc/particle_mcmc.jl
+++ b/src/mcmc/particle_mcmc.jl
@@ -339,6 +339,7 @@ function AbstractMCMC.step(
 )
     # Reset the VarInfo before new sweep.
     vi = state.vi
+    vi = DynamicPPL.setacc!!(vi, ProduceLogLikelihoodAccumulator())
     vi = DynamicPPL.reset_num_produce!!(vi)
     vi = DynamicPPL.resetlogp!!(vi)
 

--- a/src/mcmc/particle_mcmc.jl
+++ b/src/mcmc/particle_mcmc.jl
@@ -346,7 +346,9 @@ function AbstractMCMC.step(
     reference = AdvancedPS.forkr(AdvancedPS.Trace(model, spl, vi, state.rng))
 
     # For all other particles, do not retain the variables but resample them.
-    DynamicPPL.set_retained_vns_del!(vi)
+    for vn in keys(vi)
+        DynamicPPL.set_flag!(vi, vn, "del")
+    end
 
     # Create a new set of particles.
     num_particles = spl.alg.nparticles

--- a/test/essential/container.jl
+++ b/test/essential/container.jl
@@ -20,9 +20,9 @@ using Turing
     @testset "constructor" begin
         vi = DynamicPPL.VarInfo()
         vi = DynamicPPL.setacc!!(vi, Turing.Inference.ProduceLogLikelihoodAccumulator())
-        spl = Sampler(PG(10))
+        sampler = Sampler(PG(10))
         model = test()
-        trace = AdvancedPS.Trace(model, spl, vi, AdvancedPS.TracedRNG())
+        trace = AdvancedPS.Trace(model, sampler, vi, AdvancedPS.TracedRNG())
 
         # Make sure the backreference from taped_globals to the trace is in place.
         @test trace.model.ctask.taped_globals.other === trace

--- a/test/essential/container.jl
+++ b/test/essential/container.jl
@@ -9,19 +9,26 @@ using Turing
 @testset "container.jl" begin
     @model function test()
         a ~ Normal(0, 1)
+        println("a")
         x ~ Bernoulli(1)
+        println("x")
         b ~ Gamma(2, 3)
+        println("b")
         1 ~ Bernoulli(x / 2)
+        println("1")
         c ~ Beta()
+        println("c")
         0 ~ Bernoulli(x / 2)
+        println("0")
         return x
     end
 
     @testset "constructor" begin
         vi = DynamicPPL.VarInfo()
-        sampler = Sampler(PG(10))
+        vi = DynamicPPL.setacc!!(vi, Turing.Inference.ProduceLogLikelihoodAccumulator())
+        spl = Sampler(PG(10))
         model = test()
-        trace = AdvancedPS.Trace(model, sampler, vi, AdvancedPS.TracedRNG())
+        trace = AdvancedPS.Trace(model, spl, vi, AdvancedPS.TracedRNG())
 
         # Make sure the backreference from taped_globals to the trace is in place.
         @test trace.model.ctask.taped_globals.other === trace
@@ -46,6 +53,7 @@ using Turing
             return a, b
         end
         vi = DynamicPPL.VarInfo()
+        vi = DynamicPPL.setacc!!(vi, Turing.Inference.ProduceLogLikelihoodAccumulator())
         sampler = Sampler(PG(10))
         model = normal()
 

--- a/test/essential/container.jl
+++ b/test/essential/container.jl
@@ -9,17 +9,11 @@ using Turing
 @testset "container.jl" begin
     @model function test()
         a ~ Normal(0, 1)
-        println("a")
         x ~ Bernoulli(1)
-        println("x")
         b ~ Gamma(2, 3)
-        println("b")
         1 ~ Bernoulli(x / 2)
-        println("1")
         c ~ Beta()
-        println("c")
         0 ~ Bernoulli(x / 2)
-        println("0")
         return x
     end
 

--- a/test/mcmc/gibbs.jl
+++ b/test/mcmc/gibbs.jl
@@ -565,6 +565,99 @@ end
         end
     end
 
+    @testset "PG with variable number of observations" begin
+        # When sampling from a model with Particle Gibbs, it is mandatory for
+        # the number of observations to be the same in all particles, since the
+        # observations trigger particle resampling.
+        #
+        # Up until Turing v0.39, `x ~ dist` statements where `x` was the
+        # responsibility of a different (non-PG) Gibbs subsampler used to not
+        # count as an observation. Instead, the log-probability `logpdf(dist, x)`
+        # would be manually added to the VarInfo's `logp` field and included in the
+        # weighting for the _following_ observation.
+        #
+        # In Turing v0.40, this is now changed: `x ~ dist` uses tilde_observe!!
+        # which thus triggers resampling. Thus, for example, the following model
+        # does not work any more:
+        #
+        #   @model function f()
+        #       a ~ Poisson(2.0)
+        #       x = Vector{Float64}(undef, a)
+        #       for i in eachindex(x)
+        #           x[i] ~ Normal()
+        #       end
+        #   end
+        #   sample(f(), Gibbs(:a => PG(10), :x => MH()), 1000)
+        # 
+        # because the number of observations in each particle depends on the value
+        # of `a`.
+        #
+        # This testset checks that ways of working around such a situation.
+
+        function test_dynamic_bernoulli(chain)
+            means = Dict(:b => 0.5, "x[1]" => 1.0, "x[2]" => 2.0)
+            stds = Dict(:b => 0.5, "x[1]" => 1.0, "x[2]" => 1.0)
+            for vn in keys(means)
+                @test isapprox(mean(skipmissing(chain[:, vn, 1])), means[vn]; atol=0.1)
+                @test isapprox(std(skipmissing(chain[:, vn, 1])), stds[vn]; atol=0.1)
+            end
+        end
+
+        @testset "Coalescing multiple observations into one" begin
+            # Instead of observing x[1] and x[2] separately, we lump them into a
+            # single distribution.
+            @model function dynamic_bernoulli()
+                b ~ Bernoulli()
+                if b
+                    dists = [Normal(1.0)]
+                else
+                    dists = [Normal(1.0), Normal(2.0)]
+                end
+                return x ~ product_distribution(dists)
+            end
+            model = dynamic_bernoulli()
+            # This currently fails because if the global varinfo has `x` with length 2,
+            # and the particle sampler has `b = true`, it attempts to calculate the
+            # log-likelihood of a length-2 vector with respect to a length-1
+            # distribution.
+            @test_throws DimensionMismatch chain = sample(
+                StableRNG(468),
+                model,
+                Gibbs(:b => PG(10), :x => ESS()),
+                2000;
+                discard_initial=100,
+            )
+            # test_dynamic_bernoulli(chain)
+        end
+
+        @testset "Inserting @addlogprob!" begin
+            # On top of observing x[i], we also add in extra 'observations'
+            @model function dynamic_bernoulli_2()
+                b ~ Bernoulli()
+                x_length = b ? 1 : 2
+                x = Vector{Float64}(undef, x_length)
+                for i in 1:x_length
+                    x[i] ~ Normal(i, 1.0)
+                end
+                if length(x) == 1
+                    # This value is the expectation value of logpdf(Normal(), x) where x ~ Normal().
+                    # See discussion in
+                    # https://github.com/TuringLang/Turing.jl/pull/2629#discussion_r2237323817
+                    @addlogprob!(-1.418849)
+                end
+            end
+            model = dynamic_bernoulli_2()
+            chain = sample(
+                StableRNG(468),
+                model,
+                Gibbs(:b => PG(10), :x => ESS()),
+                2000;
+                discard_initial=100,
+            )
+            test_dynamic_bernoulli(chain)
+        end
+    end
+
     @testset "Demo model" begin
         @testset verbose = true "$(model.f)" for model in DynamicPPL.TestUtils.DEMO_MODELS
             vns = DynamicPPL.TestUtils.varnames(model)

--- a/test/mcmc/gibbs.jl
+++ b/test/mcmc/gibbs.jl
@@ -603,6 +603,7 @@ end
             end
         end
 
+        # TODO(DPPL0.37/penelopeysm): decide what to do with these tests
         @testset "Coalescing multiple observations into one" begin
             # Instead of observing x[1] and x[2] separately, we lump them into a
             # single distribution.


### PR DESCRIPTION
This PR:

(1) Adds `ProduceLogLikelihoodAccumulator` on steps n ≥ 2 of PG, otherwise `Libtask.produce` is never called.

(2) Removes all uses of `set_retained_vns_del!`, to avoid errors with PG-within-Gibbs (issue is that it would get a VariableOrderAccumulator from a different component sampler that didn't have the variables that PG cared about).

The role of `set_retained_vns_del!` was to mark specific variables for resampling by comparing `order` against `num_produce`. The idea was that we would only mark variables for resampling if they were 'in the future' i.e. we hadn't reached their tilde-statements in the model yet.

Instead of doing that, we now simply mark **everything** as to be resampled. This is fine because models can only be propagated in the forward direction i.e. **there is really no harm in marking previously seen variables for resampling** because we won't see them again! There are two cases where this could lead to different behaviour:

 - if the same variable appears on the lhs of tilde twice, which is generally invalid anyway.
 - if the same varinfo (with the `del` flags set) is then re-used for evaluating the model, e.g. to calculate logp. To circumvent this problem, I introduce an inverse function which marks all variables as **not** being for resampling.

**Collectively, this completely removes the need to track which variables have already been seen.** With these proposed changes there is simply no need to track the `order` of a variable or the `num_produce` of the varinfo, meaning that we can remove VariableOrderAccumulator entirely (with concomitant positive implications for performance).

I have not exhaustively tested these changes on `breaking`, but I have tried making exactly the same changes to the `del` flag on `main` and they lead to no changes in the sampled results if the PRNG seed is set.

----------------

> [!NOTE]  
> While we aren't quite there yet, this change also paves the way for eventually getting rid of the `del` flag entirely (https://github.com/TuringLang/DynamicPPL.jl/issues/982).
>
> Notice that the changes in this PR already remove the need for a per-variable `del` flag; instead we can have a single boolean for the entire VarInfo which marks whether something should be resampled or not. This would already represent a substantial simplification.
>
> However, ultimately we should like to shift this information outside of the VarInfo because then it means that VarInfo doesn't need to track information that only PG needs. The way I would propose to do this is with contexts: one which never resamples variables (which would correspond to all `del` flags unset), and one which always resamples variables (corresponding to all `del` flags set). Notice further that these roles are very similar to `DefaultContext` and the upcoming `InitContext`. There are probably a ton of subtleties (e.g., in that we have to use the traced rng rather than just naively resampling), but I think there is light at the end of the tunnel.