### PR TITLE
Unify Turing `Transition`s, fix some tests

### DIFF
--- a/test/mcmc/gibbs.jl
+++ b/test/mcmc/gibbs.jl
@@ -651,7 +651,7 @@ end
             chain = sample(
                 StableRNG(468),
                 model,
-                Gibbs(:b => PG(10), :x => ESS()),
+                Gibbs(:b => PG(20), :x => ESS()),
                 2000;
                 discard_initial=100,
             )

--- a/test/mcmc/gibbs.jl
+++ b/test/mcmc/gibbs.jl
@@ -598,8 +598,8 @@ end
             means = Dict(:b => 0.5, "x[1]" => 1.0, "x[2]" => 2.0)
             stds = Dict(:b => 0.5, "x[1]" => 1.0, "x[2]" => 1.0)
             for vn in keys(means)
-                @test isapprox(mean(skipmissing(chain[:, vn, 1])), means[vn]; atol=0.1)
-                @test isapprox(std(skipmissing(chain[:, vn, 1])), stds[vn]; atol=0.1)
+                @test isapprox(mean(skipmissing(chain[:, vn, 1])), means[vn]; atol=0.15)
+                @test isapprox(std(skipmissing(chain[:, vn, 1])), stds[vn]; atol=0.15)
             end
         end
 

--- a/test/mcmc/particle_mcmc.jl
+++ b/test/mcmc/particle_mcmc.jl
@@ -1,7 +1,7 @@
 module ParticleMCMCTests
 
 using ..Models: gdemo_default
-#using ..Models: MoGtest, MoGtest_default
+using ..SamplerTestUtils: test_chain_logp_metadata
 using AdvancedPS: ResampleWithESSThreshold, resample_systematic, resample_multinomial
 using Distributions: Bernoulli, Beta, Gamma, Normal, sample
 using Random: Random
@@ -51,15 +51,7 @@ using Turing
     end
 
     @testset "chain log-density metadata" begin
-        @model function f()
-            x ~ LogNormal()
-            return 1.0 ~ Normal(x)
-        end
-        N = 100
-        chn = sample(f(), SMC(), N)
-        @test chn[:logprior] ≈ logpdf.(LogNormal(), chn[:x])
-        @test chn[:loglikelihood] ≈ logpdf.(Normal.(chn[:x]), 1.0)
-        @test chn[:lp] ≈ chn[:logprior] + chn[:loglikelihood]
+        test_chain_logp_metadata(SMC())
     end
 
     @testset "logevidence" begin
@@ -105,15 +97,7 @@ end
     end
 
     @testset "chain log-density metadata" begin
-        @model function f()
-            x ~ LogNormal()
-            return 1.0 ~ Normal(x)
-        end
-        N = 100
-        chn = sample(f(), PG(10), N)
-        @test chn[:logprior] ≈ logpdf.(LogNormal(), chn[:x])
-        @test chn[:loglikelihood] ≈ logpdf.(Normal.(chn[:x]), 1.0)
-        @test chn[:lp] ≈ chn[:logprior] + chn[:loglikelihood]
+        test_chain_logp_metadata(PG(10))
     end
 
     @testset "logevidence" begin

--- a/test/mcmc/particle_mcmc.jl
+++ b/test/mcmc/particle_mcmc.jl
@@ -141,7 +141,6 @@ end
             end
         end
         c = sample(StableRNG(468), addlogprob_demo(), PG(10), 100)
-        @show mean(c[:x])
         # Result should be biased towards x > 0.
         @test mean(c[:x]) > 0.7
     end

--- a/test/mcmc/particle_mcmc.jl
+++ b/test/mcmc/particle_mcmc.jl
@@ -133,16 +133,17 @@ end
         @model function addlogprob_demo()
             x ~ Normal(0, 1)
             if x < 0
-                @addlogprob! -2.0
+                @addlogprob! -10.0
             else
                 # Need a balanced number of addlogprobs in all branches, or
                 # else PG will error
                 @addlogprob! 0.0
             end
         end
-        c = sample(addlogprob_demo(), PG(10), 100)
+        c = sample(StableRNG(468), addlogprob_demo(), PG(10), 100)
+        @show mean(c[:x])
         # Result should be biased towards x > 0.
-        @test mean(c[:x]) > 0.5
+        @test mean(c[:x]) > 0.7
     end
 
     # https://github.com/TuringLang/Turing.jl/issues/2007

--- a/test/mcmc/sghmc.jl
+++ b/test/mcmc/sghmc.jl
@@ -2,6 +2,7 @@ module SGHMCTests
 
 using ..Models: gdemo_default
 using ..NumericalTests: check_gdemo
+using ..SamplerTestUtils: test_chain_logp_metadata
 using DynamicPPL.TestUtils.AD: run_ad
 using DynamicPPL.TestUtils: DEMO_MODELS
 using DynamicPPL: DynamicPPL
@@ -34,15 +35,7 @@ using Turing
     end
 
     @testset "chain log-density metadata" begin
-        @model function f()
-            x ~ LogNormal()
-            return 1.0 ~ Normal(x)
-        end
-        N = 100
-        chn = sample(f(), SGHMC(; learning_rate=0.02, momentum_decay=0.5), N)
-        @test chn[:logprior] ≈ logpdf.(LogNormal(), chn[:x])
-        @test chn[:loglikelihood] ≈ logpdf.(Normal.(chn[:x]), 1.0)
-        @test chn[:lp] ≈ chn[:logprior] + chn[:loglikelihood]
+        test_chain_logp_metadata(SGHMC(; learning_rate=0.02, momentum_decay=0.5))
     end
 end
 
@@ -74,15 +67,7 @@ end
     end
 
     @testset "chain log-density metadata" begin
-        @model function f()
-            x ~ LogNormal()
-            return 1.0 ~ Normal(x)
-        end
-        N = 100
-        chn = sample(f(), SGLD(; stepsize=PolynomialStepsize(0.25)), N)
-        @test chn[:logprior] ≈ logpdf.(LogNormal(), chn[:x])
-        @test chn[:loglikelihood] ≈ logpdf.(Normal.(chn[:x]), 1.0)
-        @test chn[:lp] ≈ chn[:logprior] + chn[:loglikelihood]
+        test_chain_logp_metadata(SGLD(; stepsize=PolynomialStepsize(0.25)))
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,7 @@ seed!(23)
 
 include("test_utils/models.jl")
 include("test_utils/numerical_tests.jl")
+include("test_utils/sampler.jl")
 
 Turing.setprogress!(false)
 included_paths, excluded_paths = parse_args(ARGS)

--- a/test/test_utils/sampler.jl
+++ b/test/test_utils/sampler.jl
@@ -1,0 +1,27 @@
+module SamplerTestUtils
+
+using Turing
+using Test
+
+"""
+Check that when sampling with `spl`, the resulting chain contains log-density
+metadata that is correct.
+"""
+function test_chain_logp_metadata(spl)
+    @model function f()
+        # some prior term (but importantly, one that is constrained, i.e., can
+        # be linked with non-identity transform)
+        x ~ LogNormal()
+        # some likelihood term
+        return 1.0 ~ Normal(x)
+    end
+    chn = sample(f(), spl, 100)
+    # Check that the log-prior term is calculated in unlinked space.
+    @test chn[:logprior] ≈ logpdf.(LogNormal(), chn[:x])
+    @test chn[:loglikelihood] ≈ logpdf.(Normal.(chn[:x]), 1.0)
+    # This should always be true, but it also indirectly checks that the 
+    # log-joint is also calculated in unlinked space.
+    @test chn[:lp] ≈ chn[:logprior] + chn[:loglikelihood]
+end
+
+end


### PR DESCRIPTION
This PR removes `SGLDTransition`, `SMCTransition`, and `PGTransition` in favour of just using plain old `Transition`.

This is pretty much the last thing I want to add to 0.40. The reason why I'd like to squeeze it in now is because it will correctly fix all the `chain[:lp]`, `chain[:logprior]`, etc. for all of the samplers we have, which feels like a nice reward after all the upfront work on DynamicPPL accumulators 😄.

It also adds a deepcopy to the `Transition` constructor as otherwise it would mutate the varinfo passed in which messed things up for SGLD (I'm not sure why it didn't mess anything up for the other samplers). This deepcopy used to be there previously

https://github.com/TuringLang/Turing.jl/blob/d75e6f269b18800e366b383b5059ed08e10ad7a7/src/mcmc/Inference.jl#L192-L194

so I think maybe removing it in #2630 was too ambitious.

Fixes most of #2631, although properly fixing it will have to wait for the removal of SampleFromPrior.