### PR TITLE
Forbid PG/SMC on 1.12

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 0.40.6
+
+Error more loudly and usefully when attempting to use particle methods on Julia 1.12.
+
 # 0.40.5
 
 Bump Optimization.jl compatibility to include v5.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Turing"
 uuid = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-version = "0.40.5"
+version = "0.40.6"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/mcmc/particle_mcmc.jl
+++ b/src/mcmc/particle_mcmc.jl
@@ -2,6 +2,8 @@
 ### Particle Filtering and Particle MCMC Samplers.
 ###
 
+LIBTASK_BROKEN = v"1.12.0" <= VERSION < v"1.12.2"
+
 ### AdvancedPS models and interface
 
 """
@@ -114,6 +116,13 @@ $(TYPEDFIELDS)
 """
 struct SMC{R} <: ParticleInference
     resampler::R
+
+    function SMC(resampler::R) where {R}
+        @static if LIBTASK_BROKEN
+            error("SMC is not yet supported on Julia v1.12; please use Julia v1.11")
+        end
+        return new{R}(resampler)
+    end
 end
 
 """
@@ -255,6 +264,13 @@ struct PG{R} <: ParticleInference
     nparticles::Int
     """Resampling algorithm."""
     resampler::R
+
+    function PG(nparticles::Int, resampler::R) where {R}
+        @static if LIBTASK_BROKEN
+            error("PG is not yet supported on Julia v1.12; please use Julia v1.11")
+        end
+        return new{R}(nparticles, resampler)
+    end
 end
 
 """


### PR DESCRIPTION
It'll error when it gets to Libtask anyway, so this is just a more useful error.