### PR TITLE
Skip Mooncake on 1.12

### DIFF
--- a/test/ad.jl
+++ b/test/ad.jl
@@ -10,10 +10,8 @@ using Test
 using ..Models: gdemo_default
 import ForwardDiff, ReverseDiff
 
-# Detect if prerelease version, if so, we skip some tests
-const IS_PRERELEASE = !isempty(VERSION.prerelease)
-const INCLUDE_MOONCAKE = !IS_PRERELEASE
-
+# Skip Mooncake on 1.12 as it is not compatible yet
+const INCLUDE_MOONCAKE = VERSION >= v"1.12"
 if INCLUDE_MOONCAKE
     import Pkg
     Pkg.add("Mooncake")


### PR DESCRIPTION
1.12 isn't being tested right now on Turing, so this doesn't actually affect anything here; but DynamicPPL's integration test uses 1.12 and it seems unfair to pin that to 1.11 when most of Turing's test suite should pass on 1.12.