### PR TITLE
Use OnlyAccsVarInfo in check_model

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 0.42.1
+
+Avoid passing a full VarInfo to `check_model`, which allows more models to be checked safely for validity.
+
 # 0.42.0
 
 ## DynamicPPL 0.39

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Turing"
 uuid = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-version = "0.42.0"
+version = "0.42.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/mcmc/abstractmcmc.jl
+++ b/src/mcmc/abstractmcmc.jl
@@ -2,7 +2,9 @@
 # HMC not supporting discrete parameters.
 function _check_model(model::DynamicPPL.Model)
     new_model = DynamicPPL.setleafcontext(model, DynamicPPL.InitContext())
-    return DynamicPPL.check_model(new_model, VarInfo(); error_on_failure=true)
+    return DynamicPPL.check_model(
+        new_model, DynamicPPL.OnlyAccsVarInfo(); error_on_failure=true
+    )
 end
 function _check_model(model::DynamicPPL.Model, ::AbstractSampler)
     return _check_model(model)


### PR DESCRIPTION
Because the model is contextualised with InitContext, the call to check_model doesn't actually need anything more than an OnlyAccsVarInfo. This allows models that don't work well with Metadata* to still be checked for validity (note that the check, as defined in DynamicPPL, only uses DebugAccumulator, it does not actually use metadata in any form -- unless the model has DefaultContext as its leaf context -- which is not the case here).

(cc @PTWaade I think this is the reason why check_model failed)

\* one might ask what models don't work well with metadata, but still otherwise work. There are a couple of things that come to mind: 1) parallel assume statements; and 2) special distribution types for which the from_[linked_]_vec_transform functions are not defined. These models should in principle work with `Prior()` sampling, which only ever uses OnlyAccsVarInfo. However, currently, they don't unless you disable check_model; this is the behaviour that this PR fixes.