### PR TITLE
remove get_matching_type overload

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 0.43.3
+
+Removes some dead code.
+
 # 0.42.2
 
 `InitFromParams(mode_estimate)`, where `mode_estimate` was obtained from an optimisation on a Turing model, now accepts a second optional argument which provides a fallback initialisation strategy if some parameters are missing from `mode_estimate`.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Turing"
 uuid = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-version = "0.42.2"
+version = "0.42.3"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/mcmc/Inference.jl
+++ b/src/mcmc/Inference.jl
@@ -130,14 +130,4 @@ include("prior.jl")
 include("gibbs.jl")
 include("gibbs_conditional.jl")
 
-################
-# Typing tools #
-################
-
-function DynamicPPL.get_matching_type(
-    spl::Union{PG,SMC}, vi, ::Type{TV}
-) where {T,N,TV<:Array{T,N}}
-    return Array{T,N}
-end
-
 end # module


### PR DESCRIPTION
Terrifyingly, Turing overloaded an internal DynamicPPL function, `get_matching_type`. The function was renamed in a patch release, which is semver compliant. However, that makes Turing error when loaded, because there is no longer such a function to overload. This PR removes the overload (it was dead code and not accomplishing anything anyway).