### PR TITLE
Fix off-by-one NUTS adaptations

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,8 @@
-# 0.43.3
+# 0.42.4
+
+Fixes a typo that caused NUTS to perform one less adaptation step than in versions prior to 0.41.
+
+# 0.42.3
 
 Removes some dead code.
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Turing"
 uuid = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-version = "0.42.3"
+version = "0.42.4"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/mcmc/hmc.jl
+++ b/src/mcmc/hmc.jl
@@ -228,7 +228,7 @@ function Turing.Inference.initialstep(
     adaptor = AHMCAdaptor(spl, hamiltonian.metric, nadapts; ϵ=ϵ)
 
     transition = DynamicPPL.ParamsWithStats(theta, ldf, NamedTuple())
-    state = HMCState(vi, 1, kernel, hamiltonian, z, adaptor, ldf)
+    state = HMCState(vi, 0, kernel, hamiltonian, z, adaptor, ldf)
 
     return transition, state
 end


### PR DESCRIPTION
Closes #2750.

Prior to https://github.com/TuringLang/Turing.jl/pull/2674 the counter `i` would be initialised to `1` after the first adaptation had happened. That PR, first released in v0.41, changed it such that the counter `i` was initialised to `1` before the first adaptation happened. That should, of course, be zero, which this PR fixes.

I've checked locally and this change makes it such that results from pre-v0.41 are exactly reproducible now, as long as all else is equal (e.g. initialisation, discard_initial, etc).