### PR TITLE
Avoid reevaluating model where unnecessary

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+# 0.42.7
+
+Avoid reevaluating the model on MCMC iterations where the transition is not saved to the chain (e.g. in initial burn-in, or when using thinning).
+Also avoid each component sampler of Gibbs unnecessarily evaluating the model once per iteration.
+
 # 0.42.6
 
 Fixed a bug in SMC and PG where results were not always stored correctly in Libtask traces (due to incorrect `objectid` checks).

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Turing"
 uuid = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-version = "0.42.6"
+version = "0.42.7"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/Project.toml
+++ b/Project.toml
@@ -47,7 +47,7 @@ TuringDynamicHMCExt = "DynamicHMC"
 
 [compat]
 ADTypes = "1.9"
-AbstractMCMC = "5.9"
+AbstractMCMC = "5.13"
 AbstractPPL = "0.11, 0.12, 0.13"
 Accessors = "0.1"
 AdvancedHMC = "0.8.3"

--- a/src/mcmc/is.jl
+++ b/src/mcmc/is.jl
@@ -27,18 +27,30 @@ sample(gdemo([1.5, 2]), IS(), 1000)
 struct IS <: AbstractSampler end
 
 function Turing.Inference.initialstep(
-    rng::AbstractRNG, model::Model, spl::IS, vi::AbstractVarInfo; kwargs...
+    rng::AbstractRNG,
+    model::Model,
+    spl::IS,
+    vi::AbstractVarInfo;
+    discard_sample=false,
+    kwargs...,
 )
-    return DynamicPPL.ParamsWithStats(vi, model), nothing
+    transition = discard_sample ? nothing : DynamicPPL.ParamsWithStats(vi, model)
+    return transition, nothing
 end
 
 function AbstractMCMC.step(
-    rng::Random.AbstractRNG, model::Model, spl::IS, ::Nothing; kwargs...
+    rng::Random.AbstractRNG,
+    model::Model,
+    spl::IS,
+    ::Nothing;
+    discard_sample=false,
+    kwargs...,
 )
     model = DynamicPPL.setleafcontext(model, ISContext(rng))
     _, vi = DynamicPPL.evaluate!!(model, DynamicPPL.VarInfo())
     vi = DynamicPPL.typed_varinfo(vi)
-    return DynamicPPL.ParamsWithStats(vi, model), nothing
+    transition = discard_sample ? nothing : DynamicPPL.ParamsWithStats(vi, model)
+    return transition, nothing
 end
 
 struct ISContext{R<:AbstractRNG} <: DynamicPPL.AbstractContext

--- a/src/mcmc/prior.jl
+++ b/src/mcmc/prior.jl
@@ -10,6 +10,7 @@ function AbstractMCMC.step(
     model::DynamicPPL.Model,
     sampler::Prior,
     state=nothing;
+    discard_sample=false,
     kwargs...,
 )
     accs = DynamicPPL.AccumulatorTuple((
@@ -19,5 +20,6 @@ function AbstractMCMC.step(
     ))
     vi = DynamicPPL.OnlyAccsVarInfo(accs)
     _, vi = DynamicPPL.init!!(rng, model, vi, DynamicPPL.InitFromPrior())
-    return DynamicPPL.ParamsWithStats(vi), nothing
+    transition = discard_sample ? nothing : DynamicPPL.ParamsWithStats(vi)
+    return transition, nothing
 end


### PR DESCRIPTION
Closes #2639

Quoting from the changelog:

> Avoid reevaluating the model on MCMC iterations where the transition is not saved to the chain (e.g. in initial burn-in, or when using thinning).
> Also avoid each component sampler of Gibbs unnecessarily evaluating the model once per iteration.

This makes use of the `discard_sample` keyword argument to `step` / `step_warmup` https://github.com/TuringLang/AbstractMCMC.jl/pull/194

Note that this is still type stable as the value of the `discard_sample` kwarg can be constant propagated (I've checked this with code_warntype etc).