### PR TITLE
Replace Random.seed! with local RNGs in test suite

### DIFF
--- a/test/ext/dynamichmc.jl
+++ b/test/ext/dynamichmc.jl
@@ -1,4 +1,4 @@
-module DynamicHMCTests
+iiimodule DynamicHMCTests
 
 using ..Models: gdemo_default
 using ..NumericalTests: check_gdemo
@@ -10,9 +10,9 @@ using Random: Random
 using Turing
 
 @testset "TuringDynamicHMCExt" begin
-    Random.seed!(100)
+    rng = Xoshiro(100)
     spl = externalsampler(DynamicHMC.NUTS())
-    chn = sample(gdemo_default, spl, 10_000)
+    chn = sample(rng, gdemo_default, spl, 10_000)
     check_gdemo(chn)
 end
 

--- a/test/mcmc/Inference.jl
+++ b/test/mcmc/Inference.jl
@@ -35,11 +35,11 @@ using Turing
                 Gibbs(:s => HMC(0.1, 5), :m => ESS()),
             )
             for sampler in samplers
-                Random.seed!(5)
-                chain1 = sample(model, sampler, MCMCThreads(), 10, 4)
+                rng1 = StableRNG(5)
+                chain1 = sample(rng1, model, sampler, MCMCThreads(), 10, 4)
 
-                Random.seed!(5)
-                chain2 = sample(model, sampler, MCMCThreads(), 10, 4)
+                rng2 = StableRNG(5)
+                chain2 = sample(rng2, model, sampler, MCMCThreads(), 10, 4)
 
                 # For HMC, the first step does not have stats, so we need to use isequal to
                 # avoid comparing `missing`s

--- a/test/mcmc/emcee.jl
+++ b/test/mcmc/emcee.jl
@@ -10,13 +10,13 @@ using Turing
 
 @testset "emcee.jl" begin
     @testset "gdemo" begin
-        Random.seed!(9876)
+        rng = Xoshiro(9876)
 
         n_samples = 1000
         n_walkers = 250
 
         spl = Emcee(n_walkers, 2.0)
-        chain = sample(gdemo_default, spl, n_samples)
+        chain = sample(rng, gdemo_default, spl, n_samples)
         check_gdemo(chain)
     end
 
@@ -33,10 +33,10 @@ using Turing
         nwalkers = 250
         spl = Emcee(nwalkers, 2.0)
 
-        Random.seed!(1234)
-        chain1 = sample(gdemo_default, spl, 1)
-        Random.seed!(1234)
-        chain2 = sample(gdemo_default, spl, 1)
+        rng1 = StableRNG(1234)
+        chain1 = sample(rng1, gdemo_default, spl, 1)
+        rng2 = StableRNG(1234)
+        chain2 = sample(rng2, gdemo_default, spl, 1)
         @test Array(chain1) == Array(chain2)
 
         initial_nt = DynamicPPL.InitFromParams((s=2.0, m=1.0))

--- a/test/mcmc/gibbs.jl
+++ b/test/mcmc/gibbs.jl
@@ -262,10 +262,10 @@ end
     sampler2 = Gibbs(
         @varname(s) => MH(), @varname(s) => MH(), @varname(s) => MH(), @varname(m) => ESS()
     )
-    Random.seed!(23)
-    chain1 = sample(gdemo_default, sampler1, 10)
-    Random.seed!(23)
-    chain2 = sample(gdemo_default, sampler1, 10)
+    rng1 = StableRNG(23)
+    chain1 = sample(rng1, gdemo_default, sampler1, 10)
+    rng2 = StableRNG(23)
+    chain2 = sample(rng2, gdemo_default, sampler1, 10)
     @test chain1.value == chain2.value
 end
 
@@ -681,8 +681,9 @@ end
                 # Sampler to use for Gibbs components.
                 hmc = HMC(0.1, 32)
                 sampler = Gibbs(@varname(s) => hmc, @varname(m) => hmc)
-                Random.seed!(42)
+                rng = Xoshiro(42)
                 chain = sample(
+		    rng, 
                     model,
                     sampler,
                     MCMCThreads(),
@@ -696,9 +697,10 @@ end
 
                 # "Ground truth" samples.
                 # TODO: Replace with closed-form sampling once that is implemented in DynamicPPL.
-                Random.seed!(42)
+                Random.seed!(rng, 42)
                 chain_true = sample(
-                    model,
+                    rng, 
+		    model,
                     NUTS(),
                     MCMCThreads(),
                     num_iterations,
@@ -742,8 +744,8 @@ end
             end
 
             # `sample`
-            Random.seed!(42)
-            chain = sample(model, spl, 1_000; progress=false)
+            rng = Xoshiro(42)
+            chain = sample(rng, model, spl, 1_000; progress=false)
             check_numerical(chain, [:s, :m], [49 / 24, 7 / 6]; atol=0.4)
         end
 
@@ -820,8 +822,8 @@ end
         end
 
         # Sample!
-        Random.seed!(42)
-        chain = sample(MoGtest_default, spl, 1000; progress=false)
+        rng = Xoshiro(42)
+        chain = sample(rng, MoGtest_default, spl, 1000; progress=false)
         check_MoGtest_default(chain; atol=0.2)
     end
 
@@ -846,8 +848,8 @@ end
         end
 
         # Sample!
-        Random.seed!(42)
-        chain = sample(model, spl, 1000; progress=false)
+        rng = Xoshiro(42)
+        chain = sample(rng, model, spl, 1000; progress=false)
         check_MoGtest_default_z_vector(chain; atol=0.2)
     end
 
@@ -883,9 +885,9 @@ end
         ]
         @testset "$(sampler_inner)" for sampler_inner in samplers_inner
             sampler = Gibbs(@varname(m1) => sampler_inner, @varname(m2) => sampler_inner)
-            Random.seed!(42)
+            rng = Xoshiro(42)
             chain = sample(
-                model, sampler, 1000; discard_initial=1000, thinning=10, n_adapts=0
+                rng, model, sampler, 1000; discard_initial=1000, thinning=10, n_adapts=0
             )
             check_numerical(chain, [:m1, :m2], [-0.2, 0.6]; atol=0.1)
             check_logp_correct(sampler_inner)

--- a/test/mcmc/hmc.jl
+++ b/test/mcmc/hmc.jl
@@ -131,7 +131,6 @@ using Turing
     # easily make it fail, despite many more samples than taken by most other tests. Hence
     # explicitly specifying the seeds here.
     @testset "hmcda+gibbs inference" begin
-        Random.seed!(12345)
         alg = Gibbs(:s => PG(20), :m => HMCDA(500, 0.8, 0.25; init_ϵ=0.05))
         res = sample(StableRNG(123), gdemo_default, alg, 3000; discard_initial=1000)
         check_gdemo(res)

--- a/test/mcmc/particle_mcmc.jl
+++ b/test/mcmc/particle_mcmc.jl
@@ -55,7 +55,7 @@ using Turing
     end
 
     @testset "logevidence" begin
-        Random.seed!(100)
+        rng = StableRNG(100)
 
         @model function test()
             a ~ Normal(0, 1)
@@ -67,7 +67,7 @@ using Turing
             return x
         end
 
-        chains_smc = sample(test(), SMC(), 100)
+        chains_smc = sample(rng, test(), SMC(), 100)
 
         @test all(isone, chains_smc[:x])
         # For SMC, the chain stores the collective logevidence of the sampled trajectories

--- a/test/optimisation/Optimisation.jl
+++ b/test/optimisation/Optimisation.jl
@@ -125,7 +125,6 @@ using Turing
         end
 
         @testset "MLE" begin
-            Random.seed!(222)
             true_value = [0.0625, 1.75]
             true_logp = loglikelihood(gdemo_default, (s=true_value[1], m=true_value[2]))
             check_success(result) = check_optimisation_result(result, true_value, true_logp)
@@ -163,7 +162,6 @@ using Turing
         end
 
         @testset "MAP" begin
-            Random.seed!(222)
             true_value = [49 / 54, 7 / 6]
             true_logp = logjoint(gdemo_default, (s=true_value[1], m=true_value[2]))
             check_success(result) = check_optimisation_result(result, true_value, true_logp)
@@ -201,7 +199,6 @@ using Turing
         end
 
         @testset "MLE with box constraints" begin
-            Random.seed!(222)
             true_value = [0.0625, 1.75]
             true_logp = loglikelihood(gdemo_default, (s=true_value[1], m=true_value[2]))
             check_success(result, check_retcode=true) =
@@ -261,7 +258,6 @@ using Turing
         end
 
         @testset "MAP with box constraints" begin
-            Random.seed!(222)
             true_value = [49 / 54, 7 / 6]
             true_logp = logjoint(gdemo_default, (s=true_value[1], m=true_value[2]))
             check_success(result, check_retcode=true) =
@@ -322,7 +318,6 @@ using Turing
         end
 
         @testset "MLE with generic constraints" begin
-            Random.seed!(222)
             true_value = [0.0625, 1.75]
             true_logp = loglikelihood(gdemo_default, (s=true_value[1], m=true_value[2]))
             check_success(result, check_retcode=true) =
@@ -375,7 +370,6 @@ using Turing
         end
 
         @testset "MAP with generic constraints" begin
-            Random.seed!(222)
             true_value = [49 / 54, 7 / 6]
             true_logp = logjoint(gdemo_default, (s=true_value[1], m=true_value[2]))
             check_success(result, check_retcode=true) =
@@ -431,7 +425,6 @@ using Turing
     end
 
     @testset "StatsBase integration" begin
-        Random.seed!(54321)
         mle_est = maximum_likelihood(gdemo_default)
         # Calculated based on the two data points in gdemo_default, [1.5, 2.0]
         true_values = [0.0625, 1.75]
@@ -466,7 +459,6 @@ using Turing
             return y ~ MvNormal(mu, I)
         end
 
-        Random.seed!(987)
         true_beta = [1.0, -2.2]
         x = rand(40, 2)
         y = x * true_beta
@@ -504,7 +496,6 @@ using Turing
     # TODO(mhauru): The corresponding Optim.jl test had a note saying that some models
     # don't work for Tracker and ReverseDiff. Is that still the case?
     @testset "MAP for $(model.f)" for model in DynamicPPL.TestUtils.DEMO_MODELS
-        Random.seed!(23)
         result_true = DynamicPPL.TestUtils.posterior_optima(model)
 
         optimizers = [
@@ -543,7 +534,6 @@ using Turing
         DynamicPPL.TestUtils.demo_assume_matrix_observe_matrix_index,
     ]
     @testset "MLE for $(model.f)" for model in DynamicPPL.TestUtils.DEMO_MODELS
-        Random.seed!(23)
         result_true = DynamicPPL.TestUtils.likelihood_optima(model)
 
         optimizers = [

--- a/test/stdlib/RandomMeasures.jl
+++ b/test/stdlib/RandomMeasures.jl
@@ -49,13 +49,12 @@ using Turing.RandomMeasures: ChineseRestaurantProcess, DirichletProcess
         end
 
         # Generate some test data.
-        Random.seed!(1)
-        data = vcat(randn(10), randn(10) .- 5, randn(10) .+ 10)
+        rng = StableRNG(1)
+        data = vcat(randn(rng, 10), randn(rng, 10) .- 5, randn(rng, 10) .+ 10)
         data .-= mean(data)
         data /= std(data)
 
         # MCMC sampling
-        Random.seed!(2)
         iterations = 500
         model_fun = infiniteGMM(data)
         chain = sample(model_fun, SMC(), iterations)


### PR DESCRIPTION
Fixes #2726 

Replaced global `Random.seed!` calls in the test suite with local RNGs:
- `Xoshiro` when reproducibility is needed but exact values don't matter  
- `StableRNG` when exact output values are checked with `==`
- Deleted when the test only checks type or approximate values

The single `Random.seed!` in `runtests.jl` is kept as discussed.