### PR TITLE
Test on 1.10.11 and 1.13

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -51,19 +51,18 @@ jobs:
           - version: '1'
             os: macos-latest
             num_threads: 1
-          # Minimum supported Julia version
-          - version: 'min'
+          # 1.10
+          - version: 'lts'
             os: ubuntu-latest
             num_threads: 1
-          # Minimum supported Julia version, multithreaded
-          - version: 'min'
+          # 1.10, multithreaded
+          - version: 'lts'
             os: ubuntu-latest
             num_threads: 2
-          # TODO(mhauru) Start running 'pre' again once it differs from '1'.
           # Pre-release Julia version
-          # - version: 'pre'
-          #   os: ubuntu-latest
-          #   num_threads: 1
+          - version: 'pre'
+            os: ubuntu-latest
+            num_threads: 1
 
     steps:
       - name: Print matrix variables


### PR DESCRIPTION
We have a minimum Julia compat bound of 1.10.8. That is technically fine, but running CI on 1.10.8 causes an indeterministic segfault (#2655), which (to my understanding) has been patched in 1.10.11 (see https://github.com/JuliaLang/julia/pull/54840).

I don't think that this is enough to justify bumping the minimum version in Project.toml to 1.10.11; but we can run CI on 1.10.11 to avoid this failure from messing CI up.

Closes #2655

This PR also enables testing on 1.13, since we can now refer to it with 'pre'.