### PR TITLE
Add SafeLogDensity wrapper for graceful error handling in logdensity

### DIFF
--- a/src/Turing.jl
+++ b/src/Turing.jl
@@ -50,6 +50,9 @@ using .Variational
 include("optimisation/Optimisation.jl")
 using .Optimisation
 
+
+include("logdensity_wrapper.jl")
+
 ###########
 # Exports #
 ###########
@@ -187,4 +190,5 @@ export
     might_produce,
     @might_produce
 
+    SafeLogDensity
 end

--- a/src/logdensity_wrapper.jl
+++ b/src/logdensity_wrapper.jl
@@ -1,0 +1,17 @@
+"""
+    SafeLogDensity(ldf)
+
+Return '-Inf' if evaluation throws an error.
+"""
+
+struct SafeLogDensity{L}
+    ldf::L
+end
+
+function LogDensityProblems.logdensity(w::SafeLogDensity, x)
+    try
+        return LogDensityProblems.logdensity(w.ldf, x)
+    catch
+        return -Inf
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using Pkg
 using Random: seed!
 using Test
 using TimerOutputs: TimerOutputs, @timeit
+using LogDensityProblems
 import Turing
 
 # Fix the global Random.seed for reproducibility.
@@ -12,6 +13,7 @@ seed!(23)
 include("test_utils/models.jl")
 include("test_utils/numerical_tests.jl")
 include("test_utils/sampler.jl")
+include("test_utils/logdensity_test.jl")
 
 Turing.setprogress!(false)
 included_paths, excluded_paths = parse_args(ARGS)
@@ -80,6 +82,7 @@ end
     @testset "utilities" begin
         @timeit_include("mcmc/utilities.jl")
     end
+
 end
 
 show(TIMEROUTPUT; compact=true, sortby=:firstexec)

--- a/test/test_utils/logdensity_test.jl
+++ b/test/test_utils/logdensity_test.jl
@@ -1,0 +1,15 @@
+using Turing
+using LogDensityProblems
+using Test
+
+struct BadModel end
+
+function LogDensityProblems.logdensity(::BadModel, x)
+    error("boom")
+end
+
+@testset "SafeLogDensity local test" begin
+    wrapped = Turing.SafeLogDensity(BadModel())
+    val = LogDensityProblems.logdensity(wrapped, [1.0])
+    @test val == -Inf
+end


### PR DESCRIPTION
## Summary

This PR introduces a `SafeLogDensity` wrapper that catches errors during logdensity evaluation and returns `-Inf` instead of throwing.

## Motivation

Inspired by the discussions on improving error handling during sampling, e.g. rejecting proposals instead of failing when encountering numerical issues, this PR provides a small step in that direction by introducing a safe wrapper for logdensity evaluation.

## Changes

- add `SafeLogDensity` wrapper
- catch exceptions in `logdensity` and return `-Inf`
- add a test demonstrating fallback behavior

## Scope

This does not yet integrate with samplers or gradient evaluation. It is intended as a minimal building block for future improvements.

## Notes

The wrapper is currently not exported to keep the API surface minimal until further discussion.