### PR TITLE
Remove `ForwardDiff.value`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 0.43.6
+
+Internal change to avoid using ForwardDiff internals.
+
 # 0.43.5
 
 Fix incorrect handling of VarNamedTuple templates inside submodels when sampling with Gibbs.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Turing"
 uuid = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-version = "0.43.5"
+version = "0.43.6"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/optimisation/init.jl
+++ b/src/optimisation/init.jl
@@ -55,14 +55,16 @@ _nextfloat(x::AbstractFloat) = nextfloat(x)
 _nextfloat(x::AbstractArray{<:AbstractFloat}) = map(nextfloat, x)
 _nextfloat(x) = x
 function satisfies_constraints(
-    lb::Union{Nothing,Real},
-    ub::Union{Nothing,Real},
+    lb::Union{Nothing,AbstractFloat},
+    ub::Union{Nothing,AbstractFloat},
     proposed_val::ForwardDiff.Dual,
-    dist::UnivariateDistribution,
+    ::UnivariateDistribution,
 )
     # The prevfloat/nextfloat is needed because ForwardDiff.Dual(2.0, 1.0) > 2.0 returns
     # true, even though the primal value is within the constraints.
-    return satisfies_constraints(_prevfloat(lb), _nextfloat(ub), proposed_val, dist)
+    satisfies_lb = lb === nothing || proposed_val > prevfloat(lb)
+    satisfies_ub = ub === nothing || proposed_val < nextfloat(ub)
+    return isnan(proposed_val) || (satisfies_lb && satisfies_ub)
 end
 function satisfies_constraints(
     lb::Union{Nothing,AbstractArray{<:Real}},
@@ -77,12 +79,18 @@ function satisfies_constraints(
     return satisfies_lb && satisfies_ub
 end
 function satisfies_constraints(
-    lb::Union{Nothing,AbstractArray{<:Real}},
-    ub::Union{Nothing,AbstractArray{<:Real}},
+    lb::Union{Nothing,AbstractArray{<:AbstractFloat}},
+    ub::Union{Nothing,AbstractArray{<:AbstractFloat}},
     proposed_val::AbstractArray{<:ForwardDiff.Dual},
     dist::Union{MultivariateDistribution,MatrixDistribution},
 )
-    return satisfies_constraints(_prevfloat(lb), _nextfloat(ub), proposed_val, dist)
+    satisfies_lb =
+        lb === nothing ||
+        all(p -> isnan(p[1]) || p[1] > prevfloat(p[2]), zip(proposed_val, lb))
+    satisfies_ub =
+        ub === nothing ||
+        all(p -> isnan(p[1]) || p[1] < nextfloat(p[2]), zip(proposed_val, ub))
+    return satisfies_lb && satisfies_ub
 end
 function satisfies_constraints(
     lb::Union{Nothing,NamedTuple},

--- a/src/optimisation/init.jl
+++ b/src/optimisation/init.jl
@@ -80,7 +80,7 @@ function satisfies_constraints(
     proposed_val::AbstractArray{<:ForwardDiff.Dual},
     dist::Union{MultivariateDistribution,MatrixDistribution},
 )
-    return satisfies_constraints(lb, ub, ForwardDiff.value.(proposed_val), dist)
+    return satisfies_constraints(_prevfloat.(lb), _nextfloat.(ub), proposed_val, dist)
 end
 function satisfies_constraints(
     lb::Union{Nothing,NamedTuple},

--- a/src/optimisation/init.jl
+++ b/src/optimisation/init.jl
@@ -49,8 +49,10 @@ function satisfies_constraints(
 end
 # x may be nothing so we need to take care of that
 _prevfloat(x::AbstractFloat) = prevfloat(x)
+_prevfloat(x::AbstractArray{<:AbstractFloat}) = map(prevfloat, x)
 _prevfloat(x) = x
 _nextfloat(x::AbstractFloat) = nextfloat(x)
+_nextfloat(x::AbstractArray{<:AbstractFloat}) = map(nextfloat, x)
 _nextfloat(x) = x
 function satisfies_constraints(
     lb::Union{Nothing,Real},
@@ -80,7 +82,7 @@ function satisfies_constraints(
     proposed_val::AbstractArray{<:ForwardDiff.Dual},
     dist::Union{MultivariateDistribution,MatrixDistribution},
 )
-    return satisfies_constraints(_prevfloat.(lb), _nextfloat.(ub), proposed_val, dist)
+    return satisfies_constraints(_prevfloat(lb), _nextfloat(ub), proposed_val, dist)
 end
 function satisfies_constraints(
     lb::Union{Nothing,NamedTuple},

--- a/src/optimisation/init.jl
+++ b/src/optimisation/init.jl
@@ -47,15 +47,20 @@ function satisfies_constraints(
     satisfies_ub = ub === nothing || proposed_val <= ub
     return isnan(proposed_val) || (satisfies_lb && satisfies_ub)
 end
+# x may be nothing so we need to take care of that
+_prevfloat(x::AbstractFloat) = prevfloat(x)
+_prevfloat(x) = x
+_nextfloat(x::AbstractFloat) = nextfloat(x)
+_nextfloat(x) = x
 function satisfies_constraints(
     lb::Union{Nothing,Real},
     ub::Union{Nothing,Real},
     proposed_val::ForwardDiff.Dual,
     dist::UnivariateDistribution,
 )
-    # This overload is needed because ForwardDiff.Dual(2.0, 1.0) > 2.0 returns true, even
-    # though the primal value is within the constraints.
-    return satisfies_constraints(lb, ub, ForwardDiff.value(proposed_val), dist)
+    # The prevfloat/nextfloat is needed because ForwardDiff.Dual(2.0, 1.0) > 2.0 returns
+    # true, even though the primal value is within the constraints.
+    return satisfies_constraints(_prevfloat(lb), _nextfloat(ub), proposed_val, dist)
 end
 function satisfies_constraints(
     lb::Union{Nothing,AbstractArray{<:Real}},


### PR DESCRIPTION
Apparently this is no good since it's not exported and also messes with higher-order differentiation. I think this is semantically equivalent but truthfully I haven't traced all code paths