### PR TITLE
Fix := statements with MH

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 0.43.7
+
+Fixes an issue where sampling with `MH()` in v0.43 would not include `x := expr` results in the chain.
+
 # 0.43.6
 
 Internal change to avoid using ForwardDiff internals.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Turing"
 uuid = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-version = "0.43.6"
+version = "0.43.7"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/mcmc/mh.jl
+++ b/src/mcmc/mh.jl
@@ -285,7 +285,7 @@ function AbstractMCMC.step(
     # with OnlyAccsVarInfo:
     #    1.196674 seconds (18.51 M allocations: 722.256 MiB, 5.11% gc time)
     vi = DynamicPPL.VarInfo()
-    vi = DynamicPPL.setacc!!(vi, DynamicPPL.RawValueAccumulator(false))
+    vi = DynamicPPL.setacc!!(vi, DynamicPPL.RawValueAccumulator(true))
     vi = DynamicPPL.setacc!!(vi, MHLinkedValuesAccumulator())
     vi = DynamicPPL.setacc!!(vi, MHUnspecifiedPriorsAccumulator(spl.vns_with_proposal))
     _, vi = DynamicPPL.init!!(rng, model, vi, initial_params, spl.transform_strategy)
@@ -361,7 +361,7 @@ function AbstractMCMC.step(
 
     # Evaluate the model with a new proposal.
     new_vi = DynamicPPL.VarInfo()
-    new_vi = DynamicPPL.setacc!!(new_vi, DynamicPPL.RawValueAccumulator(false))
+    new_vi = DynamicPPL.setacc!!(new_vi, DynamicPPL.RawValueAccumulator(true))
     new_vi = DynamicPPL.setacc!!(new_vi, MHLinkedValuesAccumulator())
     new_vi = DynamicPPL.setacc!!(
         new_vi, MHUnspecifiedPriorsAccumulator(spl.vns_with_proposal)

--- a/test/mcmc/mh.jl
+++ b/test/mcmc/mh.jl
@@ -109,6 +109,18 @@ GKernel(variance, vn) = (vnt -> Normal(vnt[vn], sqrt(variance)))
         end
     end
 
+    @testset "chain includes := statements" begin
+        @model function f()
+            x ~ Normal()
+            y := x^2
+            return nothing
+        end
+        for spl in (MH(), MH(@varname(x) => Normal()), MH([1.0;;]))
+            chn = sample(f(), spl, 20)
+            @test chn[:y] == chn[:x] .^ 2
+        end
+    end
+
     @testset "info statements about proposals" begin
         @model function f()
             x = zeros(2)


### PR DESCRIPTION
The new MH sampler in v0.43 dropped `:=` statements. This patch fixes that.