### PR TITLE
Reexport other pointwise density functions

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 0.44.1
+
+Re-export `pointwise_logdensities` and `pointwise_prior_logdensities` from DynamicPPL.
+
 # 0.44.0
 
 ## Breaking changes

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Turing"
 uuid = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-version = "0.44"
+version = "0.44.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -92,18 +92,20 @@ even though [`Prior()`](@ref) is actually defined in the `Turing.Inference` modu
 
 Please see the [generated quantities](https://turinglang.org/docs/tutorials/usage-generated-quantities/) and [probability interface](https://turinglang.org/docs/tutorials/usage-probability-interface/) guides for more information.
 
-| Exported symbol            | Documentation                                                                                                                | Description                                             |
-|:-------------------------- |:---------------------------------------------------------------------------------------------------------------------------- |:------------------------------------------------------- |
-| `returned`                 | [`DynamicPPL.returned`](https://turinglang.org/DynamicPPL.jl/stable/api/#DynamicPPL.returned-Tuple%7BModel,%20NamedTuple%7D) | Calculate additional quantities defined in a model      |
-| `predict`                  | [`StatsAPI.predict`](https://turinglang.org/DynamicPPL.jl/stable/api/#Predicting)                                            | Generate samples from posterior predictive distribution |
-| `pointwise_loglikelihoods` | [`DynamicPPL.pointwise_loglikelihoods`](@extref)                                                                             | Compute log likelihoods for each sample in a chain      |
-| `logprior`                 | [`DynamicPPL.logprior`](@extref)                                                                                             | Compute log prior probability                           |
-| `logjoint`                 | [`DynamicPPL.logjoint`](@extref)                                                                                             | Compute log joint probability                           |
-| `condition`                | [`AbstractPPL.condition`](@extref)                                                                                           | Condition a model on data                               |
-| `decondition`              | [`AbstractPPL.decondition`](@extref)                                                                                         | Remove conditioning on data                             |
-| `conditioned`              | [`DynamicPPL.conditioned`](@extref)                                                                                          | Return the conditioned values of a model                |
-| `fix`                      | [`DynamicPPL.fix`](@extref)                                                                                                  | Fix the value of a variable                             |
-| `unfix`                    | [`DynamicPPL.unfix`](@extref)                                                                                                | Unfix the value of a variable                           |
+| Exported symbol                | Documentation                                                                                                                | Description                                                                  |
+|:------------------------------ |:---------------------------------------------------------------------------------------------------------------------------- |:---------------------------------------------------------------------------- |
+| `returned`                     | [`DynamicPPL.returned`](https://turinglang.org/DynamicPPL.jl/stable/api/#DynamicPPL.returned-Tuple%7BModel,%20NamedTuple%7D) | Calculate additional quantities defined in a model                           |
+| `predict`                      | [`StatsAPI.predict`](https://turinglang.org/DynamicPPL.jl/stable/api/#Predicting)                                            | Generate samples from posterior predictive distribution                      |
+| `pointwise_logdensities`       | [`DynamicPPL.pointwise_logdensities`](@extref)                                                                               | Compute log densities (both prior and likelihood) for each sample in a chain |
+| `pointwise_loglikelihoods`     | [`DynamicPPL.pointwise_loglikelihoods`](@extref)                                                                             | Compute log likelihoods for each sample in a chain                           |
+| `pointwise_prior_logdensities` | [`DynamicPPL.pointwise_prior_logdensities`](@extref)                                                                         | Compute log priors for each sample in a chain                                |
+| `logprior`                     | [`DynamicPPL.logprior`](@extref)                                                                                             | Compute log prior probability                                                |
+| `logjoint`                     | [`DynamicPPL.logjoint`](@extref)                                                                                             | Compute log joint probability                                                |
+| `condition`                    | [`AbstractPPL.condition`](@extref)                                                                                           | Condition a model on data                                                    |
+| `decondition`                  | [`AbstractPPL.decondition`](@extref)                                                                                         | Remove conditioning on data                                                  |
+| `conditioned`                  | [`DynamicPPL.conditioned`](@extref)                                                                                          | Return the conditioned values of a model                                     |
+| `fix`                          | [`DynamicPPL.fix`](@extref)                                                                                                  | Fix the value of a variable                                                  |
+| `unfix`                        | [`DynamicPPL.unfix`](@extref)                                                                                                | Unfix the value of a variable                                                |
 
 ### Initialisation strategies
 

--- a/src/Turing.jl
+++ b/src/Turing.jl
@@ -57,7 +57,9 @@ using .Optimisation
 using DynamicPPL:
     @model,
     @varname,
+    pointwise_logdensities,
     pointwise_loglikelihoods,
+    pointwise_prior_logdensities,
     generated_quantities,
     returned,
     logprior,
@@ -155,7 +157,9 @@ export
     predict,
     # Querying model probabilities - DynamicPPL
     returned,
+    pointwise_logdensities,
     pointwise_loglikelihoods,
+    pointwise_prior_logdensities,
     logprior,
     loglikelihood,
     logjoint,


### PR DESCRIPTION
Although arguably `pointwise_loglikelihoods` is the most important one, it seems a bit weird that we don't re-export the other two as well.