### PR TITLE
Fix failing kwargs in VI

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 0.44.2
+
+Fix a bug in v0.44 where extra keyword arguments passed to `vi` (e.g. `callback`) would cause Turing to error.
+
 # 0.44.1
 
 Re-export `pointwise_logdensities` and `pointwise_prior_logdensities` from DynamicPPL.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Turing"
 uuid = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-version = "0.44.1"
+version = "0.44.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/variational/Variational.jl
+++ b/src/variational/Variational.jl
@@ -85,6 +85,7 @@ function q_initialize_scale(
     num_samples::Int=10,
     num_max_trials::Int=10,
     reduce_factor::Real=one(eltype(scale)) / 2,
+    kwargs..., # must take extra kwargs even if they are ignored
 )
     num_max_trials > 0 || error("num_max_trials must be a positive integer")
     n_trial = 0

--- a/test/variational/vi.jl
+++ b/test/variational/vi.jl
@@ -185,6 +185,26 @@ begin
         vi(model, q_meanfield_gaussian, 100; fix_transforms=true)
         @test counter[] < 100
     end
+
+    @testset "with callbacks" begin
+        @model function f()
+            x ~ Normal()
+            return y ~ Normal(x)
+        end
+        function callback(; iteration, averaged_params, restructure, state, kwargs...)
+            if mod(iteration, 10) == 1
+                q_avg = restructure(averaged_params)
+                obj = AdvancedVI.RepGradELBO(128) # 128 samples for ELBO estimation
+                elbo_avg = -estimate_objective(obj, q_avg, state.prob)
+                (elbo_avg=elbo_avg,)
+            else
+                nothing
+            end
+        end
+        result = vi(f(), q_meanfield_gaussian, 100; callback=callback)
+        @test result isa Turing.Variational.VIResult
+        @test any(i -> hasproperty(i, :elbo_avg), result.info)
+    end
 end
 
 end


### PR DESCRIPTION
Running VI with extra kwargs would cause errors. This fixes it.