### PR TITLE
Fix NUTS docstring formatting to match HMC and HMCDA style

### DIFF
--- a/src/mcmc/hmc.jl
+++ b/src/mcmc/hmc.jl
@@ -320,25 +320,25 @@ function HMCDA(
 end
 
 """
-    NUTS(n_adapts::Int, δ::Float64; max_depth::Int=10, Δ_max::Float64=1000.0, init_ϵ::Float64=0.0; adtype::ADTypes.AbstractADType=AutoForwardDiff()
+    NUTS(n_adapts::Int, δ::Float64; max_depth::Int=10, Δ_max::Float64=1000.0, init_ϵ::Float64=0.0, adtype::ADTypes.AbstractADType=AutoForwardDiff())
 
 No-U-Turn Sampler (NUTS) sampler.
 
-Usage:
+# Usage
 
 ```julia
 NUTS()            # Use default NUTS configuration.
 NUTS(1000, 0.65)  # Use 1000 adaption steps, and target accept ratio 0.65.
 ```
 
-Arguments:
+# Arguments
 
-- `n_adapts::Int` : The number of samples to use with adaptation.
-- `δ::Float64` : Target acceptance rate for dual averaging.
-- `max_depth::Int` : Maximum doubling tree depth.
-- `Δ_max::Float64` : Maximum divergence during doubling tree.
-- `init_ϵ::Float64` : Initial step size; 0 means automatically searching using a heuristic procedure.
-- `adtype::ADTypes.AbstractADType` : The automatic differentiation (AD) backend.
+- `n_adapts::Int`: The number of samples to use with adaptation.
+- `δ::Float64`: Target acceptance rate for dual averaging.
+- `max_depth::Int`: Maximum doubling tree depth.
+- `Δ_max::Float64`: Maximum divergence during doubling tree.
+- `init_ϵ::Float64`: Initial step size; 0 means automatically searching using a heuristic procedure.
+- `adtype::ADTypes.AbstractADType`: The automatic differentiation (AD) backend.
     If not specified, `ForwardDiff` is used, with its `chunksize` automatically determined.
 
 """


### PR DESCRIPTION
### What does this PR do?

This PR addresses the inconsistency in the docstring formatting for NUTS compared to HMC and HMCDA in the same file.

### Changes made

Added header comments (e.g., # Usage, # Arguments) to the corresponding sections for better structure.
Fixed formatting by removing extra spaces before colons in argument lists (e.g., changed `n_adapts::Int` : to `n_adapts::Int`:).
Corrected a missing closing parenthesis in the method signature in the docstring header.
Ensured the style aligns with the formatting used in the HMC and HMCDA docstrings making everything consistent.

### Why?

Consistent docstring formatting improves the readability of the API documentation and aligns it with Julia’s documentation standards used throughout the file.