### PR TITLE
adding info_sampler_output method to track divergences

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 # 0.44.4
 
-Add warning message when there are divergent transitions with `HMC`, `NUTS` or `HMCDA`. 
+Add post-sampling warning message when there are divergent transitions with `HMC`, `NUTS` or `HMCDA`.
 
 # 0.44.3
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 0.44.4
+
+Add warning message when there are divergent transitions with `HMC`, `NUTS` or `HMCDA`. 
+
 # 0.44.3
 
 Add compatibility with SciMLBase v3.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Turing"
 uuid = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-version = "0.44.3"
+version = "0.44.4"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/mcmc/abstractmcmc.jl
+++ b/src/mcmc/abstractmcmc.jl
@@ -69,6 +69,19 @@ function find_initial_params_ldf(
     )
 end
 
+
+"""
+    info_sampler_output(chain::MCMCChains.Chains, sampler::AbstractSampler)
+
+Returns the number of divergent transitions in the chain.
+"""
+function info_sampler_output(chain::MCMCChains.Chains, sampler::AbstractSampler)
+    return nothing
+end
+function info_sampler_output(chain, sampler::AbstractSampler)
+    return nothing
+end
+
 #########################################
 # Default definitions for the interface #
 #########################################
@@ -76,7 +89,9 @@ end
 function AbstractMCMC.sample(
     model::DynamicPPL.Model, spl::AbstractSampler, N::Integer; kwargs...
 )
-    return AbstractMCMC.sample(Random.default_rng(), model, spl, N; kwargs...)
+    chain =  AbstractMCMC.sample(Random.default_rng(), model, spl, N; kwargs...)
+    info_sampler_output(chain, spl)
+    return chain
 end
 
 function AbstractMCMC.sample(
@@ -108,10 +123,12 @@ function AbstractMCMC.sample(
     N::Integer,
     n_chains::Integer;
     kwargs...,
-)
-    return AbstractMCMC.sample(
+)   
+    chain = AbstractMCMC.sample(
         Random.default_rng(), model, alg, ensemble, N, n_chains; kwargs...
     )
+    info_sampler_output(chain, alg)
+    return chain    
 end
 
 function AbstractMCMC.sample(

--- a/src/mcmc/abstractmcmc.jl
+++ b/src/mcmc/abstractmcmc.jl
@@ -69,7 +69,6 @@ function find_initial_params_ldf(
     )
 end
 
-
 """
     info_sampler_output(chain::MCMCChains.Chains, sampler::AbstractSampler)
 
@@ -86,7 +85,7 @@ end
 function AbstractMCMC.sample(
     model::DynamicPPL.Model, spl::AbstractSampler, N::Integer; kwargs...
 )
-    chain =  AbstractMCMC.sample(Random.default_rng(), model, spl, N; kwargs...)
+    chain = AbstractMCMC.sample(Random.default_rng(), model, spl, N; kwargs...)
     info_sampler_output(chain, spl)
     return chain
 end
@@ -120,12 +119,12 @@ function AbstractMCMC.sample(
     N::Integer,
     n_chains::Integer;
     kwargs...,
-)   
+)
     chain = AbstractMCMC.sample(
         Random.default_rng(), model, alg, ensemble, N, n_chains; kwargs...
     )
     info_sampler_output(chain, alg)
-    return chain    
+    return chain
 end
 
 function AbstractMCMC.sample(

--- a/src/mcmc/abstractmcmc.jl
+++ b/src/mcmc/abstractmcmc.jl
@@ -73,11 +73,8 @@ end
 """
     info_sampler_output(chain::MCMCChains.Chains, sampler::AbstractSampler)
 
-Returns the number of divergent transitions in the chain.
+A post-sampling hook that can e.g. print info about the results of sampling.
 """
-function info_sampler_output(chain::MCMCChains.Chains, sampler::AbstractSampler)
-    return nothing
-end
 function info_sampler_output(chain, sampler::AbstractSampler)
     return nothing
 end

--- a/src/mcmc/abstractmcmc.jl
+++ b/src/mcmc/abstractmcmc.jl
@@ -70,11 +70,11 @@ function find_initial_params_ldf(
 end
 
 """
-    info_sampler_output(chain::MCMCChains.Chains, sampler::AbstractSampler)
+    post_sample_hook(chain::MCMCChains.Chains, sampler::AbstractSampler)
 
 A post-sampling hook that can e.g. print info about the results of sampling.
 """
-function info_sampler_output(chain, sampler::AbstractSampler)
+function post_sample_hook(chain, sampler::AbstractSampler)
     return nothing
 end
 
@@ -86,7 +86,7 @@ function AbstractMCMC.sample(
     model::DynamicPPL.Model, spl::AbstractSampler, N::Integer; kwargs...
 )
     chain = AbstractMCMC.sample(Random.default_rng(), model, spl, N; kwargs...)
-    info_sampler_output(chain, spl)
+    post_sample_hook(chain, spl)
     return chain
 end
 
@@ -123,7 +123,7 @@ function AbstractMCMC.sample(
     chain = AbstractMCMC.sample(
         Random.default_rng(), model, alg, ensemble, N, n_chains; kwargs...
     )
-    info_sampler_output(chain, alg)
+    post_sample_hook(chain, alg)
     return chain
 end
 

--- a/src/mcmc/hmc.jl
+++ b/src/mcmc/hmc.jl
@@ -4,7 +4,7 @@ abstract type AdaptiveHamiltonian <: Hamiltonian end
 Turing.allow_discrete_variables(sampler::Hamiltonian) = false
 
 """
-    info_sampler_output(chain::MCMCChains.Chains, sampler::AbstractSampler)
+    info_sampler_output(chain::MCMCChains.Chains, sampler::Hamiltonian)
 
 Returns the number of divergent transitions in the chain.
 """ 

--- a/src/mcmc/hmc.jl
+++ b/src/mcmc/hmc.jl
@@ -11,7 +11,7 @@ Returns the number of divergent transitions in the chain.
 function info_sampler_output(chain::MCMCChains.Chains, sampler::Hamiltonian)
     n_divergent = sum(skipmissing(vec(chain[:numerical_error])))    
     if n_divergent > 0
-        @warn "number of divergent transitions: $n_divergent; consider increasing `target_accept` or reparameterising your model"
+    @warn "Number of divergent transitions: $n_divergent. Consider reparameterising your model or using a smaller step size. For adaptive samplers such as NUTS and HMCDA, consider increasing `target_accept`."
     end   
     return nothing
 end

--- a/src/mcmc/hmc.jl
+++ b/src/mcmc/hmc.jl
@@ -4,11 +4,11 @@ abstract type AdaptiveHamiltonian <: Hamiltonian end
 Turing.allow_discrete_variables(sampler::Hamiltonian) = false
 
 """
-    info_sampler_output(chain::MCMCChains.Chains, sampler::Hamiltonian)
+    post_sample_hook(chain::MCMCChains.Chains, sampler::Hamiltonian)
 
-Returns the number of divergent transitions in the chain.
+Emit a warning message if there are divergent transitions in the chain.
 """
-function info_sampler_output(chain::MCMCChains.Chains, sampler::Hamiltonian)
+function post_sample_hook(chain::MCMCChains.Chains, ::Hamiltonian)
     n_divergent = sum(skipmissing(vec(chain[:numerical_error])))
     if n_divergent > 0
         @warn "Number of divergent transitions: $n_divergent. Consider reparameterising your model or using a smaller step size. For adaptive samplers such as NUTS and HMCDA, consider increasing `target_accept`."

--- a/src/mcmc/hmc.jl
+++ b/src/mcmc/hmc.jl
@@ -3,6 +3,11 @@ abstract type StaticHamiltonian <: Hamiltonian end
 abstract type AdaptiveHamiltonian <: Hamiltonian end
 Turing.allow_discrete_variables(sampler::Hamiltonian) = false
 
+"""
+    info_sampler_output(chain::MCMCChains.Chains, sampler::AbstractSampler)
+
+Returns the number of divergent transitions in the chain.
+""" 
 function info_sampler_output(chain::MCMCChains.Chains, sampler::Hamiltonian)
     n_divergent = sum(skipmissing(vec(chain[:numerical_error])))    
     if n_divergent > 0

--- a/src/mcmc/hmc.jl
+++ b/src/mcmc/hmc.jl
@@ -3,6 +3,14 @@ abstract type StaticHamiltonian <: Hamiltonian end
 abstract type AdaptiveHamiltonian <: Hamiltonian end
 Turing.allow_discrete_variables(sampler::Hamiltonian) = false
 
+function info_sampler_output(chain::MCMCChains.Chains, sampler::Hamiltonian)
+    n_divergent = sum(skipmissing(vec(chain[:numerical_error])))    
+    if n_divergent > 0
+        @warn "number of divergent transitions: $n_divergent; consider increasing `target_accept` or reparameterising your model"
+    end   
+    return nothing
+end
+
 ###
 ### Sampler states
 ###

--- a/src/mcmc/hmc.jl
+++ b/src/mcmc/hmc.jl
@@ -3,19 +3,6 @@ abstract type StaticHamiltonian <: Hamiltonian end
 abstract type AdaptiveHamiltonian <: Hamiltonian end
 Turing.allow_discrete_variables(sampler::Hamiltonian) = false
 
-"""
-    post_sample_hook(chain::MCMCChains.Chains, sampler::Hamiltonian)
-
-Emit a warning message if there are divergent transitions in the chain.
-"""
-function post_sample_hook(chain::MCMCChains.Chains, ::Hamiltonian)
-    n_divergent = sum(skipmissing(vec(chain[:numerical_error])))
-    if n_divergent > 0
-        @warn "Number of divergent transitions: $n_divergent. Consider reparameterising your model or using a smaller step size. For adaptive samplers such as NUTS and HMCDA, consider increasing `target_accept`."
-    end
-    return nothing
-end
-
 ###
 ### Sampler states
 ###
@@ -472,6 +459,19 @@ end
 
 function AHMCAdaptor(::Hamiltonian, ::AHMC.AbstractMetric, nadapts::Int; kwargs...)
     return AHMC.Adaptation.NoAdaptation()
+end
+
+"""
+    post_sample_hook(chain::MCMCChains.Chains, sampler::Union{HMC,NUTS,HMCDA})
+
+Emit a warning message if there are divergent transitions in the chain.
+"""
+function post_sample_hook(chain::MCMCChains.Chains, ::Union{HMC,NUTS,HMCDA})
+    n_divergent = round(Int, sum(skipmissing(vec(chain[:numerical_error]))))
+    if n_divergent > 0
+        @warn "There were $n_divergent divergent transitions. Consider reparameterising your model or using a smaller step size. For adaptive samplers such as NUTS and HMCDA, consider increasing `target_accept`."
+    end
+    return nothing
 end
 
 ####

--- a/src/mcmc/hmc.jl
+++ b/src/mcmc/hmc.jl
@@ -7,12 +7,12 @@ Turing.allow_discrete_variables(sampler::Hamiltonian) = false
     info_sampler_output(chain::MCMCChains.Chains, sampler::Hamiltonian)
 
 Returns the number of divergent transitions in the chain.
-""" 
+"""
 function info_sampler_output(chain::MCMCChains.Chains, sampler::Hamiltonian)
-    n_divergent = sum(skipmissing(vec(chain[:numerical_error])))    
+    n_divergent = sum(skipmissing(vec(chain[:numerical_error])))
     if n_divergent > 0
-    @warn "Number of divergent transitions: $n_divergent. Consider reparameterising your model or using a smaller step size. For adaptive samplers such as NUTS and HMCDA, consider increasing `target_accept`."
-    end   
+        @warn "Number of divergent transitions: $n_divergent. Consider reparameterising your model or using a smaller step size. For adaptive samplers such as NUTS and HMCDA, consider increasing `target_accept`."
+    end
     return nothing
 end
 

--- a/test/mcmc/abstractmcmc.jl
+++ b/test/mcmc/abstractmcmc.jl
@@ -218,7 +218,7 @@ end
     end
 end
 
-@testset "info_sampler_output" begin
+@testset "post_sample_hook" begin
     @model function f()
         x ~ Normal()
         if x < 0

--- a/test/mcmc/abstractmcmc.jl
+++ b/test/mcmc/abstractmcmc.jl
@@ -220,20 +220,18 @@ end
 
 @testset "info_sampler_output" begin
     @model function f()
-    x ~ Normal()
+        x ~ Normal()
         if x < 0
             @addlogprob! -Inf
-            return
+            return nothing
         end
     end
     warn_message = r"Number of divergent transitions: \d+"
-    for spl in [
-                NUTS(), 
-                HMC(0.1, 5),
-                HMCDA(200, 0.65, 0.3)
-            ]
-        @test_logs min_level=Logging.Warn (:warn, warn_message) sample(f(), spl, 1000),
-        @test_logs min_level=Logging.Warn (:warn, warn_message) sample(f(), spl, MCMCThreads(),1000, 2)
+    for spl in [NUTS(), HMC(0.1, 5), HMCDA(200, 0.65, 0.3)]
+        @test_logs min_level = Logging.Warn (:warn, warn_message) sample(f(), spl, 1000),
+        @test_logs min_level = Logging.Warn (:warn, warn_message) sample(
+            f(), spl, MCMCThreads(), 1000, 2
+        )
     end
 end
 

--- a/test/mcmc/abstractmcmc.jl
+++ b/test/mcmc/abstractmcmc.jl
@@ -6,6 +6,7 @@ using LogDensityProblems: LogDensityProblems
 using Random: AbstractRNG, Random, Xoshiro
 using Test: @test, @testset, @test_throws, @test_logs
 using Turing
+using Logging
 
 @testset "Disabling check_model" begin
     # Set up a model for which check_model errors.
@@ -215,6 +216,21 @@ end
             end
         end
     end
+end
+
+@testset "info_sampler_output" begin
+    @model function f()
+    x ~ Normal()
+        if x < 0
+            @addlogprob! -Inf
+            return
+        end
+    end
+
+    @test_logs min_level=Logging.Warn (:warn, r"consider increasing `target_accept` or reparameterising your model") sample(f(), NUTS(), 1000; progress=false)
+    @test_logs min_level=Logging.Warn (:warn, r"consider increasing `target_accept` or reparameterising your model") sample(f(), NUTS(), MCMCThreads(),1000, 2; progress=false)
+    @test_logs min_level=Logging.Warn (:warn, r"consider increasing `target_accept` or reparameterising your model") sample(f(), HMC(0.1, 5), 1000; progress=false)
+    @test_logs min_level=Logging.Warn (:warn, r"consider increasing `target_accept` or reparameterising your model") sample(f(), HMC(0.1, 5), MCMCThreads(),1000, 2; progress=false)
 end
 
 end # module

--- a/test/mcmc/abstractmcmc.jl
+++ b/test/mcmc/abstractmcmc.jl
@@ -226,10 +226,12 @@ end
             return nothing
         end
     end
-    warn_message = r"Number of divergent transitions: \d+"
+    warn_message = r"There were \d+ divergent transitions"
     for spl in [NUTS(), HMC(0.1, 5), HMCDA(200, 0.65, 0.3)]
-        @test_logs min_level = Logging.Warn (:warn, warn_message) sample(f(), spl, 1000),
-        @test_logs min_level = Logging.Warn (:warn, warn_message) sample(
+        @test_logs min_level = Logging.Warn match_mode = :any (:warn, warn_message) sample(
+            f(), spl, 1000
+        ),
+        @test_logs min_level = Logging.Warn match_mode = :any (:warn, warn_message) sample(
             f(), spl, MCMCThreads(), 1000, 2
         )
     end

--- a/test/mcmc/abstractmcmc.jl
+++ b/test/mcmc/abstractmcmc.jl
@@ -231,6 +231,8 @@ end
     @test_logs min_level=Logging.Warn (:warn, r"consider increasing `target_accept` or reparameterising your model") sample(f(), NUTS(), MCMCThreads(),1000, 2; progress=false)
     @test_logs min_level=Logging.Warn (:warn, r"consider increasing `target_accept` or reparameterising your model") sample(f(), HMC(0.1, 5), 1000; progress=false)
     @test_logs min_level=Logging.Warn (:warn, r"consider increasing `target_accept` or reparameterising your model") sample(f(), HMC(0.1, 5), MCMCThreads(),1000, 2; progress=false)
+    @test_logs min_level=Logging.Warn (:warn, r"consider increasing `target_accept` or reparameterising your model") sample(f(), HMCDA(200, 0.65, 0.3), 1000; progress=false)
+    @test_logs min_level=Logging.Warn (:warn, r"consider increasing `target_accept` or reparameterising your model") sample(f(), HMCDA(200, 0.65, 0.3), MCMCThreads(),1000, 2; progress=false)
 end
 
 end # module

--- a/test/mcmc/abstractmcmc.jl
+++ b/test/mcmc/abstractmcmc.jl
@@ -226,13 +226,15 @@ end
             return
         end
     end
-
-    @test_logs min_level=Logging.Warn (:warn, r"consider increasing `target_accept` or reparameterising your model") sample(f(), NUTS(), 1000; progress=false)
-    @test_logs min_level=Logging.Warn (:warn, r"consider increasing `target_accept` or reparameterising your model") sample(f(), NUTS(), MCMCThreads(),1000, 2; progress=false)
-    @test_logs min_level=Logging.Warn (:warn, r"consider increasing `target_accept` or reparameterising your model") sample(f(), HMC(0.1, 5), 1000; progress=false)
-    @test_logs min_level=Logging.Warn (:warn, r"consider increasing `target_accept` or reparameterising your model") sample(f(), HMC(0.1, 5), MCMCThreads(),1000, 2; progress=false)
-    @test_logs min_level=Logging.Warn (:warn, r"consider increasing `target_accept` or reparameterising your model") sample(f(), HMCDA(200, 0.65, 0.3), 1000; progress=false)
-    @test_logs min_level=Logging.Warn (:warn, r"consider increasing `target_accept` or reparameterising your model") sample(f(), HMCDA(200, 0.65, 0.3), MCMCThreads(),1000, 2; progress=false)
+    warn_message = r"consider increasing `target_accept` or reparameterising your model"
+    for spl in [
+                NUTS(), 
+                HMC(0.1, 5),
+                HMCDA(200, 0.65, 0.3)
+            ]
+        @test_logs min_level=Logging.Warn (:warn, warn_message) sample(f(), spl, 1000; progress=false),
+        @test_logs min_level=Logging.Warn (:warn, warn_message) sample(f(), spl, MCMCThreads(),1000, 2; progress=false)
+    end
 end
 
 end # module

--- a/test/mcmc/abstractmcmc.jl
+++ b/test/mcmc/abstractmcmc.jl
@@ -226,14 +226,14 @@ end
             return
         end
     end
-    warn_message = r"consider increasing `target_accept` or reparameterising your model"
+    warn_message = r"Number of divergent transitions: \d+"
     for spl in [
                 NUTS(), 
                 HMC(0.1, 5),
                 HMCDA(200, 0.65, 0.3)
             ]
-        @test_logs min_level=Logging.Warn (:warn, warn_message) sample(f(), spl, 1000; progress=false),
-        @test_logs min_level=Logging.Warn (:warn, warn_message) sample(f(), spl, MCMCThreads(),1000, 2; progress=false)
+        @test_logs min_level=Logging.Warn (:warn, warn_message) sample(f(), spl, 1000),
+        @test_logs min_level=Logging.Warn (:warn, warn_message) sample(f(), spl, MCMCThreads(),1000, 2)
     end
 end
 


### PR DESCRIPTION
Hello! 

Following some discussion with @penelopeysm on slack, I'm making a PR that adds a method to warn if there are any divergences when using a Hamiltonian sampler. 

I've added a method to `src/mcmc/hmc.jl` which just warns if there are any divergences after sampling. I've also added some fallback methods to `src/mcmc/abstractmcmc.jl` that catch non-Hamiltonian sampler or cases where the chain is not an MCMCChains object.  I separated them to avoid errors as `Hamiltonian` is not defined until `hmc.jl` is loaded in `src/mcmc/inference.jl`. But I could add all methods to the `hmc.jl` file if thats preferred. 

I've added a few tests to `test/mcmc/abstractmcmc.jl` that detects the warning message for HMC and NUTs using serial and threading. I think this also makes sure warnings are not duplicated in the sampler calls. 


Thanks, 
Pavan