### PR TITLE
Add Enzyme to list of AD tools using native API

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 > [!IMPORTANT]                                                                                                                                                                                    
 > Turing.jl is an open-source project developed primarily by academic researchers within grant-funded institutions. As such, our capacity to triage issues and review contributions is necessarily limited.
 >
-> Turing.jl’s preferred automatic differentiation backends are ForwardDiff.jl and Mooncake.jl, which are supported natively through their public API. Additional backends are available through DifferentiationInterface.
+> Turing.jl’s preferred automatic differentiation backends are Enzyme.jl, ForwardDiff.jl and Mooncake.jl, which are supported natively through their public API. Additional backends are available through DifferentiationInterface.
 >
 > If you are interested in contributing to the TuringLang codebase, we recommend first submitting a feature proposal for review. The TuringLang team will indicate whether the proposal is accepted, after which implementation may proceed. Bug fixes and small changes are typically submitted directly as pull requests. Reviewer privileges are reserved for individuals with a sustained record of substantive contributions to TuringLang, or those explicitly invited by a team member.
 


### PR DESCRIPTION
Looks like this was missed in https://github.com/TuringLang/Turing.jl/pull/2816