### PR TITLE
Fix biased PG/CSMC posteriors: make `delete_retained!` mutate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,3 +98,4 @@ User-facing functions accept `initial_params` as a convenience. `_convert_initia
 
   - Non-breaking changes target `main`; breaking changes target the `breaking` branch.
   - Julia ≥ 1.10.8 required (see `[compat]` in `Project.toml`).
+  - `HISTORY.md`: one line for a bugfix or internal change. Only a breaking change or new feature earns more, and only what a user needs to act on it: what broke, and the old → new form. The mechanism and any measurements belong in the commit and the PR.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,6 @@
 # 0.46.1
 
-Fixed a bug, present since v0.41.0, that biased `PG` / `CSMC` posteriors for any model, whether sampled on its own or as a Gibbs component.
-On a two-state HMM with ten observations, `PG(16)` state marginals sat up to seven Monte Carlo standard errors away from the exact forward-backward values; they are now within one.
+Fixed a bug, present since v0.41.0, that biased `PG` / `CSMC` posteriors, whether sampled on their own or as a Gibbs component.
 
 # 0.46.0
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,10 @@
+# 0.46.1
+
+Fixed a bug that biased `PG` / `CSMC` posteriors.
+Particles forked from the reference kept replaying the retained trajectory instead of sampling afresh, so every descendant of the reference was a copy of it and the sweep lost the diversity that makes particle Gibbs valid.
+On a two-state HMM with ten observations, `PG(16)` state marginals sat up to seven Monte Carlo standard errors away from the exact forward-backward values; they are now within one.
+The bug dates back to v0.41.0, and affects any model sampled with `PG` / `CSMC`, whether on its own or as a Gibbs component.
+
 # 0.46.0
 
 ## Breaking changes

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,9 +1,7 @@
 # 0.46.1
 
-Fixed a bug that biased `PG` / `CSMC` posteriors.
-Particles forked from the reference kept replaying the retained trajectory instead of sampling afresh, so every descendant of the reference was a copy of it and the sweep lost the diversity that makes particle Gibbs valid.
+Fixed a bug, present since v0.41.0, that biased `PG` / `CSMC` posteriors for any model, whether sampled on its own or as a Gibbs component.
 On a two-state HMM with ten observations, `PG(16)` state marginals sat up to seven Monte Carlo standard errors away from the exact forward-backward values; they are now within one.
-The bug dates back to v0.41.0, and affects any model sampled with `PG` / `CSMC`, whether on its own or as a Gibbs component.
 
 # 0.46.0
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Turing"
 uuid = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-version = "0.46.0"
+version = "0.46.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/mcmc/particle_mcmc.jl
+++ b/src/mcmc/particle_mcmc.jl
@@ -66,11 +66,9 @@ function AdvancedPS.delete_retained!(trace::TracedModel)
     # This method is called if, during a CSMC update, we perform a resampling
     # and choose the reference particle as the trajectory to carry on from.
     # In such a case, we need to ensure that when we continue sampling (i.e.
-    # the next time we hit tilde_assume!!), we don't use the values in the
-    # reference particle but rather sample new values.
-    #
-    # This has to mutate: `AdvancedPS.fork` calls it for its side effect and discards the
-    # return value.
+    # the next time we hit tilde_assume!!), we don't use the values in the 
+    # reference particle but rather sample new values. This has to mutate:
+    # `AdvancedPS.fork` calls it for its side effect and discards the return value.
     trace.resample = true
     return trace
 end

--- a/src/mcmc/particle_mcmc.jl
+++ b/src/mcmc/particle_mcmc.jl
@@ -66,9 +66,13 @@ function AdvancedPS.delete_retained!(trace::TracedModel)
     # This method is called if, during a CSMC update, we perform a resampling
     # and choose the reference particle as the trajectory to carry on from.
     # In such a case, we need to ensure that when we continue sampling (i.e.
-    # the next time we hit tilde_assume!!), we don't use the values in the 
+    # the next time we hit tilde_assume!!), we don't use the values in the
     # reference particle but rather sample new values.
-    return TracedModel(trace.model, trace.varinfo, true, trace.fargs, trace.kwargs)
+    #
+    # This has to mutate: `AdvancedPS.fork` calls it for its side effect and discards the
+    # return value.
+    trace.resample = true
+    return trace
 end
 
 function AdvancedPS.reset_model(trace::TracedModel)

--- a/test/mcmc/particle_mcmc.jl
+++ b/test/mcmc/particle_mcmc.jl
@@ -169,44 +169,45 @@ end
     end
 
     @testset "conditional sweeps target the exact posterior" begin
-        # A reference particle that is not exactly the retained trajectory shows up here. The
-        # chain's stay probability is the other Gibbs component, so every `z[t]` is
-        # re-conditioned when `i` moves, and the observations are sharp enough to make the
-        # weights uneven; either is enough to bias the marginals. Measured over four seeds, a
-        # correct sweep keeps the mean error under 0.005, descendants that copy the reference
-        # rather than branching off it give 0.020 to 0.028, and a reference rebuilt by
-        # replaying random numbers instead of reusing values gives 0.017 to 0.022.
+        # Conditional SMC is invariant only if the reference is exactly the retained path, and
+        # this model is shaped so that either way of getting that wrong biases the marginals.
+        # The observations are sharp enough to keep the weights uneven, so resampling fires
+        # and a descendant of the reference that copies it rather than branching off shows up.
+        # The stay probability is the other Gibbs component, so a reference rebuilt by
+        # replaying random numbers -- `z[t] = z[t-1]` exactly when `u[t] < p` -- lands on a
+        # different path as soon as `i` moves. Mean absolute error over the marginals, across
+        # four seeds: under 0.005 for a correct sweep, 0.020 to 0.028 for the first failure,
+        # 0.017 to 0.022 for the second.
         #
-        # Enumerating all `2 * 2^8` configurations and weighting them by the model's own log
-        # density keeps the target out of the hands of a reimplementation.
+        # All `2 * 2^8` configurations enumerate the exact posterior, weighted by the model's
+        # own log density rather than by a reimplementation of it.
         means, sd, stay = (-1.0, 1.0), 0.8, (0.35, 0.65)
         @model function switching(y)
             i ~ Categorical(2)
+            p = stay[i]
+            transition = [p 1-p; 1-p p]
             z = Vector{Int}(undef, length(y))
             z[1] ~ Categorical([0.5, 0.5])
             y[1] ~ Normal(means[z[1]], sd)
             for t in 2:length(y)
-                p = stay[i]
-                z[t] ~ Categorical(z[t - 1] == 1 ? [p, 1 - p] : [1 - p, p])
+                z[t] ~ Categorical(transition[z[t - 1], :])
                 y[t] ~ Normal(means[z[t]], sd)
             end
         end
         y = [-0.9163, -2.4106, -2.1881, 0.3716, 1.3404, -1.2046, -1.8294, -0.3521]
         model = switching(y)
+        T = length(y)
 
-        confs = [
-            (i, collect(z)) for i in 1:2 for z in Iterators.product(fill(1:2, length(y))...)
-        ]
-        w = exp.([logjoint(model, (; i=i, z=z)) for (i, z) in confs])
-        w ./= sum(w)
-        exact = [
-            sum(w[k] * (confs[k][2][t] - 1) for k in eachindex(w)) for t in eachindex(y)
-        ]
+        paths = vec([collect(z) for z in Iterators.product(fill(1:2, T)...)])
+        logws = [logjoint(model, (; i=i, z=path)) for i in 1:2, path in paths]
+        ws = exp.(logws .- maximum(logws))
+        path_probs = vec(sum(ws; dims=1)) ./ sum(ws)   # posterior over paths, `i` summed out
+        exact = [path_probs' * [path[t] == 2 for path in paths] for t in 1:T]
 
         alg = Gibbs(@varname(i) => MH(), @varname(z) => CSMC(8))
         chn = sample(StableRNG(468), model, alg, 6_000)
-        zs = stack(collect(z) for z in chn[@varname(z)])
-        marginals = [mean(view(zs, t, :) .== 2) for t in eachindex(y)]
+        draws = stack(collect(z) for z in chn[@varname(z)])   # T x ndraws
+        marginals = [mean(==(2), view(draws, t, :)) for t in 1:T]
         @test mean(abs, marginals .- exact) < 0.01
     end
 

--- a/test/mcmc/particle_mcmc.jl
+++ b/test/mcmc/particle_mcmc.jl
@@ -3,7 +3,7 @@ module ParticleMCMCTests
 using ..Models: gdemo_default
 using ..SamplerTestUtils: test_chain_logp_metadata
 using AdvancedPS: ResampleWithESSThreshold, resample_systematic, resample_multinomial
-using Distributions: Bernoulli, Beta, Gamma, Normal, Poisson, sample
+using Distributions: Bernoulli, Beta, Categorical, Gamma, Normal, sample
 using FlexiChains: VNChain
 using Random: Random
 using StableRNGs: StableRNG
@@ -168,26 +168,46 @@ end
         @test length(unique(c[:s])) == 1
     end
 
-    @testset "conditional sweeps keep the population diverse" begin
-        # `k[t] ~ Poisson(1)` reweighted by `c^k[t]` is exactly `Poisson(c)`, since `e⁻¹cᵏ/k!`
-        # normalises to `e⁻ᶜcᵏ/k!`, and the reweighting is the only term carrying information:
-        # the sweep alone has to produce `E[k[t]] = c`. A descendant of the reference that
-        # replays the retained trajectory rather than branching off it is a copy of the
-        # reference, and the chain then over-visits that (high weight, hence high `k`)
-        # trajectory: `E[k]` used to come out between 2.4 and 2.7 across eight seeds, against
-        # within 0.05 of 2 once fixed.
-        c = 2.0
-        @model function tilted_poisson(T, c)
-            k = Vector{Int}(undef, T)
-            for t in 1:T
-                k[t] ~ Poisson(1.0)
-                @addlogprob! k[t] * log(c)
+    @testset "conditional sweeps target the exact posterior" begin
+        # A reference particle that is not exactly the retained trajectory shows up here. The
+        # chain's stay probability is the other Gibbs component, so every `z[t]` is
+        # re-conditioned when `i` moves, and the observations are sharp enough to make the
+        # weights uneven; either is enough to bias the marginals. Measured over four seeds, a
+        # correct sweep keeps the mean error under 0.005, descendants that copy the reference
+        # rather than branching off it give 0.020 to 0.028, and a reference rebuilt by
+        # replaying random numbers instead of reusing values gives 0.017 to 0.022.
+        #
+        # Enumerating all `2 * 2^8` configurations and weighting them by the model's own log
+        # density keeps the target out of the hands of a reimplementation.
+        means, sd, stay = (-1.0, 1.0), 0.8, (0.35, 0.65)
+        @model function switching(y)
+            i ~ Categorical(2)
+            z = Vector{Int}(undef, length(y))
+            z[1] ~ Categorical([0.5, 0.5])
+            y[1] ~ Normal(means[z[1]], sd)
+            for t in 2:length(y)
+                p = stay[i]
+                z[t] ~ Categorical(z[t - 1] == 1 ? [p, 1 - p] : [1 - p, p])
+                y[t] ~ Normal(means[z[t]], sd)
             end
         end
-        chn = sample(StableRNG(468), tilted_poisson(4, c), PG(16), 2_000)
-        ks = reduce(vcat, collect(chn[@varname(k)]))
-        @test mean(ks) ≈ c atol = 0.15
-        @test mean(iszero, ks) ≈ exp(-c) atol = 0.025
+        y = [-0.9163, -2.4106, -2.1881, 0.3716, 1.3404, -1.2046, -1.8294, -0.3521]
+        model = switching(y)
+
+        confs = [
+            (i, collect(z)) for i in 1:2 for z in Iterators.product(fill(1:2, length(y))...)
+        ]
+        w = exp.([logjoint(model, (; i=i, z=z)) for (i, z) in confs])
+        w ./= sum(w)
+        exact = [
+            sum(w[k] * (confs[k][2][t] - 1) for k in eachindex(w)) for t in eachindex(y)
+        ]
+
+        alg = Gibbs(@varname(i) => MH(), @varname(z) => CSMC(8))
+        chn = sample(StableRNG(468), model, alg, 6_000)
+        zs = stack(collect(z) for z in chn[@varname(z)])
+        marginals = [mean(view(zs, t, :) .== 2) for t in eachindex(y)]
+        @test mean(abs, marginals .- exact) < 0.01
     end
 
     @testset "addlogprob leads to reweighting" begin

--- a/test/mcmc/particle_mcmc.jl
+++ b/test/mcmc/particle_mcmc.jl
@@ -3,7 +3,7 @@ module ParticleMCMCTests
 using ..Models: gdemo_default
 using ..SamplerTestUtils: test_chain_logp_metadata
 using AdvancedPS: ResampleWithESSThreshold, resample_systematic, resample_multinomial
-using Distributions: Bernoulli, Beta, Gamma, Normal, sample
+using Distributions: Bernoulli, Beta, Gamma, Normal, Poisson, sample
 using FlexiChains: VNChain
 using Random: Random
 using StableRNGs: StableRNG
@@ -166,6 +166,28 @@ end
         c = sample(gdemo_default, PG(1), 1_000)
         @test length(unique(c[:m])) == 1
         @test length(unique(c[:s])) == 1
+    end
+
+    @testset "conditional sweeps keep the population diverse" begin
+        # `k[t] ~ Poisson(1)` reweighted by `c^k[t]` is exactly `Poisson(c)`, since `e⁻¹cᵏ/k!`
+        # normalises to `e⁻ᶜcᵏ/k!`, and the reweighting is the only term carrying information:
+        # the sweep alone has to produce `E[k[t]] = c`. A descendant of the reference that
+        # replays the retained trajectory rather than branching off it is a copy of the
+        # reference, and the chain then over-visits that (high weight, hence high `k`)
+        # trajectory: `E[k]` used to come out between 2.4 and 2.7 across eight seeds, against
+        # within 0.05 of 2 once fixed.
+        c = 2.0
+        @model function tilted_poisson(T, c)
+            k = Vector{Int}(undef, T)
+            for t in 1:T
+                k[t] ~ Poisson(1.0)
+                @addlogprob! k[t] * log(c)
+            end
+        end
+        chn = sample(StableRNG(468), tilted_poisson(4, c), PG(16), 2_000)
+        ks = reduce(vcat, collect(chn[@varname(k)]))
+        @test mean(ks) ≈ c atol = 0.15
+        @test mean(iszero, ks) ≈ exp(-c) atol = 0.025
     end
 
     @testset "addlogprob leads to reweighting" begin


### PR DESCRIPTION
### The bug

`PG` / `CSMC` posteriors have been biased since v0.41.0.

`AdvancedPS.fork` marks a fork of the reference particle as no longer retained by calling `delete_retained!` for its side effect and [discarding the return value](https://github.com/TuringLang/AdvancedPS.jl/blob/main/ext/AdvancedPSLibtaskExt.jl#L128). Turing's AdvancedPS integration returned a fresh `TracedModel` rather than mutating the one it was handed, so `resample` never became `true`.

That flag is what `tilde_assume!!` consults. With it still `false`, a descendant of the reference found every address present in its copy of the retained varinfo and took the `InitFromParams` branch, replaying the retained values instead of drawing new ones. Every offspring of the reference was therefore a duplicate of it rather than a branch off it, the population lost the diversity conditional SMC depends on, and the retained trajectory was over-selected.

The error is minor but statistically detectable. On a two-state HMM with ten observations, `PG(16)` state marginals over 20k draws sat up to 7.0 batch-means standard errors from the exact forward–backward values, and 1.3 after the fix. Under `Gibbs(:p => MH(), :z => CSMC(16))`, with `p` the transition probability, 6.4 and 7.4 standard errors on two seeds, and 1.7 after.

### The regression test

This PR adds a targeted regression test. The test reaches the sampler only through `sample`, so it applies to any PG/CSMC implementation, not to this one's internals. The model is a two-state hidden Markov chain of length $T = 8$ whose transition parameter is a second unknown:

$$
\begin{aligned}
i &\sim \mathrm{Categorical}(1/2, 1/2) \\
z_1 &\sim \mathrm{Categorical}(1/2, 1/2) \\
z_t &\sim \mathrm{Categorical}(P_{z_{t-1}, 1}, P_{z_{t-1}, 2}) \\
y_t &\sim \mathcal{N}(\mu_{z_t}, \sigma^2)
\end{aligned}
$$

for $t = 2, \dots, T$, where $P_{k,k} = p$ and $P_{k,3-k} = 1 - p$, so the chain stays put with probability $p = (0.35, 0.65)_i$. The emission means are $\mu = (-1, +1)$ with $\sigma = 0.8$. Sampled with `Gibbs(@varname(i) => MH(), @varname(z) => CSMC(8))`.

### Why this model

Conditional SMC leaves $p(z \mid i, y)$ invariant only if the reference particle is *exactly* the retained path $z^{(n)}$. There are two ways to lose that, and each ingredient of the model is there to expose one of them.

**Descendants that copy the reference.** After resampling, a child assigned the reference as its ancestor must continue with fresh randomness; if it keeps replaying the retained values it *is* the reference again, so the population over-counts one path and the weights stop representing the filtering distribution. Detecting this needs uneven weights, hence means separated by $2$ at $\sigma = 0.8$: putting a state in the wrong place costs $\approx (2/\sigma)^2/2 \approx 3$ nats, so the ESS gate triggers resampling at almost every step.

**A reference rebuilt by replaying uniforms.** Replay regenerates the path by pushing the stored uniforms back through the sampling map $z_t = g(u_t; \theta, z_{t-1})$, where $g$ is the inverse CDF of the latent's conditional — here $z_t = z_{t-1}$ iff $u_t < p$. That is faithful only while $p$ is fixed: once the MH step moves $i$, every $u_t$ between $p$ and $p'$ flips its step, and because $z_{t-1}$ is itself an argument of $g$, one flip changes what "stay" means for the rest of the path. Two design consequences follow, in the notes below.

### Exact target

The configuration space is finite, $2 \cdot 2^{8} = 512$ points, so the posterior is available in closed form — weighted by the model's own log density $\ell$, not by a reimplementation of it:

$$
\pi(i, z \mid y) = \frac{e^{\ell(i,z)}}{\sum_{i', z'} e^{\ell(i', z')}}
$$

and the state marginal it implies is

$$
\pi_t = \Pr(z_t = 2 \mid y) = \sum_{(i,z) : z_t = 2} \pi(i, z \mid y)
$$

The statistic over 6000 draws is the mean absolute error of the state marginals:

$$
D = \frac{1}{T}\sum_{t=1}^{T} \left| \hat{\pi}_t - \pi_t \right| < 0.01
$$

Averaging over $t$ rather than taking a maximum is deliberate: the Monte Carlo error at each $t$ has random sign and partly cancels, while both defects shift many marginals in the same direction and add up.

### Result

The same test body, three seeds, four implementations:

| Implementation | 468 | 469 | 470 | Verdict |
|-----------------------------------|--------|--------|--------|----------|
| main + this fix                   | 0.0053 | 0.0045 | 0.0024 | passes |
| main as-is (cloned reference)     | 0.0354 | 0.0264 | 0.0303 | bias detected |
| #2848 (replayed reference)        | 0.0219 | 0.0244 | 0.0227 | bias detected |
| #2853 (the rewrite)               | 0.0032 | 0.0022 | 0.0049 | passes |

Twelve runs, no misclassification. The worst passing value leaves 1.9x headroom under the threshold and the weakest bias signal sits 2.2x above it, with a factor of four between the two groups and nothing in between. The testset costs about 50 s.

That #2853 passes on the same tolerance is a check on the test rather than on that branch: it shares no code with the AdvancedPS-based implementation, so anything the test measures is a property of the sampler's output distribution.

### Design notes on the regression test 

*The parameter assigned to the `MH` Gibbs step has to be the transition.* The map $g$ involves only the parameters of the conditional being sampled. An emission parameter such as $\sigma$ appears in $p(y_t \mid z_t)$, a density that is evaluated and never sampled, so $g$ never sees it, and replay reproduces the retained path exactly — the reference comes out right by accident. Measured: with the parameter moved to the emission, the error on #2848 falls from 0.017–0.022 to 0.0028, which is noise.

*The latents have to be dependent.* With independent latents, the target factorises, $p(z \mid \theta, y) = \prod_t p(z_t \mid \theta, y_t)$, and the reference has no lineage to corrupt: its value at step $t$ enters only its own weight at step $t$. A reference regenerated under $p'$ is then one more prior-like draw among the $N - 1$ fresh ones, exchangeable with them, and the population is a plain importance sampler for the right target. In the Markov chain, the reference *is* a lineage — its descendants inherit the corrupted prefix at every resampling step — so the error compounds along $t$ and again across outer Gibbs iterations, which shows up as a shift in path functionals: the expected number of switches moves by $+0.06$ to $+0.14$.