### PR TITLE
Use internal_values_as_vector in emcee

### DIFF
--- a/src/mcmc/emcee.jl
+++ b/src/mcmc/emcee.jl
@@ -85,7 +85,11 @@ function AbstractMCMC.step(
         DynamicPPL.LogDensityFunction(model, getlogjoint_internal, linked_vi),
         map(vis) do vi
             vi = DynamicPPL.link!!(vi, model)
-            AMH.Transition(vi[:], DynamicPPL.getlogjoint_internal(vi), false)
+            AMH.Transition(
+                DynamicPPL.internal_values_as_vector(vi),
+                DynamicPPL.getlogjoint_internal(vi),
+                false,
+            )
         end,
     )
 


### PR DESCRIPTION
Removes the last `vi[:]` call in Turing, which unblocks deprecating it in DynamicPPL. See TuringLang/DynamicPPL.jl#1454 and the review discussion on TuringLang/DynamicPPL.jl#1451.