### PR TITLE
Forward step_warmup to external samplers

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,10 @@
+# 0.47.4
+
+`externalsampler` now forwards `AbstractMCMC.step_warmup` to the sampler it wraps, so an
+external sampler that adapts during warmup, such as
+`AdvancedMH.RobustAdaptiveMetropolis`, adapts instead of sampling with its initial
+proposal.
+
 # 0.47.3
 
 Random-measure distributions moved to the `TuringDistributionsExt` package extension. Replace

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Turing"
 uuid = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-version = "0.47.3"
+version = "0.47.4"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/mcmc/external_sampler.jl
+++ b/src/mcmc/external_sampler.jl
@@ -35,6 +35,10 @@ This section describes the latter.
   documented in AbstractMCMC.jl). This function must return a tuple of two elements, a
   'transition' and a 'state'.
 
+- `AbstractMCMC.step_warmup` (optional; documented in AbstractMCMC.jl). If your sampler
+  adapts, implement this and Turing.jl will route the `num_warmup` iterations through it.
+  Samplers that do not implement it fall back to `AbstractMCMC.step`, as before.
+
 - `AbstractMCMC.getparams(external_state)`: How to extract the parameters from the **state**
   returned by your sampler (i.e., the **second** return value of `step`). For your sampler
   to work with Turing.jl, this function should return a Vector of parameter values. Note that
@@ -128,6 +132,47 @@ struct TuringState{S,P<:AbstractVector,L<:DynamicPPL.LogDensityFunction}
 end
 
 function AbstractMCMC.step(
+    rng::Random.AbstractRNG, model::DynamicPPL.Model, sampler::ExternalSampler; kwargs...
+)
+    return _external_first_step(AbstractMCMC.step, rng, model, sampler; kwargs...)
+end
+
+function AbstractMCMC.step_warmup(
+    rng::Random.AbstractRNG, model::DynamicPPL.Model, sampler::ExternalSampler; kwargs...
+)
+    return _external_first_step(AbstractMCMC.step_warmup, rng, model, sampler; kwargs...)
+end
+
+function AbstractMCMC.step(
+    rng::Random.AbstractRNG,
+    model::DynamicPPL.Model,
+    sampler::ExternalSampler,
+    state::TuringState;
+    kwargs...,
+)
+    return _external_subsequent_step(
+        AbstractMCMC.step, rng, model, sampler, state; kwargs...
+    )
+end
+
+function AbstractMCMC.step_warmup(
+    rng::Random.AbstractRNG,
+    model::DynamicPPL.Model,
+    sampler::ExternalSampler,
+    state::TuringState;
+    kwargs...,
+)
+    return _external_subsequent_step(
+        AbstractMCMC.step_warmup, rng, model, sampler, state; kwargs...
+    )
+end
+
+# `step` and `step_warmup` differ only in which function is called on the wrapped
+# sampler, so the four methods above delegate to these two helpers. The
+# `step_function` argument should always be either `AbstractMCMC.step` or
+# `AbstractMCMC.step_warmup`.
+function _external_first_step(
+    step_function::F,
     rng::Random.AbstractRNG,
     model::DynamicPPL.Model,
     sampler_wrapper::ExternalSampler{unconstrained};
@@ -136,7 +181,7 @@ function AbstractMCMC.step(
     discard_sample=false,
     fix_transforms::Bool=false,
     kwargs...,
-) where {unconstrained}
+) where {F,unconstrained}
     sampler = sampler_wrapper.sampler
 
     # Construct LogDensityFunction
@@ -150,14 +195,14 @@ function AbstractMCMC.step(
     )
     x = find_initial_params_ldf(rng, f, initial_params)
 
-    # Then just call `AbstractMCMC.step` with the right arguments.
+    # Then just call the inner step function with the right arguments.
     _, state_inner = if initial_state === nothing
-        AbstractMCMC.step(
+        step_function(
             rng, AbstractMCMC.LogDensityModel(f), sampler; initial_params=x, kwargs...
         )
 
     else
-        AbstractMCMC.step(
+        step_function(
             rng,
             AbstractMCMC.LogDensityModel(f),
             sampler,
@@ -178,19 +223,20 @@ function AbstractMCMC.step(
     return (new_transition, TuringState(state_inner, new_parameters, f))
 end
 
-function AbstractMCMC.step(
+function _external_subsequent_step(
+    step_function::F,
     rng::Random.AbstractRNG,
     model::DynamicPPL.Model,
     sampler_wrapper::ExternalSampler,
     state::TuringState;
     discard_sample=false,
     kwargs...,
-)
+) where {F}
     sampler = sampler_wrapper.sampler
     f = state.ldf
 
-    # Then just call `AdvancedMCMC.step` with the right arguments.
-    _, state_inner = AbstractMCMC.step(
+    # Then just call the inner step function with the right arguments.
+    _, state_inner = step_function(
         rng, AbstractMCMC.LogDensityModel(f), sampler, state.state; kwargs...
     )
 

--- a/test/mcmc/external_sampler.jl
+++ b/test/mcmc/external_sampler.jl
@@ -7,11 +7,14 @@ using AdvancedMH: AdvancedMH
 using Distributions: sample
 using Distributions.FillArrays: Zeros
 using DynamicPPL: DynamicPPL
+using FlexiChains: FlexiChains
 using ForwardDiff: ForwardDiff
+using LinearAlgebra: LinearAlgebra
 using LogDensityProblems: LogDensityProblems
 using Random: Random
 using ReverseDiff: ReverseDiff
 using StableRNGs: StableRNG
+using Statistics: mean
 using Test: @test, @test_throws, @testset
 using Turing
 using Turing.Inference: AdvancedHMC
@@ -73,6 +76,57 @@ using Turing.Inference: AdvancedHMC
         return nothing, MyState(params)
     end
 
+    # Counts which of `step` / `step_warmup` the sampler is reached through, at the
+    # first step and at later ones.
+    mutable struct WarmupCounter <: AbstractMCMC.AbstractSampler
+        warmup_init::Int
+        warmup_later::Int
+        step_init::Int
+        step_later::Int
+    end
+    WarmupCounter() = WarmupCounter(0, 0, 0, 0)
+
+    function AbstractMCMC.step(
+        ::Random.AbstractRNG,
+        ::AbstractMCMC.LogDensityModel,
+        spl::WarmupCounter;
+        initial_params::AbstractVector,
+        kwargs...,
+    )
+        spl.step_init += 1
+        return nothing, MyState(initial_params)
+    end
+    function AbstractMCMC.step(
+        ::Random.AbstractRNG,
+        ::AbstractMCMC.LogDensityModel,
+        spl::WarmupCounter,
+        state::MyState;
+        kwargs...,
+    )
+        spl.step_later += 1
+        return nothing, state
+    end
+    function AbstractMCMC.step_warmup(
+        ::Random.AbstractRNG,
+        ::AbstractMCMC.LogDensityModel,
+        spl::WarmupCounter;
+        initial_params::AbstractVector,
+        kwargs...,
+    )
+        spl.warmup_init += 1
+        return nothing, MyState(initial_params)
+    end
+    function AbstractMCMC.step_warmup(
+        ::Random.AbstractRNG,
+        ::AbstractMCMC.LogDensityModel,
+        spl::WarmupCounter,
+        state::MyState;
+        kwargs...,
+    )
+        spl.warmup_later += 1
+        return nothing, state
+    end
+
     @model function test_external_sampler()
         a ~ Beta(2, 2)
         return b ~ Normal(a)
@@ -92,6 +146,24 @@ using Turing.Inference: AdvancedHMC
     @test all(chn[:logprior] .== expected_logpdf)
     @test all(chn[:loglikelihood] .== 0.0)
     @test all(chn[:param_length] .== 2)
+
+    @testset "warmup steps reach the external sampler" begin
+        spl = WarmupCounter()
+        sample(
+            model,
+            externalsampler(spl),
+            5;
+            num_warmup=3,
+            initial_params=InitFromParams((a=a, b=b)),
+            progress=false,
+        )
+        # Without forwarding, AbstractMCMC's fallback sends every one of these to
+        # `step` instead, so the warmup counts would be zero.
+        @test spl.warmup_init == 1
+        @test spl.warmup_later == 3
+        @test spl.step_init == 0
+        @test spl.step_later == 4
+    end
 end
 
 function initialize_nuts(model::DynamicPPL.Model)
@@ -262,6 +334,23 @@ end
                         sampler_name="AdvancedMH",
                     )
                 end
+            end
+
+            @testset "adaptive samplers adapt during warmup" begin
+                # RAM adapts only in `step_warmup`, so from a badly scaled proposal
+                # it cannot move at all unless warmup steps reach it.
+                @model demo_ram() = x ~ MvNormal(zeros(2), [1.0 0.99; 0.99 1.0])
+                S0 = LinearAlgebra.LowerTriangular(Matrix(50.0 * LinearAlgebra.I, 2, 2))
+                sampler = AdvancedMH.RobustAdaptiveMetropolis(; S=S0)
+                chn = sample(
+                    StableRNG(468),
+                    demo_ram(),
+                    externalsampler(sampler),
+                    2_000;
+                    num_warmup=2_000,
+                    progress=false,
+                )
+                @test mean(chn[FlexiChains.Extra(:accepted)]) > 0.01
             end
 
             @testset "logp is set correctly" begin


### PR DESCRIPTION
Closes #2870.

An ExternalSampler used as a Gibbs component now also receives warmup steps, because `gibbs_step_recursive` passes `step_function = AbstractMCMC.step_warmup`. Samplers that do not define `step_warmup` are unaffected, because AbstractMCMC's fallback still routes them to step.