### PR TITLE
Skip the Aqua persistent-tasks check on Windows

### DIFF
--- a/test/Aqua.jl
+++ b/test/Aqua.jl
@@ -24,6 +24,10 @@ using Turing
 # meaningful in practice (in particular, to trigger this we would need to call `g(..., f)`,
 # which is incredibly unlikely).
 Aqua.test_ambiguities([Turing]; exclude=[Libtask.might_produce])
-Aqua.test_all(Turing; ambiguities=false)
+# The persistent-tasks check precompiles a temporary package in a subprocess. On the
+# Windows runners that subprocess dies intermittently before the check runs, and Aqua
+# reports the precompilation failure as a persistent-tasks failure, see
+# https://github.com/JuliaTesting/Aqua.jl/issues/315.
+Aqua.test_all(Turing; ambiguities=false, persistent_tasks=!Sys.iswindows())
 
 end


### PR DESCRIPTION
The Aqua persistent-tasks check precompiles a temporary package in a subprocess. On the Windows runners that subprocess dies intermittently before Turing finishes loading, and Aqua 0.8.16 reports that as a persistent-tasks failure while discarding the subprocess's stderr (JuliaTesting/Aqua.jl#315). It failed both attempts on main at 5a9463d ([run](https://github.com/TuringLang/Turing.jl/actions/runs/33551597672)) and one attempt on 2026-08-29 ([run](https://github.com/TuringLang/Turing.jl/actions/runs/33265301582)). The fix in JuliaTesting/Aqua.jl#389 is merged but unreleased, and it only makes the report honest, a dying subprocess would still fail the check. Task leaks are not platform-specific, so the check on Linux and macOS keeps the coverage.