### PR TITLE
Fix biased MH samples from ignored aggregate proposals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,8 @@ Note: "linked" and "unconstrained" are synonymous in this codebase. Linking tran
 
 Interfaces that accept or return named parameter collections should use `VarNamedTuple`, not `NamedTuple` or `Dict{VarName}`. `NamedTuple` and `Dict{VarName}` are accepted as user-facing input but should be converted to `VarNamedTuple` at the boundary (see `_to_varnamedtuple` in `src/common.jl`). Don't propagate them through internal code.
 
+With executed sites `x[1]` and `x[2]`, key `x` is not an exact match, although `haskey(values, @varname(x))` succeeds and `DynamicPPL.LinkSome` matches both descendants. In MH this can ignore the proposal for `x` yet link its descendants, which are then proposed from their constrained priors but scored under a Jacobian-adjusted linked target, giving the wrong acceptance probability.
+
 ### `getlogjoint_internal` vs `getlogjoint`
 
 Samplers operating in unconstrained space should use `getlogjoint_internal`, which includes the Jacobian correction from the linking transform. This is the default and what you almost always want. The exceptions are ESS (which needs the likelihood in constrained space, per the algorithm) and optimisation (where the Jacobian term should not influence the objective).

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+`MH` no longer includes ignored aggregate proposals in its acceptance ratio.
+
 # 0.47.4
 
 `externalsampler` now forwards `AbstractMCMC.step_warmup` to the sampler it wraps, so an

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 0.47.5
 
 `MH` no longer includes ignored aggregate proposals in its acceptance ratio.
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Turing"
 uuid = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
-version = "0.47.4"
+version = "0.47.5"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/mcmc/mh.jl
+++ b/src/mcmc/mh.jl
@@ -164,6 +164,15 @@ struct LinkedRW{C}
 end
 LinkedRW(var::Real) = LinkedRW(var * I)
 
+# For example, `LinkExact(Set([@varname(x)]))` links `x` but not `x[1]`,
+# whereas `DynamicPPL.LinkSome` links both.
+struct LinkExact{V<:Set{<:VarName}} <: DynamicPPL.AbstractTransformStrategy
+    vns::V
+end
+function DynamicPPL.target_transform(strategy::LinkExact, vn::VarName)
+    return vn in strategy.vns ? DynamicPPL.DynamicLink() : DynamicPPL.Unlink()
+end
+
 """
     InitFromProposals(proposals::VarNamedTuple, verbose::Bool)
 
@@ -222,11 +231,12 @@ function MH(pair1::SymOrVNPair, pairs::Vararg{SymOrVNPair})
     # have `LinkedRW` proposals. That in turn is obtained using `MHLinkedValuesAccumulator`.
     function init_strategy_constructor(raw_vals, linked_vals)
         proposals = DynamicPPL.VarNamedTuple()
+        raw_vns = Set(keys(raw_vals))
         for pair in vn_proposal_pairs
             # Convert all keys to VarNames.
             vn, proposal = pair
             vn = _to_varname(vn)
-            if vn ∉ keys(raw_vals)
+            if vn ∉ raw_vns
                 continue
             end
             proposal_dist = if proposal isa Distribution
@@ -254,7 +264,7 @@ function MH(pair1::SymOrVNPair, pairs::Vararg{SymOrVNPair})
     link_strategy = if isempty(linkedrw_vns)
         DynamicPPL.UnlinkAll()
     else
-        DynamicPPL.LinkSome(linkedrw_vns, DynamicPPL.UnlinkAll())
+        LinkExact(linkedrw_vns)
     end
     return MH(init_strategy_constructor, link_strategy, all_vns)
 end

--- a/src/mcmc/mh.jl
+++ b/src/mcmc/mh.jl
@@ -226,7 +226,7 @@ function MH(pair1::SymOrVNPair, pairs::Vararg{SymOrVNPair})
             # Convert all keys to VarNames.
             vn, proposal = pair
             vn = _to_varname(vn)
-            if !haskey(raw_vals, vn)
+            if vn ∉ keys(raw_vals)
                 continue
             end
             proposal_dist = if proposal isa Distribution

--- a/test/mcmc/mh.jl
+++ b/test/mcmc/mh.jl
@@ -108,24 +108,28 @@ GKernel(variance, vn) = (vnt -> Normal(vnt[vn], sqrt(variance)))
             @test mean(chn[:y]) ≈ 4 / 3 atol = 0.05
         end
 
-        @testset "ignored aggregate proposal" begin
+        @testset "ignored aggregate proposals" begin
             @model function f()
                 x = zeros(2)
                 x[1] ~ Exponential(0.5)
                 return x[2] ~ Exponential(0.5)
             end
 
-            expected = sample(StableRNG(2876), f(), MH(), 20; progress=false)
-            actual = sample(
-                StableRNG(2876),
-                f(),
-                MH(@varname(x) => filldist(Exponential(1.0), 2)),
-                20;
-                progress=false,
-                verbose=false,
-            )
-            @test actual[@varname(x[1])] == expected[@varname(x[1])]
-            @test actual[@varname(x[2])] == expected[@varname(x[2])]
+            expected = sample(StableRNG(2876), f(), MH(), 20; progress=false, verbose=false)
+            for proposal in (filldist(Exponential(1.0), 2), LinkedRW([1.0 0.0; 0.0 1.0]))
+                @testset let proposal = proposal
+                    actual = sample(
+                        StableRNG(2876),
+                        f(),
+                        MH(@varname(x) => proposal),
+                        20;
+                        progress=false,
+                        verbose=false,
+                    )
+                    @test actual[@varname(x[1])] == expected[@varname(x[1])]
+                    @test actual[@varname(x[2])] == expected[@varname(x[2])]
+                end
+            end
         end
     end
 

--- a/test/mcmc/mh.jl
+++ b/test/mcmc/mh.jl
@@ -107,6 +107,26 @@ GKernel(variance, vn) = (vnt -> Normal(vnt[vn], sqrt(variance)))
             @test mean(chn[:x]) ≈ 2 / 3 atol = 0.05
             @test mean(chn[:y]) ≈ 4 / 3 atol = 0.05
         end
+
+        @testset "ignored aggregate proposal" begin
+            @model function f()
+                x = zeros(2)
+                x[1] ~ Exponential(0.5)
+                return x[2] ~ Exponential(0.5)
+            end
+
+            expected = sample(StableRNG(2876), f(), MH(), 20; progress=false)
+            actual = sample(
+                StableRNG(2876),
+                f(),
+                MH(@varname(x) => filldist(Exponential(1.0), 2)),
+                20;
+                progress=false,
+                verbose=false,
+            )
+            @test actual[@varname(x[1])] == expected[@varname(x[1])]
+            @test actual[@varname(x[2])] == expected[@varname(x[2])]
+        end
     end
 
     @testset "chain includes := statements" begin


### PR DESCRIPTION
### The bug

An aggregate proposal can be addressable through a `VarNamedTuple` without being one of its exact keys. For a model containing `x[1] ~ ...` and `x[2] ~ ...`, `haskey(raw_vals, @varname(x))` is therefore true even though the model never executes a statement for `x`.

MH retains the proposal for `x`, but `InitFromProposals` does not use it when evaluating the indexed statements. Both sites are drawn from their priors. Density accounting nevertheless includes the unused aggregate density:

$$
g_{\mathrm{recorded}}(x) = p(x_1)p(x_2)q(x)
$$

The extra density ratio changes the invariant density from $p(x)L(x)$ to one proportional to $p(x)L(x)/q(x)$.

### The proof

```julia
using Distributions, DynamicPPL, Random, Statistics, Turing

@model function model()
    x = zeros(2)
    x[1] ~ Exponential(0.5)
    x[2] ~ Exponential(0.5)
end

chain = sample(
    MersenneTwister(0x5eed), model(),
    MH(@varname(x) => filldist(Exponential(1.0), 2)), 100_000;
    discard_initial=10_000, progress=false, verbose=false,
)

mean(chain[@varname(x[1])]), mean(chain[@varname(x[2])])
```

Before the fix, this gives approximately `(1.03, 0.94)` instead of `(0.5, 0.5)`. After the fix, it gives `(0.5020, 0.4999)`.

The regression test compares this chain against `MH()` under the same `StableRNG`. The chains differ before the fix and agree exactly afterward.

### The fix

Use membership in `keys(raw_vals)`, which contains the exact executed `VarName`s, instead of `haskey`, which also accepts structurally reconstructable aggregates. This excludes unused proposals before constructing `InitFromProposals`, keeping initialization and both directions of the MH ratio consistent.

Fixes #2876.
