### PR TITLE
hmc: Convert `initial_params` for NUTS/HMCDA and delete a dead adaptor branch

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+`NUTS` and `HMCDA` now accept a `NamedTuple` or `Dict{VarName}` `initial_params`, which `HMC` already did.
+
 # 0.47.4
 
 `externalsampler` now forwards `AbstractMCMC.step_warmup` to the sampler it wraps, so an

--- a/src/mcmc/hmc.jl
+++ b/src/mcmc/hmc.jl
@@ -99,6 +99,10 @@ function AbstractMCMC.sample(
     kwargs...,
 )
     check_model && Turing._check_model(model, sampler)
+    # The generic `sample` in `abstractmcmc.jl` converts a `NamedTuple`/`Dict` here; this
+    # method exists only to resolve `nadapts` and `discard_initial`, so it has to do the same
+    # or `NUTS`/`HMCDA` reject an `initial_params` that `HMC` accepts.
+    initial_params = Turing._convert_initial_params(initial_params)
     if initial_state === nothing
         # If `nadapts` is `-1`, then the user called a convenience
         # constructor like `NUTS()` or `NUTS(0.65)`,

--- a/src/mcmc/hmc.jl
+++ b/src/mcmc/hmc.jl
@@ -454,17 +454,9 @@ function AHMCAdaptor(
     pc = AHMC.MassMatrixAdaptor(metric)
     da = AHMC.StepSizeAdaptor(alg.δ, ϵ)
 
-    if iszero(alg.n_adapts)
-        adaptor = AHMC.Adaptation.NoAdaptation()
-    else
-        if metric == AHMC.UnitEuclideanMetric
-            adaptor = AHMC.NaiveHMCAdaptor(pc, da)  # there is actually no adaptation for mass matrix
-        else
-            adaptor = AHMC.StanHMCAdaptor(pc, da)
-            AHMC.initialize!(adaptor, nadapts)
-        end
-    end
-
+    iszero(alg.n_adapts) && return AHMC.Adaptation.NoAdaptation()
+    adaptor = AHMC.StanHMCAdaptor(pc, da)
+    AHMC.initialize!(adaptor, nadapts)
     return adaptor
 end
 

--- a/test/mcmc/hmc.jl
+++ b/test/mcmc/hmc.jl
@@ -295,6 +295,33 @@ using Turing
         )
     end
 
+    @testset "raw initial_params for the adapting samplers" begin
+        # `NUTS`/`HMCDA` resolve `nadapts` in their own `sample` method, which copied the
+        # generic body without its `_convert_initial_params` call, so a `NamedTuple` or
+        # `Dict{VarName}` that `HMC` accepted raised a `TypeError` for them from the typed
+        # `initial_params` keyword. The first draw is checked, not merely that nothing throws,
+        # so that a conversion which quietly substituted the prior would still fail here.
+        @model function two()
+            s ~ InverseGamma(2, 3)
+            return x ~ Normal(0, sqrt(s))
+        end
+        for spl in (NUTS(5, 0.65), HMCDA(5, 0.65, 1.0), HMC(0.1, 5))
+            for init in ((s=1.0, x=0.5), Dict(@varname(s) => 1.0, @varname(x) => 0.5))
+                chain = sample(
+                    StableRNG(4),
+                    two(),
+                    spl,
+                    10;
+                    initial_params=init,
+                    discard_adapt=false,
+                    progress=false,
+                )
+                @test chain[@varname(s)][1] == 1.0
+                @test chain[@varname(x)][1] == 0.5
+            end
+        end
+    end
+
     @testset "check_model fails with discrete variables" begin
         @model function discrete_model()
             return x ~ Categorical([0.5, 0.5])


### PR DESCRIPTION
`NUTS` and `HMCDA` rejected a `NamedTuple` `initial_params` that `HMC` accepted. Also deletes an `AHMCAdaptor` branch whose guard compares an instance against a type and never runs.