### PR TITLE
emcee: Honour `chain_type` and refuse walkers in different parameter layouts

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,3 @@
-# Unreleased
-
-`Emcee` now honours `chain_type=MCMCChains.Chains`, and refuses walkers that start in different parameter layouts instead of failing inside the decode or the stretch proposal.
-
 # 0.47.4
 
 `externalsampler` now forwards `AbstractMCMC.step_warmup` to the sampler it wraps, so an

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-`Emcee` now honours `chain_type=MCMCChains.Chains`, and refuses a model whose variables or their sizes depend on its own draws instead of failing inside the decode or the stretch proposal.
+`Emcee` now honours `chain_type=MCMCChains.Chains`, and refuses walkers that start in different parameter layouts instead of failing inside the decode or the stretch proposal.
 
 # 0.47.4
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+`Emcee` now honours `chain_type=MCMCChains.Chains`, and refuses a model whose variables or their sizes depend on its own draws instead of failing inside the decode or the stretch proposal.
+
 # 0.47.4
 
 `externalsampler` now forwards `AbstractMCMC.step_warmup` to the sampler it wraps, so an

--- a/ext/TuringMCMCChainsExt.jl
+++ b/ext/TuringMCMCChainsExt.jl
@@ -31,7 +31,7 @@ function AbstractMCMC.bundle_samples(
     model::DynamicPPL.Model,
     spl::Emcee,
     state::EmceeState,
-    ::Type{MCMCChains.Chains},
+    ::Type{MCMCChains.Chains};
     kwargs...,
 )
     n_walkers = _get_n_walkers(spl)

--- a/src/mcmc/emcee.jl
+++ b/src/mcmc/emcee.jl
@@ -81,7 +81,7 @@ function AbstractMCMC.step(
     end
 
     linked_vis = map(vi -> DynamicPPL.link!!(vi, model), vis)
-    check_walkers_same_dimension(linked_vis)
+    check_walkers_same_layout(linked_vis)
     state = EmceeState(
         DynamicPPL.LogDensityFunction(model, getlogjoint_internal, linked_vis[1]),
         map(linked_vis) do vi
@@ -93,30 +93,43 @@ function AbstractMCMC.step(
 end
 
 """
-    check_walkers_same_dimension(linked_vis)
+    check_walkers_same_layout(linked_vis)
 
-Throw unless every walker has the same number of parameters.
+Throw unless every walker occupies the same parameter layout.
 
-The stretch move interpolates between two walkers' position vectors, so the ensemble needs one
-parameter space shared by all of them. On a model whose set of variables depends on its own
-draws, walkers initialised from the prior can land in different branches and so have different
-lengths, and the mismatch otherwise surfaces as a `DimensionMismatch` from inside the proposal's
-broadcast.
+The stretch move interpolates between two walkers' position vectors, and the single
+`LogDensityFunction` is built from the first walker, so every walker's vector is decoded against
+that one layout. All of them therefore have to hold the same variables in the same order at the
+same widths. On a model whose set of variables, or their sizes, depends on its own draws,
+walkers initialised from the prior do not.
 
-The check is necessary rather than sufficient: it rules out walkers that start in different
-branches, not a model whose dimension varies at all. A proposal can still reach a vector whose
-trace visits other variables, and the single `LogDensityFunction` built here would decode it
-against the layout of the first walker. `Emcee` has no way to express that, so a dynamic model
-is best avoided with it entirely.
+Each variable's own width is compared, not the names and not the total. Names alone passed
+walkers agreeing on names while a variable's dimension differed, and names with the total passed
+two variables trading dimensions -- `x` of 2 and `y` of 3 against `x` of 3 and `y` of 2 -- both
+of which then failed inside the decode or the proposal's broadcast.
+
+This is necessary rather than sufficient: it rules out walkers whose *starting* layouts differ,
+not a model whose layout can vary at all. A proposal can still reach a vector whose trace visits
+other variables or other sizes, and it would be decoded against the first walker's layout. A
+model like that is best not sampled with `Emcee`.
 """
-function check_walkers_same_dimension(linked_vis)
-    dims = map(vi -> length(vi[:]), linked_vis)
-    allequal(dims) && return nothing
-    throw(
+function check_walkers_same_layout(linked_vis)
+    layouts = map(linked_vis) do vi
+        [
+            vn => length(DynamicPPL.get_internal_value(tv)) for
+            (vn, tv) in pairs(DynamicPPL.get_values(vi))
+        ]
+    end
+    allequal(layouts) && return nothing
+    shown = unique(
+        map(l -> string("[", join(("$k of $v" for (k, v) in l), ", "), "]"), layouts)
+    )
+    return throw(
         ArgumentError(
-            "`Emcee`'s walkers have different numbers of parameters ($(join(sort(unique(dims)), ", "))). " *
-            "The stretch move moves along the line between two walkers, so they all have to " *
-            "live in one parameter space. This model's set of variables depends on its own " *
+            "`Emcee`'s walkers do not occupy the same parameter layout " *
+            "($(join(shown, " versus "))). The stretch move moves along the line between two " *
+            "walkers and every walker is decoded against one layout, so they all have to live " *
+            "in one parameter space. This model's variables, or their sizes, depend on its own " *
             "draws, which `Emcee` cannot sample.",
         ),
     )

--- a/src/mcmc/emcee.jl
+++ b/src/mcmc/emcee.jl
@@ -108,10 +108,16 @@ walkers agreeing on names while a variable's dimension differed, and names with 
 two variables trading dimensions -- `x` of 2 and `y` of 3 against `x` of 3 and `y` of 2 -- both
 of which then failed inside the decode or the proposal's broadcast.
 
-This is necessary rather than sufficient: it rules out walkers whose *starting* layouts differ,
-not a model whose layout can vary at all. A proposal can still reach a vector whose trace visits
-other variables or other sizes, and it would be decoded against the first walker's layout. A
-model like that is best not sampled with `Emcee`.
+Widths and not transforms: the layout fixes each variable's range, while its link is re-derived
+at every evaluation, so walkers holding one variable under different transforms still sample
+correctly, and comparing transforms would refuse them.
+
+This is necessary rather than sufficient, and only the *initial* walkers are examined. A
+proposal can still cross into a branch none of them started in, and the decode then fails on a
+variable the layout has no range for -- `m ~ Normal(); m > 0 ? (x ~ Normal()) : (y ~ Normal())`,
+started entirely in `m > 0`, raises `KeyError: key y not found` once a proposal reaches `m < 0`.
+Catching that would mean validating every evaluation. A model whose layout varies at all is best
+not sampled with `Emcee`.
 """
 function check_walkers_same_layout(linked_vis)
     layouts = map(linked_vis) do vi

--- a/src/mcmc/emcee.jl
+++ b/src/mcmc/emcee.jl
@@ -103,10 +103,10 @@ that one layout. All of them therefore have to hold the same variables in the sa
 same widths. On a model whose set of variables, or their sizes, depends on its own draws,
 walkers initialised from the prior do not.
 
-Each variable's own width is compared, not the names and not the total. Names alone passed
-walkers agreeing on names while a variable's dimension differed, and names with the total passed
-two variables trading dimensions -- `x` of 2 and `y` of 3 against `x` of 3 and `y` of 2 -- both
-of which then failed inside the decode or the proposal's broadcast.
+Each variable's name, order, and width are compared, rather than only the names or the total
+width. Comparing names alone passed walkers agreeing on names while a variable's dimension
+differed, and names with the total width passed two variables trading dimensions -- `x` of 2 and
+`y` of 3 against `x` of 3 and `y` of 2 -- both of which then failed inside the decode or proposal.
 
 Widths and not transforms: the layout fixes each variable's range, while its link is re-derived
 at every evaluation, so walkers holding one variable under different transforms still sample

--- a/src/mcmc/emcee.jl
+++ b/src/mcmc/emcee.jl
@@ -80,16 +80,46 @@ function AbstractMCMC.step(
         ]
     end
 
-    linked_vi = DynamicPPL.link!!(vis[1], model)
+    linked_vis = map(vi -> DynamicPPL.link!!(vi, model), vis)
+    check_walkers_same_dimension(linked_vis)
     state = EmceeState(
-        DynamicPPL.LogDensityFunction(model, getlogjoint_internal, linked_vi),
-        map(vis) do vi
-            vi = DynamicPPL.link!!(vi, model)
+        DynamicPPL.LogDensityFunction(model, getlogjoint_internal, linked_vis[1]),
+        map(linked_vis) do vi
             AMH.Transition(vi[:], DynamicPPL.getlogjoint_internal(vi), false)
         end,
     )
 
     return transition, state
+end
+
+"""
+    check_walkers_same_dimension(linked_vis)
+
+Throw unless every walker has the same number of parameters.
+
+The stretch move interpolates between two walkers' position vectors, so the ensemble needs one
+parameter space shared by all of them. On a model whose set of variables depends on its own
+draws, walkers initialised from the prior can land in different branches and so have different
+lengths, and the mismatch otherwise surfaces as a `DimensionMismatch` from inside the proposal's
+broadcast.
+
+The check is necessary rather than sufficient: it rules out walkers that start in different
+branches, not a model whose dimension varies at all. A proposal can still reach a vector whose
+trace visits other variables, and the single `LogDensityFunction` built here would decode it
+against the layout of the first walker. `Emcee` has no way to express that, so a dynamic model
+is best avoided with it entirely.
+"""
+function check_walkers_same_dimension(linked_vis)
+    dims = map(vi -> length(vi[:]), linked_vis)
+    allequal(dims) && return nothing
+    throw(
+        ArgumentError(
+            "`Emcee`'s walkers have different numbers of parameters ($(join(sort(unique(dims)), ", "))). " *
+            "The stretch move moves along the line between two walkers, so they all have to " *
+            "live in one parameter space. This model's set of variables depends on its own " *
+            "draws, which `Emcee` cannot sample.",
+        ),
+    )
 end
 
 function AbstractMCMC.step(

--- a/test/mcmc/emcee.jl
+++ b/test/mcmc/emcee.jl
@@ -54,9 +54,9 @@ using Turing
     end
 
     @testset "chain_type" begin
-        # `bundle_samples` declared `::Type{MCMCChains.Chains}` positionally where the caller
-        # passes it as a keyword, so this silently fell through to the generic method and
-        # returned the raw transitions.
+        # `bundle_samples` declared `kwargs...` as positional varargs instead of keyword
+        # varargs, so calls that forwarded keyword arguments silently fell through to the generic
+        # method and returned the raw transitions.
         chain = sample(
             StableRNG(7), gdemo_default, Emcee(4), 5; chain_type=MCMCChains.Chains
         )

--- a/test/mcmc/emcee.jl
+++ b/test/mcmc/emcee.jl
@@ -61,6 +61,25 @@ using Turing
         )
         @test chain isa MCMCChains.Chains
     end
+
+    @testset "model whose dimension depends on its own draws" begin
+        # Walkers initialised from the prior land in different branches, so they have
+        # different numbers of parameters and the stretch move has no line to move along.
+        @model function branchy()
+            b ~ Bernoulli(0.5)
+            x ~ Normal(0, 1)
+            if b
+                y ~ Normal(0, 1)
+                1.0 ~ Normal(x + y, 1)
+            else
+                1.0 ~ Normal(x, 1)
+            end
+        end
+        @test_throws(
+            "walkers have different numbers of parameters",
+            sample(StableRNG(5), branchy(), Emcee(10), 5),
+        )
+    end
 end
 
 end

--- a/test/mcmc/emcee.jl
+++ b/test/mcmc/emcee.jl
@@ -7,6 +7,7 @@ using DynamicPPL: DynamicPPL
 using Random: Random, Xoshiro
 using StableRNGs: StableRNG
 using FlexiChains: FlexiChains
+using LinearAlgebra: I
 using MCMCChains: MCMCChains
 using Test: @test, @test_throws, @testset
 using Turing
@@ -76,8 +77,50 @@ using Turing
             end
         end
         @test_throws(
-            "walkers have different numbers of parameters",
+            "do not occupy the same parameter layout",
             sample(StableRNG(5), branchy(), Emcee(10), 5),
+        )
+        # Two branches can hold different variables and the same total dimension, which a
+        # comparison of lengths passed; sampling then threw `KeyError: key y not found`.
+        @model function samelen()
+            b ~ Bernoulli(0.5)
+            if b == 1
+                x ~ Normal(0, 1)
+                1.0 ~ Normal(x, 1)
+            else
+                y ~ Normal(100, 1)
+                1.0 ~ Normal(y, 1)
+            end
+        end
+        @test_throws(
+            "do not occupy the same parameter layout",
+            sample(StableRNG(468), samelen(), Emcee(10, 2.0), 5),
+        )
+        # And the converse: the same variable NAMES with a different width. Comparing names
+        # alone let this through to a `DimensionMismatch` from inside the stretch move, so both
+        # the names and the total length are compared.
+        @model function samenames()
+            n ~ Normal()
+            x ~ MvNormal(zeros(n > 0 ? 2 : 3), I)
+            return 0.5 ~ Normal(sum(x), 1.0)
+        end
+        @test_throws(
+            "do not occupy the same parameter layout",
+            sample(StableRNG(468), samenames(), Emcee(20, 2.0), 5),
+        )
+        # And two variables trading dimensions: the names match and so does the total, so
+        # neither a name comparison nor a total-length one sees it, and the decode then fails
+        # with a `DimensionMismatch`. Each variable's own width is what has to agree.
+        @model function trade()
+            n ~ Normal()
+            k = n > 0 ? 2 : 3
+            x ~ MvNormal(zeros(k), I)
+            y ~ MvNormal(zeros(5 - k), I)
+            return 0.5 ~ Normal(sum(x) + sum(y), 1)
+        end
+        @test_throws(
+            "do not occupy the same parameter layout",
+            sample(StableRNG(468), trade(), Emcee(10, 2.0), 5),
         )
     end
 end

--- a/test/mcmc/emcee.jl
+++ b/test/mcmc/emcee.jl
@@ -7,6 +7,7 @@ using DynamicPPL: DynamicPPL
 using Random: Random, Xoshiro
 using StableRNGs: StableRNG
 using FlexiChains: FlexiChains
+using MCMCChains: MCMCChains
 using Test: @test, @test_throws, @testset
 using Turing
 
@@ -49,6 +50,16 @@ using Turing
         chain = sample(gdemo_default, spl, 1; initial_params=fill(initial_nt, nwalkers))
         @test chain[:s] == fill(2.0, 1, nwalkers)
         @test chain[:m] == fill(1.0, 1, nwalkers)
+    end
+
+    @testset "chain_type" begin
+        # `bundle_samples` declared `::Type{MCMCChains.Chains}` positionally where the caller
+        # passes it as a keyword, so this silently fell through to the generic method and
+        # returned the raw transitions.
+        chain = sample(
+            StableRNG(7), gdemo_default, Emcee(4), 5; chain_type=MCMCChains.Chains
+        )
+        @test chain isa MCMCChains.Chains
     end
 end
 


### PR DESCRIPTION
`chain_type=MCMCChains.Chains` fell through to the generic method. Walkers whose per-variable layouts differ are now refused instead of failing inside the decode or the stretch proposal.