### PR TITLE
optimisation: Stop silently discarding `lb`/`ub` bounds

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,3 @@
-# Unreleased
-
-`estimate_mode` now throws on a bound that does not cover a whole variable, where it previously either dropped it and returned the unconstrained mode or failed with a bare `DimensionMismatch`, and warns on a bound no variable can use rather than ignoring it in silence.
-
 # 0.47.4
 
 `externalsampler` now forwards `AbstractMCMC.step_warmup` to the sampler it wraps, so an

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+`estimate_mode` now throws on a bound that does not cover a whole variable, where it previously either dropped it and returned the unconstrained mode or failed with a bare `DimensionMismatch`, and warns on a bound no variable can use rather than ignoring it in silence.
+
 # 0.47.4
 
 `externalsampler` now forwards `AbstractMCMC.step_warmup` to the sampler it wraps, so an

--- a/src/optimisation/init.jl
+++ b/src/optimisation/init.jl
@@ -328,20 +328,37 @@ function make_optim_bounds_and_init(
     inits = fill(et(NaN), nelems)
     lb_vec = fill(et(-Inf), nelems)
     ub_vec = fill(et(Inf), nelems)
+    # Which variables a bound was actually written for. `check_constraints_reached` needs this
+    # rather than a prediction of it: asking `get_constraints` instead reported a bound as used
+    # whenever the collection could answer for the variable, which is not the same as the bound
+    # reaching this assembly. A bound naming non-leading elements of a variable the model writes
+    # whole -- `x[2]`, or `x[1]` and `x[3]` -- never arrives here at all, and was passed as
+    # harmless while the mode came back unconstrained.
+    applied_lb, applied_ub = VarName[], VarName[]
     for (vn, init_val) in constraint_acc.init_vecs
         range = DynamicPPL.get_range_and_transform(ldf, vn).range
         inits[range] = init_val
         if haskey(constraint_acc.lb_vecs, vn)
-            lb_vec[range] = check_bound_length(constraint_acc.lb_vecs[vn], "lb", vn, range)
+            check_bound_covers(lb, "lb", vn, range)
+            lb_vec[range] = constraint_acc.lb_vecs[vn]
+            # Recorded as applied only if the caller's value can be read for this variable.
+            # `haskey` is true whenever the accumulator visited it, which it does even when the
+            # value cannot be read -- a scalar `lb = (x = 0.9,)` against an element-wise
+            # `x[1] ~` leaves an infinite bound behind, and counting that as applied dropped
+            # the caller's bound in silence. Testing `isfinite` on the result instead would
+            # refuse a bound the caller deliberately wrote as infinite.
+            get_constraints(lb, vn) === nothing || push!(applied_lb, vn)
         end
         if haskey(constraint_acc.ub_vecs, vn)
-            ub_vec[range] = check_bound_length(constraint_acc.ub_vecs[vn], "ub", vn, range)
+            check_bound_covers(ub, "ub", vn, range)
+            ub_vec[range] = constraint_acc.ub_vecs[vn]
+            get_constraints(ub, vn) === nothing || push!(applied_ub, vn)
         end
     end
     # The loop above visits the model's variables, so a bound whose key names none of them is
     # never consulted and the mode comes back unconstrained. Name it instead.
-    check_constraints_reached(lb, "lb", keys(constraint_acc.init_vecs))
-    check_constraints_reached(ub, "ub", keys(constraint_acc.init_vecs))
+    check_constraints_reached(lb, "lb", applied_lb, keys(constraint_acc.init_vecs))
+    check_constraints_reached(ub, "ub", applied_ub, keys(constraint_acc.init_vecs))
     # Make sure we have filled in all values. This should never happen, but we should just
     # check.
     if any(isnan, inits)
@@ -352,62 +369,88 @@ function make_optim_bounds_and_init(
 end
 
 """
-    check_bound_length(bound, name, vn, range)
+    check_bound_covers(constraints, name, vn, range)
 
-Return `bound`, having checked it has one entry per element of `vn`.
+Throw unless `constraints` bounds every element of `vn`, or none of them.
 
-A bound naming part of a variable the model writes whole -- `lb = Dict(@varname(x[1]) => 0.0)`
-against `x ~ MvNormal(zeros(2), I)` -- answers `haskey` and so reaches this assembly, but with
-fewer entries than the variable occupies. Assigning it raised a bare `DimensionMismatch` naming
-neither the variable nor the keyword.
+A bound reaches the optimiser only if it covers a whole variable as the model writes it, so a
+bound on part of one is a mistake rather than a partial constraint: the unmentioned elements are
+left free and the mode comes back unconstrained in them.
+
+Elements are counted, not keys, because one key can hold many: `lb = (x = [0.9, 0.9],)` covers
+two under a single key, `Dict(x[1] => 0.9, x[2] => 0.9)` the same two under one key each. A key
+coarser than `vn` counts only if a value can be read for `vn` -- a scalar `lb = (x = 0.9,)` holds
+nothing for an element-wise `x[1] ~` and is never applied.
 """
-function check_bound_length(bound, name, vn, range)
-    length(bound) == length(range) && return bound
-    throw(
+function check_bound_covers(constraints::DynamicPPL.VarNamedTuple, name, vn, range)
+    # Elements, not keys: one key can hold a whole vector, so `lb = (x = [0.9, 0.9],)` covers
+    # two elements under a single key while `Dict(x[1] => 0.9, x[2] => 0.9)` covers the same two
+    # under one key each.
+    covered = 0
+    for leaf in keys(constraints)
+        if AbstractPPL.subsumes(vn, leaf)
+            # A key inside `vn` contributes the elements it holds.
+            covered += length(DynamicPPL.getvalue(constraints, leaf))
+        elseif AbstractPPL.subsumes(leaf, vn)
+            # A key coarser than `vn` covers it only if a value can actually be read for `vn`:
+            # `lb = (x = [0.9, 0.9],)` bounds both of an element-wise `x[1] ~`, `x[2] ~`, while
+            # a scalar `lb = (x = 0.9,)` holds nothing for `x[1]` and is never applied. Asking
+            # subsumption alone treated the scalar as covering them and dropped it in silence.
+            get_constraints(constraints, vn) === nothing || return nothing
+        end
+    end
+    # Nothing bound for this variable at all is not this check's business:
+    # `check_constraints_reached` decides whether such a key is malformed or merely moot.
+    (covered == 0 || covered == length(range)) && return nothing
+    return throw(
         ArgumentError(
-            "`$(name)` gives $(length(bound)) bound(s) for $(vn), which the model writes as " *
-            "one value of $(length(range)) element(s). Bound every element of $(vn) or none " *
-            "of it.",
+            "`$(name)` names $(covered) element(s) under $(vn), which the model writes as one " *
+            "value of $(length(range)) element(s). A bound is honoured only if it covers the " *
+            "whole variable, so bound every element of $(vn) or none of it.",
         ),
     )
 end
 
 """
-    check_constraints_reached(constraints::VarNamedTuple, name, model_vns)
+    check_constraints_reached(constraints, name, applied, model_vns)
 
-Warn about any bound in `constraints` that no variable of the model can use.
+Complain about any bound that was not applied.
 
-Bounds are applied by asking `get_constraints(constraints, vn)` for each variable the model
-reaches, so one it cannot answer for is ignored, and `estimate_mode` returns as if that bound had
-never been given. The original silence over that was the defect; `lb = (nope = 0.0,)` alone left
-`bounds_kwargs` empty and the mode came back unconstrained.
+`applied` lists the variables a bound was actually written for, taken from the assembly rather
+than predicted: whether the collection *could* answer for a variable is not the same question as
+whether a bound reached the optimiser.
 
-Two granularities have to be reconciled, and getting that wrong is what made an earlier version
-of this check refuse bounds that work. `keys(constraints)` enumerates *leaves* -- a bound written
-`Dict(@varname(x[1:2]) => [0.9, 0.9])` enumerates as `x[1]`, `x[2]` -- while `model_vns` holds
-whole tilde `VarName`s, which may be compound. Asking about a single leaf in isolation therefore
-answers `false` for the compound name that in fact consumes it. So a leaf counts as used when
-some reached variable both draws from these constraints and stands in a subsumption relation to
-it, which compares the two at the same granularity.
+`keys(constraints)` enumerates leaves while `applied` and `model_vns` hold whole tilde
+`VarName`s, which may be compound, so a leaf is matched against them by subsumption in either
+direction.
 
-This warns rather than throws because a bound naming a variable the model has but does not reach
--- conditioned, fixed, or in a branch not taken -- is indistinguishable here from one naming
-nothing at all: `model_vns` holds only what was reached. Refusing it broke the ordinary pattern
-of reusing one `lb`/`ub` across conditioned variants of a model, whose modes were correctly
-constrained on the variables that do exist. A bound of the wrong *shape* is a different matter
-and still throws; see [`check_bound_length`](@ref).
+An unapplied bound is fatal when the model reaches a variable covering it, since bounding part of
+a value the model writes whole cannot be honoured. When no reached variable covers it the bound
+is merely moot -- the key may name a variable that is conditioned, fixed, or in a branch not
+taken, which is indistinguishable here from one naming nothing -- so that warns.
 """
-function check_constraints_reached(constraints::VarNamedTuple, name, model_vns)
-    used(leaf) =
-        any(model_vns) do vn
-            get_constraints(constraints, vn) === nothing && return false
-            return AbstractPPL.subsumes(vn, leaf) || AbstractPPL.subsumes(leaf, vn)
+function check_constraints_reached(constraints::VarNamedTuple, name, applied, model_vns)
+    claims(vns, leaf) =
+        any(vns) do vn
+            AbstractPPL.subsumes(vn, leaf) || AbstractPPL.subsumes(leaf, vn)
         end
-    unused = [leaf for leaf in keys(constraints) if !used(leaf)]
-    isempty(unused) && return nothing
-    @warn "`$(name)` has bounds for $(join(unused, ", ")) that no variable of the model can " *
-        "use, so they have no effect. The model's variables are $(join(model_vns, ", ")). A " *
-        "bound is applied only if it covers a whole variable as the model writes it; this is " *
-        "harmless if the variable is conditioned, fixed, or in a branch not taken."
+    unapplied = [leaf for leaf in keys(constraints) if !claims(applied, leaf)]
+    isempty(unapplied) && return nothing
+    malformed = filter(leaf -> claims(model_vns, leaf), unapplied)
+    if !isempty(malformed)
+        # Name the variables that could have used these keys, not every variable in the model.
+        covering = sort!(unique(vn for vn in model_vns if claims(malformed, vn)); by=string)
+        throw(
+            ArgumentError(
+                "`$(name)` has bounds for $(join(sort!(malformed; by=string), ", ")) that " *
+                "cannot be applied. The model writes those values as " *
+                "$(join(covering, ", ")), and a bound is honoured only if it covers a whole " *
+                "variable as the model writes it. Bound every element of it, or none.",
+            ),
+        )
+    end
+    @warn "`$(name)` has bounds for $(join(unapplied, ", ")) that no variable of the model " *
+        "can use, so they have no effect. The model's variables are $(join(model_vns, ", ")). " *
+        "This is harmless if the variable is conditioned, fixed, or in a branch not taken."
     return nothing
 end

--- a/src/optimisation/init.jl
+++ b/src/optimisation/init.jl
@@ -377,20 +377,22 @@ A bound reaches the optimiser only if it covers a whole variable as the model wr
 bound on part of one is a mistake rather than a partial constraint: the unmentioned elements are
 left free and the mode comes back unconstrained in them.
 
-Elements are counted, not keys, because one key can hold many: `lb = (x = [0.9, 0.9],)` covers
-two under a single key, `Dict(x[1] => 0.9, x[2] => 0.9)` the same two under one key each. A key
-coarser than `vn` counts only if a value can be read for `vn` -- a scalar `lb = (x = 0.9,)` holds
-nothing for an element-wise `x[1] ~` and is never applied.
+Scalar leaves are counted, not keys, because one key can hold many: `lb = (x = [0.9, 0.9],)`
+covers two under a single key, `Dict(x[1] => 0.9, x[2] => 0.9)` the same two under one key each,
+and `lb = (x = (a = [0.1, 0.1], b = 0.1),)` covers three. A key coarser than `vn` counts only if
+a value can be read for `vn` -- a scalar `lb = (x = 0.9,)` holds nothing for an element-wise
+`x[1] ~` and is never applied.
 """
 function check_bound_covers(constraints::DynamicPPL.VarNamedTuple, name, vn, range)
-    # Elements, not keys: one key can hold a whole vector, so `lb = (x = [0.9, 0.9],)` covers
-    # two elements under a single key while `Dict(x[1] => 0.9, x[2] => 0.9)` covers the same two
-    # under one key each.
     covered = 0
     for leaf in keys(constraints)
         if AbstractPPL.subsumes(vn, leaf)
-            # A key inside `vn` contributes the elements it holds.
-            covered += length(DynamicPPL.getvalue(constraints, leaf))
+            # A key inside `vn` contributes the scalar leaves it holds, not the length of its
+            # value: `(a = [0.1, 0.1], b = 0.1)` is one key of length two holding three
+            # elements.
+            covered += count(
+                Returns(true), DynamicPPL.varname_leaves(leaf, constraints[leaf])
+            )
         elseif AbstractPPL.subsumes(leaf, vn)
             # A key coarser than `vn` covers it only if a value can actually be read for `vn`:
             # `lb = (x = [0.9, 0.9],)` bounds both of an element-wise `x[1] ~`, `x[2] ~`, while

--- a/src/optimisation/init.jl
+++ b/src/optimisation/init.jl
@@ -420,9 +420,11 @@ Complain about any bound that was not applied.
 than predicted: whether the collection *could* answer for a variable is not the same question as
 whether a bound reached the optimiser.
 
-`keys(constraints)` enumerates leaves while `applied` and `model_vns` hold whole tilde
-`VarName`s, which may be compound, so a leaf is matched against them by subsumption in either
-direction.
+`applied` and `model_vns` hold whole tilde `VarName`s, which may be compound, so a bound is
+matched against them by subsumption in either direction. That is why the accounting is per leaf
+and not per key: `keys(constraints)` gives the caller's key, `x` for `lb = (x = [0.9, 100.0],)`,
+and subsumption would let the one element a model writing only `x[1]` consumes stand for the
+whole key, dropping the rest without a word.
 
 An unapplied bound is fatal when the model reaches a variable covering it, since bounding part of
 a value the model writes whole cannot be honoured. When no reached variable covers it the bound
@@ -434,7 +436,10 @@ function check_constraints_reached(constraints::VarNamedTuple, name, applied, mo
         any(vns) do vn
             AbstractPPL.subsumes(vn, leaf) || AbstractPPL.subsumes(leaf, vn)
         end
-    unapplied = [leaf for leaf in keys(constraints) if !claims(applied, leaf)]
+    leaves = Iterators.flatten(
+        DynamicPPL.varname_leaves(key, constraints[key]) for key in keys(constraints)
+    )
+    unapplied = [leaf for leaf in leaves if !claims(applied, leaf)]
     isempty(unapplied) && return nothing
     malformed = filter(leaf -> claims(model_vns, leaf), unapplied)
     if !isempty(malformed)

--- a/src/optimisation/init.jl
+++ b/src/optimisation/init.jl
@@ -375,35 +375,39 @@ end
 """
     check_constraints_reached(constraints::VarNamedTuple, name, model_vns)
 
-Throw unless every key of `constraints` is one [`get_constraints`](@ref) will actually reach.
+Warn about any bound in `constraints` that no variable of the model can use.
 
 Bounds are applied by asking `get_constraints(constraints, vn)` for each variable the model
-reaches, which is a `haskey` on the whole collection, so a key it does not answer for is
-ignored and `estimate_mode` returns the unconstrained mode with no complaint.
+reaches, so one it cannot answer for is ignored, and `estimate_mode` returns as if that bound had
+never been given. The original silence over that was the defect; `lb = (nope = 0.0,)` alone left
+`bounds_kwargs` empty and the mode came back unconstrained.
 
-The test here is that same `haskey`, and it has to be: a key can name a variable the model
-does have and still not be reached. `lb = (x = 0.0,)` against an element-wise `x[1] ~`,
-`x[2] ~` is the case -- a scalar bound is not a value for `x[1]`, so the bound is dropped --
-and `lb = Dict(@varname(x[1]) => 0.0)` against a whole `x ~ MvNormal(...)` is the other, which
-reaches the vectorised assembly a bound short and fails with a bare `DimensionMismatch`.
-Asking about subsumption instead of about `haskey` accepted both, which is worse than not
-checking: it reads as an assurance the bound was applied. Give a bound per element of the
-variable as it is written (`lb = (x = [0.0, 0.0],)` for either model above).
+Two granularities have to be reconciled, and getting that wrong is what made an earlier version
+of this check refuse bounds that work. `keys(constraints)` enumerates *leaves* -- a bound written
+`Dict(@varname(x[1:2]) => [0.9, 0.9])` enumerates as `x[1]`, `x[2]` -- while `model_vns` holds
+whole tilde `VarName`s, which may be compound. Asking about a single leaf in isolation therefore
+answers `false` for the compound name that in fact consumes it. So a leaf counts as used when
+some reached variable both draws from these constraints and stands in a subsumption relation to
+it, which compares the two at the same granularity.
+
+This warns rather than throws because a bound naming a variable the model has but does not reach
+-- conditioned, fixed, or in a branch not taken -- is indistinguishable here from one naming
+nothing at all: `model_vns` holds only what was reached. Refusing it broke the ordinary pattern
+of reusing one `lb`/`ub` across conditioned variants of a model, whose modes were correctly
+constrained on the variables that do exist. A bound of the wrong *shape* is a different matter
+and still throws; see [`check_bound_length`](@ref).
 """
 function check_constraints_reached(constraints::VarNamedTuple, name, model_vns)
-    for key in keys(constraints)
-        # Asked of this key alone: with the whole collection, one usable key would excuse
-        # every unusable one beside it.
-        only_key = DynamicPPL.subset(constraints, (key,))
-        any(vn -> get_constraints(only_key, vn) !== nothing, model_vns) && continue
-        throw(
-            ArgumentError(
-                "`$(name)` has a bound for $(key) that no variable of the model can " *
-                "use, so it would be ignored and the mode returned as if unconstrained. " *
-                "The model's variables are $(join(model_vns, ", ")); give a bound per " *
-                "element of each, shaped as the model writes it.",
-            ),
-        )
-    end
+    used(leaf) =
+        any(model_vns) do vn
+            get_constraints(constraints, vn) === nothing && return false
+            return AbstractPPL.subsumes(vn, leaf) || AbstractPPL.subsumes(leaf, vn)
+        end
+    unused = [leaf for leaf in keys(constraints) if !used(leaf)]
+    isempty(unused) && return nothing
+    @warn "`$(name)` has bounds for $(join(unused, ", ")) that no variable of the model can " *
+        "use, so they have no effect. The model's variables are $(join(model_vns, ", ")). A " *
+        "bound is applied only if it covers a whole variable as the model writes it; this is " *
+        "harmless if the variable is conditioned, fixed, or in a branch not taken."
     return nothing
 end

--- a/src/optimisation/init.jl
+++ b/src/optimisation/init.jl
@@ -326,23 +326,84 @@ function make_optim_bounds_and_init(
     # TODO(penelopeysm) This should really be exported
     et = eltype(DynamicPPL.get_input_vector_type(ldf))
     inits = fill(et(NaN), nelems)
-    lb = fill(et(-Inf), nelems)
-    ub = fill(et(Inf), nelems)
+    lb_vec = fill(et(-Inf), nelems)
+    ub_vec = fill(et(Inf), nelems)
     for (vn, init_val) in constraint_acc.init_vecs
         range = DynamicPPL.get_range_and_transform(ldf, vn).range
         inits[range] = init_val
         if haskey(constraint_acc.lb_vecs, vn)
-            lb[range] = constraint_acc.lb_vecs[vn]
+            lb_vec[range] = check_bound_length(constraint_acc.lb_vecs[vn], "lb", vn, range)
         end
         if haskey(constraint_acc.ub_vecs, vn)
-            ub[range] = constraint_acc.ub_vecs[vn]
+            ub_vec[range] = check_bound_length(constraint_acc.ub_vecs[vn], "ub", vn, range)
         end
     end
+    # The loop above visits the model's variables, so a bound whose key names none of them is
+    # never consulted and the mode comes back unconstrained. Name it instead.
+    check_constraints_reached(lb, "lb", keys(constraint_acc.init_vecs))
+    check_constraints_reached(ub, "ub", keys(constraint_acc.init_vecs))
     # Make sure we have filled in all values. This should never happen, but we should just
     # check.
     if any(isnan, inits)
         error("Could not generate vector of initial values as some values are missing.")
     end
     # Concretise before returning.
-    return [x for x in lb], [x for x in ub], [x for x in inits]
+    return [x for x in lb_vec], [x for x in ub_vec], [x for x in inits]
+end
+
+"""
+    check_bound_length(bound, name, vn, range)
+
+Return `bound`, having checked it has one entry per element of `vn`.
+
+A bound naming part of a variable the model writes whole -- `lb = Dict(@varname(x[1]) => 0.0)`
+against `x ~ MvNormal(zeros(2), I)` -- answers `haskey` and so reaches this assembly, but with
+fewer entries than the variable occupies. Assigning it raised a bare `DimensionMismatch` naming
+neither the variable nor the keyword.
+"""
+function check_bound_length(bound, name, vn, range)
+    length(bound) == length(range) && return bound
+    throw(
+        ArgumentError(
+            "`$(name)` gives $(length(bound)) bound(s) for $(vn), which the model writes as " *
+            "one value of $(length(range)) element(s). Bound every element of $(vn) or none " *
+            "of it.",
+        ),
+    )
+end
+
+"""
+    check_constraints_reached(constraints::VarNamedTuple, name, model_vns)
+
+Throw unless every key of `constraints` is one [`get_constraints`](@ref) will actually reach.
+
+Bounds are applied by asking `get_constraints(constraints, vn)` for each variable the model
+reaches, which is a `haskey` on the whole collection, so a key it does not answer for is
+ignored and `estimate_mode` returns the unconstrained mode with no complaint.
+
+The test here is that same `haskey`, and it has to be: a key can name a variable the model
+does have and still not be reached. `lb = (x = 0.0,)` against an element-wise `x[1] ~`,
+`x[2] ~` is the case -- a scalar bound is not a value for `x[1]`, so the bound is dropped --
+and `lb = Dict(@varname(x[1]) => 0.0)` against a whole `x ~ MvNormal(...)` is the other, which
+reaches the vectorised assembly a bound short and fails with a bare `DimensionMismatch`.
+Asking about subsumption instead of about `haskey` accepted both, which is worse than not
+checking: it reads as an assurance the bound was applied. Give a bound per element of the
+variable as it is written (`lb = (x = [0.0, 0.0],)` for either model above).
+"""
+function check_constraints_reached(constraints::VarNamedTuple, name, model_vns)
+    for key in keys(constraints)
+        # Asked of this key alone: with the whole collection, one usable key would excuse
+        # every unusable one beside it.
+        only_key = DynamicPPL.subset(constraints, (key,))
+        any(vn -> get_constraints(only_key, vn) !== nothing, model_vns) && continue
+        throw(
+            ArgumentError(
+                "`$(name)` has a bound for $(key) that no variable of the model can " *
+                "use, so it would be ignored and the mode returned as if unconstrained. " *
+                "The model's variables are $(join(model_vns, ", ")); give a bound per " *
+                "element of each, shaped as the model writes it.",
+            ),
+        )
+    end
+    return nothing
 end

--- a/test/optimisation/Optimisation.jl
+++ b/test/optimisation/Optimisation.jl
@@ -270,6 +270,17 @@ end
                 whole(); lb=Dict(@varname(x[1]) => 0.9), ub=Dict(@varname(x[1]) => 9.0)
             ),
         )
+        # Counting elements alone cannot tell a covering bound from one that names as many
+        # elements somewhere else, so the coincidence has to be caught by the reachability
+        # accounting instead.
+        @test_throws(
+            "cannot be applied",
+            maximum_a_posteriori(
+                whole();
+                lb=Dict(@varname(x[1]) => 0.9, @varname(x[3]) => 0.9),
+                ub=Dict(@varname(x[1]) => 9.0, @varname(x[3]) => 9.0),
+            ),
+        )
         # Bounding every element works for both shapes.
         for m in (elementwise(), whole())
             @test maximum_a_posteriori(m; lb=(x=[0.9, 0.9],), ub=(x=[9.0, 9.0],)) isa Any
@@ -290,6 +301,15 @@ end
                 (x=(a=0.1, b=0.1),),
                 (x=(a=0.5, b=0.5),),
                 product_distribution((a=Beta(2, 2), b=Beta(2, 2))),
+            ),
+            # A field holding several elements: the coverage check must count scalar leaves,
+            # not the two fields of the named tuple.
+            (
+                (x=(a=[0.1, 0.1], b=0.1),),
+                (x=(a=[0.5, 0.5], b=0.5),),
+                product_distribution((
+                    a=product_distribution([Beta(2, 2), Beta(2, 2)]), b=Beta(2, 2)
+                )),
             ),
         )
             @model f() = x ~ dist

--- a/test/optimisation/Optimisation.jl
+++ b/test/optimisation/Optimisation.jl
@@ -17,7 +17,8 @@ using ReverseDiff: ReverseDiff
 using StableRNGs: StableRNG
 using StatsBase: StatsBase
 using StatsBase: coef, coefnames, coeftable, informationmatrix, stderror, vcov
-using Test: @test, @testset, @test_throws
+using Logging: Logging
+using Test: @test, @test_logs, @testset, @test_throws
 using Turing
 using Turing.Optimisation:
     ModeResult, InitWithConstraintCheck, satisfies_constraints, make_optim_bounds_and_init
@@ -157,15 +158,17 @@ end
 
     @testset "bound naming no variable" begin
         # Bounds are applied by asking for each variable the model reaches, so a key matching
-        # none of them used to be dropped and the unconstrained mode returned.
+        # none of them is dropped and the unconstrained mode returned. That is warned about
+        # rather than refused: a key naming a variable the model has but does not reach --
+        # conditioned, fixed, or in a branch not taken -- is indistinguishable from one naming
+        # nothing, and refusing it broke reusing one `lb`/`ub` across variants of a model.
         @model function normal_m()
             x ~ Normal(0, 1)
             return 1.0 ~ Normal(x, 1)
         end
-        @test_throws(
-            "no variable of the model can use",
-            maximum_a_posteriori(normal_m(); lb=(nope=0.0,), ub=(nope=1.0,)),
-        )
+        @test_logs min_level = Logging.Warn match_mode = :any (
+            :warn, r"no variable of the model can use"
+        ) maximum_a_posteriori(normal_m(); lb=(nope=0.0,), ub=(nope=1.0,))
         # A bound that does name one still binds.
         @test maximum_a_posteriori(normal_m(); lb=(x=0.7,), ub=(x=10.0,)).params[@varname(
             x
@@ -185,10 +188,35 @@ end
             x ~ MvNormal(zeros(2), I)
             return 1.0 ~ Normal(x[1] + x[2], 1)
         end
-        @test_throws(
-            "no variable of the model can use",
-            maximum_a_posteriori(elementwise(); lb=(x=0.9,), ub=(x=9.0,)),
-        )
+        @test_logs min_level = Logging.Warn match_mode = :any (
+            :warn, r"no variable of the model can use"
+        ) maximum_a_posteriori(elementwise(); lb=(x=0.9,), ub=(x=9.0,))
+        # A bound written at a compound `VarName`, or per element of a variable the model
+        # writes whole, IS applied and must not be complained about. Testing each enumerated
+        # leaf key in isolation refused both of these, since no single-leaf subset answers for
+        # a compound name.
+        @model function slice()
+            x = Vector{Float64}(undef, 2)
+            x[1:2] ~ MvNormal(zeros(2), I)
+            return 1.0 ~ Normal(sum(x), 1)
+        end
+        @test maximum_a_posteriori(slice(); lb=Dict(@varname(x[1:2]) => [0.9, 0.9]), ub=Dict(@varname(x[1:2]) => [9.0, 9.0])).params[@varname(
+            x[1]
+        )] ≈ 0.9 atol = 1e-4
+        @test maximum_a_posteriori(whole(); lb=Dict(@varname(x[1]) => 0.9, @varname(x[2]) => 0.9), ub=Dict(@varname(x[1]) => 9.0, @varname(x[2]) => 9.0)).params[@varname(
+            x
+        )] ≈ [0.9, 0.9] atol = 1e-4
+        # A bound on a variable the model does not reach is moot, not an error: the mode is
+        # still correctly constrained on the variables that do exist.
+        @model function gd()
+            s ~ InverseGamma(2, 3)
+            m ~ Normal(0, sqrt(s))
+            return 1.0 ~ Normal(m, sqrt(s))
+        end
+        for variant in (gd() | (m=1.0,), DynamicPPL.fix(gd(), (m=1.0,)))
+            @test maximum_a_posteriori(variant; lb=(s=0.01, m=-9.0), ub=(s=10.0, m=9.0)) isa
+                Any
+        end
         @test_throws(
             "which the model writes as one value",
             maximum_a_posteriori(

--- a/test/optimisation/Optimisation.jl
+++ b/test/optimisation/Optimisation.jl
@@ -188,9 +188,13 @@ end
             x ~ MvNormal(zeros(2), I)
             return 1.0 ~ Normal(x[1] + x[2], 1)
         end
-        @test_logs min_level = Logging.Warn match_mode = :any (
-            :warn, r"no variable of the model can use"
-        ) maximum_a_posteriori(elementwise(); lb=(x=0.9,), ub=(x=9.0,))
+        # A scalar bound on a variable the model writes element by element cannot be read for
+        # any of those elements, so it is refused rather than warned about: the model does reach
+        # `x`, which makes this a malformed bound and not a moot key. Give one per element.
+        @test_throws(
+            "cannot be applied",
+            maximum_a_posteriori(elementwise(); lb=(x=0.9,), ub=(x=9.0,)),
+        )
         # A bound written at a compound `VarName`, or per element of a variable the model
         # writes whole, IS applied and must not be complained about. Testing each enumerated
         # leaf key in isolation refused both of these, since no single-leaf subset answers for
@@ -214,9 +218,41 @@ end
             return 1.0 ~ Normal(m, sqrt(s))
         end
         for variant in (gd() | (m=1.0,), DynamicPPL.fix(gd(), (m=1.0,)))
-            @test maximum_a_posteriori(variant; lb=(s=0.01, m=-9.0), ub=(s=10.0, m=9.0)) isa
-                Any
+            # Warned about, not refused, and `s` is still bounded.
+            @test_logs min_level = Logging.Warn match_mode = :any (
+                :warn, r"no variable of the model can use"
+            ) maximum_a_posteriori(variant; lb=(s=0.01, m=-9.0), ub=(s=10.0, m=9.0))
+            @test maximum_a_posteriori(variant; lb=(s=0.9, m=-9.0), ub=(s=10.0, m=9.0)).params[@varname(
+                s
+            )] >= 0.9 - 1e-6
         end
+        # The case the fix exists for. The accumulator sizes its bound vector from the highest
+        # index named, so `x[1]` alone came back short and raised a bare `DimensionMismatch`,
+        # while `x[2]` alone, or `x[1]` with `x[3]`, produced a full-length vector that passed
+        # and left the unnamed elements free -- the mode came back at 0.25 for each under a
+        # lower bound of 0.5.
+        @model function whole3()
+            x ~ MvNormal(zeros(3), I)
+            return 1.0 ~ Normal(sum(x), 1)
+        end
+        @model function slice3()
+            x = Vector{Float64}(undef, 3)
+            x[1:3] ~ MvNormal(zeros(3), I)
+            return 1.0 ~ Normal(sum(x), 1)
+        end
+        for m3 in (whole3(), slice3())
+            for lb3 in (
+                Dict(@varname(x[2]) => 0.5),
+                Dict(@varname(x[1]) => 0.5, @varname(x[3]) => 0.5),
+            )
+                ub3 = Dict(k => 9.0 for k in keys(lb3))
+                @test_throws "element(s) under" maximum_a_posteriori(m3; lb=lb3, ub=ub3)
+            end
+            @test maximum_a_posteriori(m3; lb=(x=fill(0.5, 3),), ub=(x=fill(9.0, 3),)).params[@varname(
+                x[1]
+            )] ≈ 0.5 atol = 1e-4
+        end
+
         @test_throws(
             "which the model writes as one value",
             maximum_a_posteriori(

--- a/test/optimisation/Optimisation.jl
+++ b/test/optimisation/Optimisation.jl
@@ -210,6 +210,17 @@ end
         @test maximum_a_posteriori(whole(); lb=Dict(@varname(x[1]) => 0.9, @varname(x[2]) => 0.9), ub=Dict(@varname(x[1]) => 9.0, @varname(x[2]) => 9.0)).params[@varname(
             x
         )] ≈ [0.9, 0.9] atol = 1e-4
+        # A compound key covering more elements than the model reaches drops the surplus.
+        # Accounting per key rather than per leaf let the one element `x[1]` consumes stand for
+        # the whole of `x`, so the bound on `x[2]` disappeared without a word.
+        @model function first_only()
+            x = Vector{Float64}(undef, 1)
+            x[1] ~ Normal(0, 1)
+            return 1.0 ~ Normal(x[1], 1)
+        end
+        @test_logs min_level = Logging.Warn match_mode = :any (:warn, r"bounds for x\[2\]") maximum_a_posteriori(
+            first_only(); lb=(x=[0.9, 100.0],), ub=(x=[9.0, 200.0],)
+        )
         # A bound on a variable the model does not reach is moot, not an error: the mode is
         # still correctly constrained on the variables that do exist.
         @model function gd()

--- a/test/optimisation/Optimisation.jl
+++ b/test/optimisation/Optimisation.jl
@@ -155,6 +155,52 @@ end
         )
     end
 
+    @testset "bound naming no variable" begin
+        # Bounds are applied by asking for each variable the model reaches, so a key matching
+        # none of them used to be dropped and the unconstrained mode returned.
+        @model function normal_m()
+            x ~ Normal(0, 1)
+            return 1.0 ~ Normal(x, 1)
+        end
+        @test_throws(
+            "no variable of the model can use",
+            maximum_a_posteriori(normal_m(); lb=(nope=0.0,), ub=(nope=1.0,)),
+        )
+        # A bound that does name one still binds.
+        @test maximum_a_posteriori(normal_m(); lb=(x=0.7,), ub=(x=10.0,)).params[@varname(
+            x
+        )] ≈ 0.7 atol = 1e-4
+
+        # A key can name a variable the model has and still not be usable. A scalar bound on
+        # an element-wise `x[i] ~` was silently dropped, and a bound on one element of a
+        # variable the model writes whole reached the assembly a bound short and raised a
+        # bare `DimensionMismatch`.
+        @model function elementwise()
+            x = Vector{Float64}(undef, 2)
+            x[1] ~ Normal(0, 1)
+            x[2] ~ Normal(0, 1)
+            return 1.0 ~ Normal(x[1] + x[2], 1)
+        end
+        @model function whole()
+            x ~ MvNormal(zeros(2), I)
+            return 1.0 ~ Normal(x[1] + x[2], 1)
+        end
+        @test_throws(
+            "no variable of the model can use",
+            maximum_a_posteriori(elementwise(); lb=(x=0.9,), ub=(x=9.0,)),
+        )
+        @test_throws(
+            "which the model writes as one value",
+            maximum_a_posteriori(
+                whole(); lb=Dict(@varname(x[1]) => 0.9), ub=Dict(@varname(x[1]) => 9.0)
+            ),
+        )
+        # Bounding every element works for both shapes.
+        for m in (elementwise(), whole())
+            @test maximum_a_posteriori(m; lb=(x=[0.9, 0.9],), ub=(x=[9.0, 9.0],)) isa Any
+        end
+    end
+
     @testset "generation of vector constraints" begin
         @testset "$dist" for (lb, ub, dist) in (
             ((x=0.1,), (x=0.5,), Normal()),


### PR DESCRIPTION
A bound naming no variable, covering part of one, or covering more elements than the model reaches was silently dropped or half-applied. Each now warns or throws.