### PR TITLE
prior: Warn that `initial_params` has no effect

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+`Prior()` now warns that `initial_params` has no effect instead of discarding it silently.
+
 # 0.47.4
 
 `externalsampler` now forwards `AbstractMCMC.step_warmup` to the sampler it wraps, so an

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,3 @@
-# Unreleased
-
-`Prior()` now warns that `initial_params` has no effect instead of discarding it silently.
-
 # 0.47.4
 
 `externalsampler` now forwards `AbstractMCMC.step_warmup` to the sampler it wraps, so an

--- a/src/mcmc/particle_mcmc.jl
+++ b/src/mcmc/particle_mcmc.jl
@@ -666,9 +666,9 @@ end
 
 # Neither sampler has anywhere to put a user-supplied starting point: both draw their particles from
 # the prior. `InitFromPrior` is what the ensemble wrapper injects per chain, not a user request.
-function warn_initial_params_ignored(name, initial_params)
+function warn_initial_params_ignored(name, why, initial_params)
     if initial_params !== nothing && !(initial_params isa DynamicPPL.InitFromPrior)
-        @warn "$name draws its particles from the prior; `initial_params` is ignored."
+        @warn "$name $why, so `initial_params` has no effect and is ignored."
     end
     return nothing
 end
@@ -713,7 +713,7 @@ function AbstractMCMC.sample(
     if save_state || initial_state !== nothing
         @warn "SMC runs one sweep and keeps no sampler state; `save_state` and `initial_state` are ignored."
     end
-    warn_initial_params_ignored("SMC", initial_params)
+    warn_initial_params_ignored("SMC", "draws its particles from the prior", initial_params)
     # Accepted only so it can be reported as ignored: AbstractMCMC's contract is one callback
     # per step, and SMC is a single sweep, so there is no iteration to call back from.
     if callback !== nothing
@@ -833,7 +833,7 @@ function AbstractMCMC.step(
     kwargs...,
 )
     error_if_threadsafe_eval(model)
-    warn_initial_params_ignored("PG", initial_params)
+    warn_initial_params_ignored("PG", "draws its particles from the prior", initial_params)
     particles = [Particle(model, particle_rng(rng)) for _ in 1:(sampler.nparticles)]
     logZ, _ = sweep!(rng, particles, sampler.resampler, sampler.multithreaded)
     return pg_transition_and_state(rng, particles, logZ, discard_sample)

--- a/src/mcmc/prior.jl
+++ b/src/mcmc/prior.jl
@@ -2,17 +2,45 @@
     Prior()
 
 Algorithm for sampling from the prior.
+
+Every draw is an independent draw from the prior, so there is no starting point for
+`initial_params` to set; passing one warns and has no effect. To hold a variable at a value,
+`condition` or `fix` the model instead.
 """
 struct Prior <: AbstractSampler end
 
 function AbstractMCMC.step(
     rng::Random.AbstractRNG,
     model::DynamicPPL.Model,
-    sampler::Prior,
-    state=nothing;
+    sampler::Prior;
+    initial_params=DynamicPPL.InitFromPrior(),
     discard_sample=false,
     kwargs...,
 )
+    # Every draw comes from the prior independently, so there is no starting point for one to
+    # set: honouring `initial_params` would put a value that is not a prior draw into a sample
+    # advertised as one. It is still ignored; only the silence has gone. Warned here, in the
+    # method that starts a run, rather than in the one below that continues it, so that it is
+    # said once per `sample` call -- `maxlog` would instead say it once per session, leaving
+    # every later call as quiet as before.
+    warn_initial_params_ignored(
+        "`Prior()`", "draws every sample from the prior", initial_params
+    )
+    return _prior_step(rng, model, discard_sample)
+end
+
+function AbstractMCMC.step(
+    rng::Random.AbstractRNG,
+    model::DynamicPPL.Model,
+    sampler::Prior,
+    state;
+    discard_sample=false,
+    kwargs...,
+)
+    return _prior_step(rng, model, discard_sample)
+end
+
+function _prior_step(rng::Random.AbstractRNG, model::DynamicPPL.Model, discard_sample::Bool)
     accs = DynamicPPL.AccumulatorTuple((
         DynamicPPL.RawValueAccumulator(true),
         DynamicPPL.LogPriorAccumulator(),

--- a/test/mcmc/Inference.jl
+++ b/test/mcmc/Inference.jl
@@ -18,7 +18,9 @@ import ReverseDiff
 import Statistics
 using StableRNGs: StableRNG
 using StatsFuns: logsumexp
-using Test: @test, @test_throws, @testset
+using Logging: Logging
+import Test
+using Test: @test, @test_logs, @test_throws, @testset
 using Turing
 
 @testset verbose = true "Testing Inference.jl" begin
@@ -210,6 +212,44 @@ using Turing
             @test isapprox(chain[:logjoint], chain[:logprior] .+ chain[:loglikelihood])
             # And that the outcome is not influenced by the likelihood
             @test mean(chain[@varname(x)]) ≈ 0.0 atol = 0.1
+        end
+
+        @testset "initial_params is ignored out loud, not in silence" begin
+            @model f() = x ~ Normal(2.0, 1.0)
+            @test_logs (:warn, r"`initial_params` has no effect") sample(
+                StableRNG(3),
+                f(),
+                Prior(),
+                2;
+                initial_params=DynamicPPL.InitFromParams((x=99.0,)),
+            )
+            # Said once per `sample`, not once per session: `maxlog` would leave every call
+            # after the first as quiet as before the warning existed. And not once per draw
+            # either, which is why it lives in the method that starts a run.
+            tl = Test.TestLogger()
+            Logging.with_logger(tl) do
+                for i in 1:3
+                    sample(
+                        StableRNG(i),
+                        f(),
+                        Prior(),
+                        2;
+                        initial_params=DynamicPPL.InitFromParams((x=99.0,)),
+                    )
+                end
+            end
+            @test count(r -> occursin("initial_params", string(r.message)), tl.logs) == 3
+            # The ordinary path stays silent, which is the risk of warning from `step`.
+            @test_logs min_level = Logging.Warn sample(StableRNG(3), f(), Prior(), 5)
+            # And the draws really are prior draws, not the value that was ignored.
+            chain = sample(
+                StableRNG(3),
+                f(),
+                Prior(),
+                200;
+                initial_params=DynamicPPL.InitFromParams((x=99.0,)),
+            )
+            @test all(<(20), chain[@varname(x)])
         end
     end
 


### PR DESCRIPTION
`Prior()` accepted `initial_params` and discarded it without a word. It stays discarded — every draw is an independent prior draw — and now says so once per `sample`.

Two notes before these go up. None of the four closes an existing issue, so no Fixes line is included; add one if you know of a matching issue. And optimisation is the one where the title undersells the diff — four separate silent-failure modes in src/optimisation/init.jl, each with its own commit and regression test — so a reviewer may want the commit log rather than the body alone.