### PR TITLE
mh: validate exact proposal sites

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,15 @@ Note: "linked" and "unconstrained" are synonymous in this codebase. Linking tran
 
 Interfaces that accept or return named parameter collections should use `VarNamedTuple`, not `NamedTuple` or `Dict{VarName}`. `NamedTuple` and `Dict{VarName}` are accepted as user-facing input but should be converted to `VarNamedTuple` at the boundary (see `_to_varnamedtuple` in `src/common.jl`). Don't propagate them through internal code.
 
+Inference code that selects proposals, transforms, or density terms by `VarName` must use
+the exact name passed to `tilde_assume!!`. Parameter values do not preserve that identity:
+`haskey(values, @varname(x))` can succeed for separate sites `x[1]` and `x[2]`, while
+`keys(raw_values)` can expose those two names for the single site `x[1:2]`; raw values may
+also include `:=` outputs. Track executed sites separately and require exact membership.
+Otherwise sampling, transformation, and density accounting can cover different sites and
+bias the chain. MH proposal keys follow this rule; Gibbs alone determines which sites a
+component updates.
+
 ### `getlogjoint_internal` vs `getlogjoint`
 
 Samplers operating in unconstrained space should use `getlogjoint_internal`, which includes the Jacobian correction from the linking transform. This is the default and what you almost always want. The exceptions are ESS (which needs the likelihood in constrained space, per the algorithm) and optimisation (where the Jacobian term should not influence the objective).

--- a/src/mcmc/mh.jl
+++ b/src/mcmc/mh.jl
@@ -11,7 +11,9 @@ Each argument `proposal` can be
 - Blank (i.e. `MH()`), in which case `MH` defaults to using the prior for each parameter as
   the proposal distribution.
 - A mapping of `VarName`s to a `Distribution`, `LinkedRW`, or a generic callable that
-  defines a conditional proposal distribution.
+  defines a conditional proposal distribution. Each key must exactly equal the complete
+  left-hand side of an executed `~` statement: `@varname(x)` does not match `x[1] ~ ...`.
+  A `Symbol` can be used when the left-hand side is a root `VarName`.
 
 
     MH(cov_matrix)
@@ -131,11 +133,7 @@ spl = MH(
 ```
 """
 struct MH{I,L<:DynamicPPL.AbstractTransformStrategy} <: AbstractSampler
-    "A function which takes two arguments: (1) the VarNamedTuple of raw values at the
-    previous step, and (2) a VarNamedTuple of linked values for any variables that have
-    `LinkedRW` proposals; and returns an AbstractInitStrategy. We don't have access to the
-    VNTs until the actual sampling, so we have to use a function here; the strategy itself
-    will be constructed anew in each sampling step."
+    "Construct an init strategy from raw values, linked values, and exact `~` sites."
     init_strategy_constructor::I
     "Linked variables, i.e., variables which have a `LinkedRW` proposal."
     transform_strategy::L
@@ -216,18 +214,14 @@ _to_varname(x) = throw(ArgumentError("Expected Symbol or VarName, got $(typeof(x
 
 function MH(pair1::SymOrVNPair, pairs::Vararg{SymOrVNPair})
     vn_proposal_pairs = (pair1, pairs...)
-    # It is assumed that `raw_vals` is a VarNamedTuple that has all the variables' values
-    # already set. We can obtain this by using `RawValueAccumulator`. Furthermore,
-    # `linked_vals` is a VarNamedTuple that stores a `MHLinkedVal` for any variables that
-    # have `LinkedRW` proposals. That in turn is obtained using `MHLinkedValuesAccumulator`.
-    function init_strategy_constructor(raw_vals, linked_vals)
+    function init_strategy_constructor(raw_vals, linked_vals, sites)
         proposals = DynamicPPL.VarNamedTuple()
         for pair in vn_proposal_pairs
-            # Convert all keys to VarNames.
             vn, proposal = pair
             vn = _to_varname(vn)
-            if !haskey(raw_vals, vn)
-                continue
+            if !(vn in keys(sites))
+                msg = "MH proposal `$vn` does not exactly match an executed `~` site"
+                throw(ArgumentError(msg))
             end
             proposal_dist = if proposal isa Distribution
                 # Static proposal.
@@ -271,6 +265,7 @@ function AbstractMCMC.step(
     # Generate and return initial parameters.
     vi = DynamicPPL.OnlyAccsVarInfo()
     vi = DynamicPPL.setacc!!(vi, DynamicPPL.RawValueAccumulator(true))
+    vi = DynamicPPL.setacc!!(vi, MHSitesAccumulator())
     vi = DynamicPPL.setacc!!(vi, MHLinkedValuesAccumulator())
     vi = DynamicPPL.setacc!!(vi, MHUnspecifiedPriorsAccumulator(spl.vns_with_proposal))
     _, vi = DynamicPPL.init!!(rng, model, vi, initial_params, spl.transform_strategy)
@@ -283,7 +278,10 @@ function AbstractMCMC.step(
     # here.
     initial_raw_values = DynamicPPL.get_raw_values(vi)
     initial_linked_values = DynamicPPL.getacc(vi, Val(MH_ACC_NAME)).values
-    init_strategy = spl.init_strategy_constructor(initial_raw_values, initial_linked_values)
+    initial_sites = DynamicPPL.getacc(vi, Val(MH_SITE_ACC_NAME)).values
+    init_strategy = spl.init_strategy_constructor(
+        initial_raw_values, initial_linked_values, initial_sites
+    )
     initial_unspecified_priors = DynamicPPL.getacc(vi, Val(MH_PRIOR_ACC_NAME)).values
     initial_log_proposal_density = log_proposal_density(
         vi, init_strategy, initial_unspecified_priors
@@ -308,10 +306,7 @@ function AbstractMCMC.step(
         )
     end
 
-    # We evaluate the model once with the sampler's init strategy and print all the
-    # proposals that were used. This helps the user detect cases where the proposals are
-    # silently ignored (e.g. because the VarName in the proposal doesn't match the VarName
-    # in the model).
+    # Evaluate the model once with a verbose strategy to report each site's proposal.
     if verbose && init_strategy isa InitFromProposals
         @info "When sampling with MH, the following proposals will be used at each step.\nThis output can be disabled by passing `verbose=false` to `sample()`."
         verbose_init_strategy = InitFromProposals(init_strategy.proposals, true)
@@ -338,15 +333,17 @@ function AbstractMCMC.step(
     # that were used in the previous step.
     old_raw_values = DynamicPPL.get_raw_values(old_vi)
     old_linked_values = DynamicPPL.getacc(old_vi, Val(MH_ACC_NAME)).values
+    old_sites = DynamicPPL.getacc(old_vi, Val(MH_SITE_ACC_NAME)).values
     old_unspecified_priors = DynamicPPL.getacc(old_vi, Val(MH_PRIOR_ACC_NAME)).values
 
     init_strategy_given_old = spl.init_strategy_constructor(
-        old_raw_values, old_linked_values
+        old_raw_values, old_linked_values, old_sites
     )
 
     # Evaluate the model with a new proposal.
     new_vi = DynamicPPL.OnlyAccsVarInfo()
     new_vi = DynamicPPL.setacc!!(new_vi, DynamicPPL.RawValueAccumulator(true))
+    new_vi = DynamicPPL.setacc!!(new_vi, MHSitesAccumulator())
     new_vi = DynamicPPL.setacc!!(new_vi, MHLinkedValuesAccumulator())
     new_vi = DynamicPPL.setacc!!(
         new_vi, MHUnspecifiedPriorsAccumulator(spl.vns_with_proposal)
@@ -360,10 +357,11 @@ function AbstractMCMC.step(
     # ratio.
     new_raw_values = DynamicPPL.get_raw_values(new_vi)
     new_linked_values = DynamicPPL.getacc(new_vi, Val(MH_ACC_NAME)).values
+    new_sites = DynamicPPL.getacc(new_vi, Val(MH_SITE_ACC_NAME)).values
     new_unspecified_priors = DynamicPPL.getacc(new_vi, Val(MH_PRIOR_ACC_NAME)).values
 
     init_strategy_given_new = spl.init_strategy_constructor(
-        new_raw_values, new_linked_values
+        new_raw_values, new_linked_values, new_sites
     )
 
     # Calculate the log-acceptance probability.
@@ -458,6 +456,12 @@ end
 function MHLinkedValuesAccumulator()
     return DynamicPPL.VNTAccumulator{MH_ACC_NAME}(store_linked_values)
 end
+
+# Record exact `~` VarNames for proposal matching; raw values split ranged sites and
+# include `:=` variables.
+const MH_SITE_ACC_NAME = :MHSites
+store_mh_site(val, tval, logjac, vn, dist) = nothing
+MHSitesAccumulator() = DynamicPPL.VNTAccumulator{MH_SITE_ACC_NAME}(store_mh_site)
 
 # Accumulator to store priors for any variables that were not given an explicit proposal.
 # This is needed to compute the log-proposal density correctly.

--- a/test/mcmc/mh.jl
+++ b/test/mcmc/mh.jl
@@ -60,6 +60,7 @@ GKernel(variance, vn) = (vnt -> Normal(vnt[vn], sqrt(variance)))
             test_mean_and_std(MH(@varname(y) => LinkedRW(0.5)))
             # this is a random walk in unlinked space
             test_mean_and_std(MH(@varname(y) => vnt -> Normal(vnt[@varname(y)], 0.5)))
+            # https://github.com/TuringLang/Turing.jl/issues/1583
             test_mean_and_std(MH(@varname(x) => Normal(), @varname(y) => LinkedRW(0.5)))
             test_mean_and_std(MH(@varname(x) => LinkedRW(0.5), @varname(y) => Normal()))
             # this uses AdvancedMH
@@ -121,31 +122,42 @@ GKernel(variance, vn) = (vnt -> Normal(vnt[vn], sqrt(variance)))
         end
     end
 
-    @testset "info statements about proposals" begin
-        @model function f()
+    @testset "proposal names and logging" begin
+        @model function indexed_sites()
             x = zeros(2)
             x[1] ~ Normal()
             return x[2] ~ Normal()
         end
 
-        spl = MH(@varname(x[1]) => Normal(), @varname(x[2]) => Normal())
+        # https://github.com/TuringLang/Turing.jl/issues/2876
+        aggregate_spl = MH(@varname(x) => MvNormal(zeros(2), I))
+        @test_throws ArgumentError sample(indexed_sites(), aggregate_spl, 2; progress=false)
+        indexed_spl = MH(@varname(x[1]) => Normal(), @varname(x[2]) => Normal())
         @test_logs (:info, r"varname x\[1\]: proposal .*Normal") (
             :info, r"varname x\[2\]: proposal .*Normal"
-        ) match_mode = :any sample(f(), spl, 2; progress=false)
+        ) match_mode = :any sample(indexed_sites(), indexed_spl, 2; progress=false)
 
-        spl = MH(@varname(x) => MvNormal(zeros(2), I))
-        @test_logs (:info, r"varname x\[1\]: no proposal specified") (
-            :info, r"varname x\[2\]: no proposal specified"
-        ) match_mode = :any sample(f(), spl, 2; progress=false)
+        @model function ranged_site()
+            x = zeros(2)
+            return x[1:2] ~ MvNormal(zeros(2), I)
+        end
+        @test_throws ArgumentError sample(ranged_site(), indexed_spl, 2; progress=false)
+        ranged_spl = MH(@varname(x[1:2]) => MvNormal(zeros(2), I))
+        @test_logs (:info, r"varname x\[1:2\]: proposal") match_mode = :any sample(
+            ranged_site(), ranged_spl, 2; progress=false
+        )
 
-        spl = MH(@varname(x.a) => Normal(), @varname(x[2]) => Normal())
-        @test_logs (:info, r"varname x\[1\]: no proposal specified") (
-            :info, r"varname x\[2\]: proposal .*Normal"
-        ) match_mode = :any sample(f(), spl, 2; progress=false)
+        @model function deterministic_site()
+            x ~ Normal()
+            return y := x
+        end
+        @test_throws ArgumentError sample(
+            deterministic_site(), MH(:y => Normal()), 2; progress=false
+        )
 
         # Check that verbose=false disables it
         @test_logs min_level = Logging.Info sample(
-            f(), spl, 2; progress=false, verbose=false
+            indexed_sites(), indexed_spl, 2; progress=false, verbose=false
         )
     end
 


### PR DESCRIPTION
Draft alternative to #2877 for #2876. This records `VarName`s seen at executed `~` sites and requires keyed MH proposals to match exactly, preventing unused aggregate proposals from entering the acceptance ratio. Tests cover indexed and ranged sites, `:=` variables, and #1583-related linking behavior.

Open questions remain around preserving linear-index identity, distinguishing inactive proposals under conditioning and Gibbs, and avoiding repeated site-key scans. These should be resolved before this approach is merged.