### PR TITLE
ESS retains stale prior means after Gibbs conditioning

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -22,6 +22,8 @@ docstring ([#2863](https://github.com/TuringLang/Turing.jl/pull/2863)).
 
 ## Other changes
 
+`ESS` Gibbs components now use the current conditional prior after another component changes its parameters.
+
 Gibbs chains now include component-sampler statistics
 ([#2863](https://github.com/TuringLang/Turing.jl/pull/2863)).
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -22,7 +22,8 @@ docstring ([#2863](https://github.com/TuringLang/Turing.jl/pull/2863)).
 
 ## Other changes
 
-`ESS` Gibbs components now use the current conditional prior after another component changes its parameters.
+`ESS` Gibbs components now use the current conditional prior after another component changes its parameters
+([#2885](https://github.com/TuringLang/Turing.jl/pull/2885)).
 
 Gibbs chains now include component-sampler statistics
 ([#2863](https://github.com/TuringLang/Turing.jl/pull/2863)).

--- a/src/mcmc/ess.jl
+++ b/src/mcmc/ess.jl
@@ -198,12 +198,14 @@ function gibbs_update_state!!(
     model::DynamicPPL.Model,
     global_vals::DynamicPPL.VarNamedTuple,
 )
-    # TODO(TuringLang/Turing.jl#2873): Rebuild the priors here. Reusing `state.priors` is
-    # incorrect when another component changes their parameters.
-    # Collect the new likelihood during the same model evaluation.
+    # Another component can change the parameters of this block's conditional priors.
     new_ldf, new_params, accs = gibbs_recompute_ldf_and_params(
-        state.ldf, model, global_vals, (DynamicPPL.LogLikelihoodAccumulator(),)
+        state.ldf,
+        model,
+        global_vals,
+        (DynamicPPL.LogLikelihoodAccumulator(), DynamicPPL.PriorDistributionAccumulator()),
     )
     new_loglike = DynamicPPL.getloglikelihood(accs)
-    return TuringESSState(new_ldf, new_params, new_loglike, state.priors)
+    new_priors = DynamicPPL.get_priors(accs)
+    return TuringESSState(new_ldf, new_params, new_loglike, new_priors)
 end

--- a/test/mcmc/ess.jl
+++ b/test/mcmc/ess.jl
@@ -126,7 +126,8 @@ using Turing
         @test chn1[@varname(x)] == chn2[@varname(x[1])]
         @test chn1[@varname(y)] == chn2[@varname(x[2])]
         @test mean(chn1[@varname(z)]) ≈ mean(zdist) atol = 0.05
-        @test mean(chn1[@varname(y)]) ≈ mean(ydist) atol = 0.05
+        @test mean(chn1[@varname(x)]) ≈ mean(zdist) atol = 0.05
+        @test mean(chn1[@varname(y)]) ≈ mean(ydist) atol = 0.1
     end
 end
 


### PR DESCRIPTION
`gibbs_update_state!!(::ESS, ...)` rebuilds the conditioned log-density and parameters but retains initialization-time priors. When another component changes a prior’s parameters, ESS centres proposals on a stale mean and biases the chain. Refresh the priors during the same conditioned-model evaluation.

Fix https://github.com/TuringLang/Turing.jl/issues/2873