### PR TITLE
Reject model-dropping `setparams!!` in external Gibbs components

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -33,6 +33,9 @@ Gibbs chains now include component-sampler statistics
 
 `Prior()` now warns that `initial_params` has no effect instead of discarding it silently ([#2881](https://github.com/TuringLang/Turing.jl/pull/2881)).
 
+`Gibbs` now rejects an external sampler whose state inherits AbstractMCMC's model-dropping
+three-argument `setparams!!` fallback, rather than running with stale model-dependent caches.
+
 # 0.47.4
 
 `externalsampler` now forwards `AbstractMCMC.step_warmup` to the sampler it wraps, so an

--- a/src/mcmc/external_sampler.jl
+++ b/src/mcmc/external_sampler.jl
@@ -310,6 +310,37 @@ end
 #### Gibbs interface
 ####
 
+const _ABSTRACTMCMC_SETPARAMS_FALLBACK = which(
+    AbstractMCMC.setparams!!, Tuple{AbstractMCMC.AbstractModel,Any,Any}
+)
+
+_check_external_sampler_setparams_for_gibbs(::AbstractSampler, ::Any) = nothing
+function _check_external_sampler_setparams_for_gibbs(
+    sampler::ExternalSampler, state::TuringState
+)
+    signature = Tuple{
+        AbstractMCMC.LogDensityModel{typeof(state.ldf)},
+        typeof(state.state),
+        typeof(state.params),
+    }
+    if which(AbstractMCMC.setparams!!, signature) === _ABSTRACTMCMC_SETPARAMS_FALLBACK
+        sampler_name = nameof(typeof(sampler.sampler))
+        state_name = nameof(typeof(state.state))
+        throw(
+            ArgumentError(
+                "externalsampler($(sampler_name)) cannot be used as a Gibbs component: " *
+                "`AbstractMCMC.setparams!!` for $(state_name) dispatches to " *
+                "AbstractMCMC's fallback, which discards the reconditioned model. Define " *
+                "a three-argument method for this state type that updates all " *
+                "model-dependent state. A cacheless state may delegate explicitly to " *
+                "`setparams!!(state, params)`. See " *
+                "Turing.jl/issues/2875 for details.",
+            ),
+        )
+    end
+    return nothing
+end
+
 function gibbs_get_parameter_values(state::TuringState)
     pws = DynamicPPL.ParamsWithStats(
         state.params, state.ldf; include_log_probs=false, include_colon_eq=false

--- a/src/mcmc/gibbs.jl
+++ b/src/mcmc/gibbs.jl
@@ -1332,6 +1332,7 @@ function gibbs_initialstep_recursive(
         kwargs...,
         discard_sample=true,
     )
+    _check_external_sampler_setparams_for_gibbs(sampler, new_state)
     report = gibbs_get_parameter_values(new_state)
     check_reported_variables(varnames, conditioned, report)
     proposed = merge(conditioned, report)

--- a/test/mcmc/external_sampler.jl
+++ b/test/mcmc/external_sampler.jl
@@ -28,6 +28,7 @@ using Turing.Inference: AdvancedHMC
     end
     AbstractMCMC.getparams(s::MyState) = s.params
     AbstractMCMC.getstats(s::MyState) = (param_length=length(s.params),)
+    AbstractMCMC.setparams!!(::MyState, params) = MyState(params)
 
     # externalsamplers must accept LogDensityModel inside their step function.
     # By default Turing gives the externalsampler a LDF constructed with
@@ -146,6 +147,11 @@ using Turing.Inference: AdvancedHMC
     @test all(chn[:logprior] .== expected_logpdf)
     @test all(chn[:loglikelihood] .== 0.0)
     @test all(chn[:param_length] .== 2)
+
+    @testset "Gibbs requires model-aware state updates" begin
+        spl = Gibbs(@varname(a) => externalsampler(MySampler()), @varname(b) => MH())
+        @test_throws "Turing.jl/issues/2875" AbstractMCMC.step(StableRNG(42), model, spl)
+    end
 
     @testset "warmup steps reach the external sampler" begin
         spl = WarmupCounter()


### PR DESCRIPTION
AbstractMCMC’s three-argument `setparams!!` fallback discards the reconditioned model, leaving model-dependent caches stale. Reject external Gibbs components that use this fallback once their state type is known.

Closes #2875.