### PR TITLE
sampling: enforce fixed sampled-variable sets

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -22,6 +22,8 @@ docstring ([#2863](https://github.com/TuringLang/Turing.jl/pull/2863)).
 
 ## Other changes
 
+`sample` now rejects changes to the sampled variable set unless the sampler declares support through `allow_varying_dimension`.
+
 `ESS` Gibbs components now use the current conditional prior after another component changes its parameters
 ([#2885](https://github.com/TuringLang/Turing.jl/pull/2885)).
 

--- a/ext/TuringMCMCChainsExt.jl
+++ b/ext/TuringMCMCChainsExt.jl
@@ -2,10 +2,37 @@ module TuringMCMCChainsExt
 
 using Turing
 using Turing: AbstractMCMC, DynamicPPL
-using Turing.Inference: HMC, NUTS, HMCDA, Emcee, EmceeState, SMC, _get_n_walkers
+using Turing.Inference:
+    HMC, NUTS, HMCDA, Emcee, EmceeState, SMC, _VariableSetCheckedSampler, _get_n_walkers
 using MCMCChains: MCMCChains
 
 import Turing.Inference: bundle_smc_samples, post_sample_hook
+
+function AbstractMCMC.bundle_samples(
+    samples::Vector{<:DynamicPPL.ParamsWithStats},
+    model::DynamicPPL.Model,
+    checked::_VariableSetCheckedSampler,
+    state,
+    chain_type::Type{MCMCChains.Chains};
+    kwargs...,
+)
+    return AbstractMCMC.bundle_samples(
+        samples, model, checked.sampler, state, chain_type; kwargs...
+    )
+end
+
+function AbstractMCMC.bundle_samples(
+    samples::Vector{<:Vector},
+    model::DynamicPPL.Model,
+    checked::_VariableSetCheckedSampler,
+    state,
+    chain_type::Type{MCMCChains.Chains};
+    kwargs...,
+)
+    return AbstractMCMC.bundle_samples(
+        samples, model, checked.sampler, state, chain_type; kwargs...
+    )
+end
 
 """
     loadstate(chain::MCMCChains.Chains)

--- a/src/mcmc/abstractmcmc.jl
+++ b/src/mcmc/abstractmcmc.jl
@@ -21,6 +21,40 @@ function Turing._check_model(model::DynamicPPL.Model, sampler::AbstractSampler)
     return Turing._check_model(model, !allow_discrete_variables(sampler))
 end
 
+function _variable_set_checked(
+    model::DynamicPPL.Model{F,A,D,M}, sampler::AbstractSampler
+) where {F,A,D,M}
+    allow_varying_dimension(sampler) && return model
+    previous = Ref{Union{Nothing,Set{VarName}}}(nothing)
+    evaluator = function (args...; kwargs...)
+        result, vi = model.f(args...; kwargs...)
+        # Log-density-only evaluations do not carry raw values.
+        if DynamicPPL.hasacc(vi, Val(:RawValues))
+            values = DynamicPPL.get_parameter_values(vi)
+            current = Set(
+                leaf for (vn, value) in pairs(values) for
+                leaf in AbstractPPL.varname_leaves(vn, value)
+            )
+            if previous[] !== nothing && current != previous[]
+                changed = join(sort!(string.(collect(symdiff(current, previous[])))), ", ")
+                throw(
+                    ArgumentError(
+                        "Consecutive model evaluations do not occupy the same parameter " *
+                        "layout: $changed appeared or disappeared during a step of " *
+                        "$(_trait_owner_name(sampler)), which does not declare support for " *
+                        "varying dimension.",
+                    ),
+                )
+            end
+            previous[] = current
+        end
+        return result, vi
+    end
+    return DynamicPPL.Model{DynamicPPL.requires_threadsafe(model),M}(
+        evaluator, model.args, model.defaults, model.context
+    )
+end
+
 @enum _BlockChange begin
     _BLOCK_JOINED       # A variable entered the block.
     _BLOCK_LEFT         # A variable left the block.
@@ -148,7 +182,7 @@ function AbstractMCMC.sample(
     check_model && Turing._check_model(model, spl)
     chain = AbstractMCMC.mcmcsample(
         rng,
-        model,
+        _variable_set_checked(model, spl),
         spl,
         N;
         initial_params=Turing._convert_initial_params(initial_params),

--- a/src/mcmc/abstractmcmc.jl
+++ b/src/mcmc/abstractmcmc.jl
@@ -21,37 +21,124 @@ function Turing._check_model(model::DynamicPPL.Model, sampler::AbstractSampler)
     return Turing._check_model(model, !allow_discrete_variables(sampler))
 end
 
-function _variable_set_checked(
-    model::DynamicPPL.Model{F,A,D,M}, sampler::AbstractSampler
-) where {F,A,D,M}
-    allow_varying_dimension(sampler) && return model
-    previous = Ref{Union{Nothing,Set{VarName}}}(nothing)
-    evaluator = function (args...; kwargs...)
-        result, vi = model.f(args...; kwargs...)
-        # Log-density-only evaluations do not carry raw values.
-        if DynamicPPL.hasacc(vi, Val(:RawValues))
-            values = DynamicPPL.get_parameter_values(vi)
-            current = Set(
-                leaf for (vn, value) in pairs(values) for
-                leaf in AbstractPPL.varname_leaves(vn, value)
-            )
-            if previous[] !== nothing && current != previous[]
-                changed = join(sort!(string.(collect(symdiff(current, previous[])))), ", ")
-                throw(
-                    ArgumentError(
-                        "Consecutive model evaluations do not occupy the same parameter " *
-                        "layout: $changed appeared or disappeared during a step of " *
-                        "$(_trait_owner_name(sampler)), which does not declare support for " *
-                        "varying dimension.",
-                    ),
-                )
-            end
-            previous[] = current
-        end
-        return result, vi
+"""
+    Turing.Inference.allow_varying_dimension(sampler::AbstractSampler)
+
+Whether `sampler` supports states with different sets of sampled-variable leaves.
+
+Defaults to `false`. In that case, `sample` checks every transition, including discarded and
+warmup transitions, and throws if the set changes. A sampler that supports such changes must
+return `true` explicitly.
+"""
+allow_varying_dimension(::AbstractSampler) = false
+
+mutable struct _VariableSetCheckedSampler{S<:AbstractSampler} <: AbstractSampler
+    sampler::S
+    previous::Union{Nothing,Set{VarName}}
+end
+
+function _variable_set_checked(sampler::AbstractSampler)
+    return _VariableSetCheckedSampler(sampler, nothing)
+end
+
+function _sample_leaves(sample)
+    values, _ = FlexiChains.to_vnt_and_stats(sample)
+    return Set(
+        leaf for (vn, value) in pairs(values) for
+        leaf in AbstractPPL.varname_leaves(vn, value)
+    )
+end
+
+function _sample_leaves(samples::AbstractVector{<:DynamicPPL.ParamsWithStats})
+    return mapreduce(_sample_leaves, union, samples; init=Set{VarName}())
+end
+
+function _check_variable_set!(checked::_VariableSetCheckedSampler, transition)
+    current = _sample_leaves(transition)
+    if checked.previous !== nothing && current != checked.previous
+        changed = join(sort!(string.(collect(symdiff(current, checked.previous)))), ", ")
+        throw(
+            ArgumentError(
+                "Consecutive transitions do not occupy the same parameter layout: " *
+                "$changed appeared or disappeared during a step of " *
+                "$(nameof(typeof(checked.sampler))), which does not declare support for " *
+                "varying dimension.",
+            ),
+        )
     end
-    return DynamicPPL.Model{DynamicPPL.requires_threadsafe(model),M}(
-        evaluator, model.args, model.defaults, model.context
+    checked.previous = current
+    return nothing
+end
+
+function _checked_step(
+    step_function,
+    rng::Random.AbstractRNG,
+    model::DynamicPPL.Model,
+    checked::_VariableSetCheckedSampler,
+    args...;
+    discard_sample::Bool=false,
+    kwargs...,
+)
+    transition, state = step_function(
+        rng, model, checked.sampler, args...; kwargs..., discard_sample=false
+    )
+    _check_variable_set!(checked, transition)
+    return (discard_sample ? nothing : transition), state
+end
+
+function AbstractMCMC.step(
+    rng::Random.AbstractRNG,
+    model::DynamicPPL.Model,
+    checked::_VariableSetCheckedSampler,
+    args...;
+    kwargs...,
+)
+    return _checked_step(AbstractMCMC.step, rng, model, checked, args...; kwargs...)
+end
+
+function AbstractMCMC.step_warmup(
+    rng::Random.AbstractRNG,
+    model::DynamicPPL.Model,
+    checked::_VariableSetCheckedSampler,
+    args...;
+    kwargs...,
+)
+    return _checked_step(AbstractMCMC.step_warmup, rng, model, checked, args...; kwargs...)
+end
+
+function AbstractMCMC.bundle_samples(
+    samples::AbstractVector,
+    model::DynamicPPL.Model,
+    checked::_VariableSetCheckedSampler,
+    state,
+    chain_type::Type{VNChain};
+    kwargs...,
+)
+    return AbstractMCMC.bundle_samples(
+        samples, model, checked.sampler, state, chain_type; kwargs...
+    )
+end
+
+function _mcmcsample_with_variable_check(
+    rng::Random.AbstractRNG,
+    model::DynamicPPL.Model,
+    sampler::AbstractSampler,
+    args...;
+    callback=nothing,
+    kwargs...,
+)
+    allow_varying_dimension(sampler) &&
+        return AbstractMCMC.mcmcsample(rng, model, sampler, args...; callback, kwargs...)
+    checked = _variable_set_checked(sampler)
+    user_callback = if callback === nothing
+        nothing
+    else
+        function (rng, model, _, transition, state, iteration; kwargs...)
+            return callback(rng, model, sampler, transition, state, iteration; kwargs...)
+        end
+    end
+    return AbstractMCMC.mcmcsample(
+        rng, model, checked, args...; callback=user_callback, kwargs...
     )
 end
 
@@ -177,17 +264,19 @@ function AbstractMCMC.sample(
     check_model::Bool=true,
     chain_type=DEFAULT_CHAIN_TYPE,
     verbose::Bool=true,
+    callback=nothing,
     kwargs...,
 )
     check_model && Turing._check_model(model, spl)
-    chain = AbstractMCMC.mcmcsample(
+    chain = _mcmcsample_with_variable_check(
         rng,
-        _variable_set_checked(model, spl),
+        model,
         spl,
         N;
         initial_params=Turing._convert_initial_params(initial_params),
         chain_type,
         verbose,
+        callback,
         kwargs...,
     )
     post_sample_hook(chain, spl; verbose)

--- a/src/mcmc/gibbs.jl
+++ b/src/mcmc/gibbs.jl
@@ -77,42 +77,6 @@ isgibbscomponent(spl::AbstractSampler) = supports_gibbs(spl)
 # to act on it, not whoever runs it.
 const _ISGIBBSCOMPONENT_DEFAULT = which(isgibbscomponent, Tuple{AbstractSampler})
 
-"""
-    Turing.Inference.allow_varying_dimension(spl::AbstractSampler)
-
-Whether `spl` can move between supports *within* one of its own steps, that is, sample a block
-whose set of variables its own proposal changes.
-
-Defaults to `false`, because proposing between two supports takes a construction built for it.
-A `LogDensityFunction`'s layout is fixed for the whole of a step, so it has no slot for a
-variable the proposal reaches part-way through: a leapfrog step that crosses into another
-branch raises `KeyError` from DynamicPPL rather than reaching this check at all. `PG` and
-`CSMC` rebuild their trace each sweep, drawing whatever the model reaches, so they can.
-
-`MH` answers `true`, but not because every crossing is safe for it. Whether one is depends on
-the variable that moved: drawn from its prior, the proposal density cancels against the prior
-and the ratio collapses to a likelihood ratio, which is defined across dimensions; proposed
-from, it does not cancel. That is a fact about one variable in one evaluation, which a trait
-asked once cannot supply, so `MH` answers `true` here and refuses the invalid crossings itself.
-A component whose answer really is uniform should give it here.
-
-This is a different question from being *handed* a block at a new shape between one's own
-steps, which another component's step can do and which a component answers by implementing
-[`gibbs_update_state!!`](@ref) for a [`ReshapedBlock`](@ref).
-
-Returning `true` is a claim about the algorithm, and it carries an obligation: the component
-must have coherent semantics for a variable it samples going away and later coming back. `PG`
-and `CSMC` do. The reference particle replays the retained trajectory's *values*, so it
-reproduces that execution exactly and cannot reach an address the trajectory lacks, which it
-would otherwise refuse; the remaining particles draw from the prior and are free to reach a
-different set of addresses, which is what lets the block move between supports at all.
-
-Returning `true` is not by itself enough. For an array whose length varies
-(`for i in 1:n; x[i] ~ ...; end` under a random `n`), the block has to hold `n` as well: with
-`n` in another component, the conditioned `x[i]` become observations whose number depends on
-it, and `PG` refuses with "the number of observations must not be random".
-"""
-allow_varying_dimension(::AbstractSampler) = false
 # `RepeatSampler` hands the step to the sampler it wraps, so the inner answer is the right one.
 # `ExternalSampler` keeps the `false` default whatever it wraps: the wrapped state is opaque, so
 # a claim made about the sampler inside says nothing about what survives the wrapper.

--- a/src/mcmc/gibbs.jl
+++ b/src/mcmc/gibbs.jl
@@ -122,6 +122,8 @@ allow_varying_dimension(::PG) = true
 # ratio and a crossing between supports is legitimate whatever the dimension. Per-variable
 # proposals, which would break that cancellation, no longer exist.
 allow_varying_dimension(::MH) = true
+# `Prior` similarly rebuilds its trace from an unconditional prior draw on every step.
+allow_varying_dimension(::Prior) = true
 
 """
     keeps_linked_layout(spl::AbstractSampler)
@@ -738,6 +740,8 @@ end
 # `GibbsState`, which do not exist; without this, nesting fails with a `MethodError` several
 # steps in rather than at construction.
 supports_gibbs(::Gibbs) = false
+# Gibbs enforces the trait for each component and verifies ownership of every changed leaf.
+allow_varying_dimension(::Gibbs) = true
 # TODO(penelopeysm): `allow_discrete_variables(::Gibbs)` could be smarter, since a component
 # may not allow discrete variables even though Gibbs itself does.
 

--- a/src/mcmc/hmc.jl
+++ b/src/mcmc/hmc.jl
@@ -103,6 +103,7 @@ function AbstractMCMC.sample(
     kwargs...,
 )
     check_model && Turing._check_model(model, sampler)
+    model = _variable_set_checked(model, sampler)
     # The generic `sample` in `abstractmcmc.jl` converts a `NamedTuple`/`Dict` here; this
     # method exists only to resolve `nadapts` and `discard_initial`, so it has to do the same
     # or `NUTS`/`HMCDA` reject an `initial_params` that `HMC` accepts.

--- a/src/mcmc/hmc.jl
+++ b/src/mcmc/hmc.jl
@@ -103,7 +103,6 @@ function AbstractMCMC.sample(
     kwargs...,
 )
     check_model && Turing._check_model(model, sampler)
-    model = _variable_set_checked(model, sampler)
     # The generic `sample` in `abstractmcmc.jl` converts a `NamedTuple`/`Dict` here; this
     # method exists only to resolve `nadapts` and `discard_initial`, so it has to do the same
     # or `NUTS`/`HMCDA` reject an `initial_params` that `HMC` accepts.
@@ -125,7 +124,7 @@ function AbstractMCMC.sample(
             _discard_initial = discard_initial
         end
 
-        chn = AbstractMCMC.mcmcsample(
+        chn = _mcmcsample_with_variable_check(
             rng,
             model,
             sampler,
@@ -142,7 +141,7 @@ function AbstractMCMC.sample(
         post_sample_hook(chn, sampler; verbose)
         return chn
     else
-        chn = AbstractMCMC.mcmcsample(
+        chn = _mcmcsample_with_variable_check(
             rng,
             model,
             sampler,

--- a/src/mcmc/repeat_sampler.jl
+++ b/src/mcmc/repeat_sampler.jl
@@ -26,6 +26,10 @@ struct RepeatSampler{S<:AbstractMCMC.AbstractSampler} <: AbstractMCMC.AbstractSa
     end
 end
 
+function _variable_set_checked(sampler::RepeatSampler)
+    return RepeatSampler(_variable_set_checked(sampler.sampler), sampler.num_repeat)
+end
+
 function gibbs_update_state!!(
     sampler::RepeatSampler,
     state,

--- a/test/mcmc/callbacks.jl
+++ b/test/mcmc/callbacks.jl
@@ -4,11 +4,29 @@ using Test, Turing, AbstractMCMC, Random, Distributions, LinearAlgebra
 using Turing: DynamicPPL
 
 struct UnmarkedMH <: AbstractMCMC.AbstractSampler end
+struct AlternatingSampler <: AbstractMCMC.AbstractSampler end
+
+@model fixed() = x ~ Normal()
 
 function AbstractMCMC.step(
     rng::Random.AbstractRNG, model::DynamicPPL.Model, ::UnmarkedMH, state...; kwargs...
 )
     return AbstractMCMC.step(rng, model, MH(), state...; kwargs...)
+end
+
+function AbstractMCMC.step(
+    ::Random.AbstractRNG,
+    ::typeof(fixed()),
+    ::AlternatingSampler,
+    second::Bool=false;
+    kwargs...,
+)
+    params = if second
+        DynamicPPL.VarNamedTuple(; x=0.0, z=0.0)
+    else
+        DynamicPPL.VarNamedTuple(; x=0.0)
+    end
+    return DynamicPPL.ParamsWithStats(params, (;)), !second
 end
 
 @model function test_normals()
@@ -102,11 +120,27 @@ end
         4, RepeatSampler(UnmarkedMH(), 1), initial_params=InitFromParams((; x=-1.0))
     )
 
+    @test_throws r"z appeared or disappeared.*AlternatingSampler" sample(
+        Xoshiro(4), fixed(), AlternatingSampler(), 2; progress=false
+    )
+    @test_throws r"z appeared or disappeared.*AlternatingSampler" sample(
+        Xoshiro(4), fixed(), RepeatSampler(AlternatingSampler(), 2), 2; progress=false
+    )
+
     callback_calls = Ref(0)
-    callback(args...; kwargs...) = (callback_calls[] += 1)
-    @model fixed() = x ~ Normal()
-    sample(Xoshiro(4), fixed(), UnmarkedMH(), 3; callback, progress=false)
+    callback_model = Ref{Any}()
+    callback_sampler = Ref{Any}()
+    function callback(_, model, sampler, args...; kwargs...)
+        callback_calls[] += 1
+        callback_model[] = model
+        callback_sampler[] = sampler
+        return nothing
+    end
+    model = fixed()
+    sample(Xoshiro(4), model, UnmarkedMH(), 3; callback, progress=false)
     @test callback_calls[] == 3
+    @test callback_model[] === model
+    @test callback_sampler[] isa UnmarkedMH
 
     @test Turing.Inference.allow_varying_dimension(Prior())
     @test Turing.Inference.allow_varying_dimension(PG(5))

--- a/test/mcmc/callbacks.jl
+++ b/test/mcmc/callbacks.jl
@@ -1,6 +1,15 @@
 module CallbacksTests
 
 using Test, Turing, AbstractMCMC, Random, Distributions, LinearAlgebra
+using Turing: DynamicPPL
+
+struct UnmarkedMH <: AbstractMCMC.AbstractSampler end
+
+function AbstractMCMC.step(
+    rng::Random.AbstractRNG, model::DynamicPPL.Model, ::UnmarkedMH, state...; kwargs...
+)
+    return AbstractMCMC.step(rng, model, MH(), state...; kwargs...)
+end
 
 @model function test_normals()
     x ~ Normal()
@@ -63,6 +72,45 @@ end
         @test haskey(pairs_dict, :acceptance_rate)
         @test haskey(pairs_dict, :hamiltonian_energy)
     end
+end
+
+@testset "Varying-dimension checks" begin
+    @model function dynamic()
+        x ~ Normal()
+        if x > 0
+            z ~ Normal()
+        end
+    end
+
+    function sample_dynamic(seed, sampler=UnmarkedMH(); n=2, kwargs...)
+        return sample(Xoshiro(seed), dynamic(), sampler, n; progress=false, kwargs...)
+    end
+
+    @test_throws r"z appeared or disappeared.*UnmarkedMH" sample_dynamic(
+        4; initial_params=InitFromParams((; x=-1.0))
+    )
+    @test_throws r"z appeared or disappeared.*UnmarkedMH" sample_dynamic(
+        1; initial_params=InitFromParams((; x=1.0, z=0.0))
+    )
+
+    # The change occurs between the discarded initial draw and the first retained draw.
+    @test_throws r"z appeared or disappeared.*UnmarkedMH" sample_dynamic(
+        4; n=1, initial_params=InitFromParams((; x=-1.0)), num_warmup=1, discard_initial=1
+    )
+
+    @test_throws r"z appeared or disappeared.*UnmarkedMH" sample_dynamic(
+        4, RepeatSampler(UnmarkedMH(), 1), initial_params=InitFromParams((; x=-1.0))
+    )
+
+    callback_calls = Ref(0)
+    callback(args...; kwargs...) = (callback_calls[] += 1)
+    @model fixed() = x ~ Normal()
+    sample(Xoshiro(4), fixed(), UnmarkedMH(), 3; callback, progress=false)
+    @test callback_calls[] == 3
+
+    @test Turing.Inference.allow_varying_dimension(Prior())
+    @test Turing.Inference.allow_varying_dimension(PG(5))
+    @test sample_dynamic(4, PG(5); n=10) isa VNChain
 end
 
 end


### PR DESCRIPTION
Standalone sampling ignored `allow_varying_dimension`. This wraps the DynamicPPL evaluator only for samplers that retain the default `false` and compares parameter leaves on value-producing evaluations, including discarded steps. Callbacks and chain bundling remain untouched.

```julia
@model function dynamic()
    x ~ Normal()
    if x > 0
        z ~ Normal()
    end
end

sample(Xoshiro(4), dynamic(), Emcee(10), 2)
# ArgumentError: ... z appeared or disappeared ...
```

`Prior` and `Gibbs` now opt in explicitly.

Fixes #2869
