### PR TITLE
optimisation: eliminate growable constraint warnings

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,6 +14,8 @@ parameter vector. In `Gibbs`, assign `MH(cov_matrix)` to the target variable blo
 
 `estimate_mode` now throws on a bound that does not cover a whole variable, where it previously either dropped it and returned the unconstrained mode or failed with a bare `DimensionMismatch`, and warns on a bound no variable can use rather than ignoring it in silence.
 
+`estimate_mode` now represents indexed bounds using the model's parameter shapes, avoiding growable-array warnings during optimisation.
+
 `Prior()` now warns that `initial_params` has no effect instead of discarding it silently.
 
 # 0.47.4

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,7 +14,7 @@ parameter vector. In `Gibbs`, assign `MH(cov_matrix)` to the target variable blo
 
 `estimate_mode` now throws on a bound that does not cover a whole variable, where it previously either dropped it and returned the unconstrained mode or failed with a bare `DimensionMismatch`, and warns on a bound no variable can use rather than ignoring it in silence.
 
-`estimate_mode` now represents indexed bounds using the model's parameter shapes, avoiding growable-array warnings during optimisation.
+`estimate_mode` now represents indexed bounds using the model's parameter shapes, avoiding growable-array warnings during optimisation ([#2888](https://github.com/TuringLang/Turing.jl/pull/2888)).
 
 `Prior()` now warns that `initial_params` has no effect instead of discarding it silently.
 

--- a/src/optimisation/Optimisation.jl
+++ b/src/optimisation/Optimisation.jl
@@ -158,7 +158,7 @@ end
 
 struct ConstraintCheckAccumulator{Vlb<:AbstractDict,Vub<:AbstractDict} <:
        AbstractAccumulator
-    # These maps are keyed by executed `~` sites; `VarNamedTuple` lookup also matches descendants.
+    # Keep exact site keys: `VarNamedTuple` can match `x[1]` from a bound for `x[1:2]`.
     lb::Vlb # Must be in unlinked space
     ub::Vub # Must be in unlinked space
 end
@@ -337,14 +337,8 @@ function estimate_mode(
     tfm_strategy = link ? DynamicPPL.LinkAll() : DynamicPPL.UnlinkAll()
     getlogdensity = logprob_func(estimator)
 
-    # Capture the model's parameter containers so indexed bounds can be represented with their
-    # actual shapes rather than inferred growable arrays.
-    layout_varinfo = DynamicPPL.OnlyAccsVarInfo((
-        DynamicPPL.VectorValueAccumulator(), DynamicPPL.RawValueAccumulator(false)
-    ))
-    _, layout_varinfo = DynamicPPL.init!!(
-        model, layout_varinfo, DynamicPPL.InitFromPrior(), tfm_strategy
-    )
+    # Capture model shapes before representing indexed bounds.
+    layout_varinfo = _optimisation_layout_varinfo(model, tfm_strategy)
     parameter_template = DynamicPPL.get_raw_values(layout_varinfo)
     lb = ModelConstraints(lb, parameter_template)
     ub = ModelConstraints(ub, parameter_template)
@@ -361,7 +355,7 @@ function estimate_mode(
     )
 
     # Generate bounds and initial parameters in the unlinked or linked space as requested.
-    lb_vec, ub_vec, inits_vec = make_optim_bounds_and_init(
+    lb_vec, ub_vec, inits_vec = _make_optim_bounds_and_init!(
         rng,
         ldf,
         Turing._convert_initial_params(initial_params),

--- a/src/optimisation/Optimisation.jl
+++ b/src/optimisation/Optimisation.jl
@@ -156,8 +156,9 @@ function DynamicPPL.InitFromParams(
     return DynamicPPL.InitFromParams(m.params, fallback)
 end
 
-struct ConstraintCheckAccumulator{Vlb<:VarNamedTuple,Vub<:VarNamedTuple} <:
+struct ConstraintCheckAccumulator{Vlb<:AbstractDict,Vub<:AbstractDict} <:
        AbstractAccumulator
+    # These maps are keyed by executed `~` sites; `VarNamedTuple` lookup also matches descendants.
     lb::Vlb # Must be in unlinked space
     ub::Vub # Must be in unlinked space
 end
@@ -172,8 +173,8 @@ function DynamicPPL.accumulate_assume!!(
     template::Any,
 )
     # `val`, `acc.lb`, and `acc.ub` are all in unlinked space.
-    lb = get_constraints(acc.lb, vn)
-    ub = get_constraints(acc.ub, vn)
+    lb = get(acc.lb, vn, nothing)
+    ub = get(acc.ub, vn, nothing)
     if !satisfies_constraints(lb, ub, val, dist)
         throw(
             DomainError(
@@ -333,28 +334,41 @@ function estimate_mode(
     solve_kwargs...,
 )
     check_model && Turing._check_model(model)
-    lb = Turing._to_varnamedtuple(lb)
-    ub = Turing._to_varnamedtuple(ub)
-
-    # Generate a LogDensityFunction first. We do this first because we want to use the
-    # info stored in the LDF to generate the initial parameters and constraints in the
-    # correct order.
     tfm_strategy = link ? DynamicPPL.LinkAll() : DynamicPPL.UnlinkAll()
     getlogdensity = logprob_func(estimator)
+
+    # Capture the model's parameter containers so indexed bounds can be represented with their
+    # actual shapes rather than inferred growable arrays.
+    layout_varinfo = DynamicPPL.OnlyAccsVarInfo((
+        DynamicPPL.VectorValueAccumulator(), DynamicPPL.RawValueAccumulator(false)
+    ))
+    _, layout_varinfo = DynamicPPL.init!!(
+        model, layout_varinfo, DynamicPPL.InitFromPrior(), tfm_strategy
+    )
+    parameter_template = DynamicPPL.get_raw_values(layout_varinfo)
+    lb = ModelConstraints(lb, parameter_template)
+    ub = ModelConstraints(ub, parameter_template)
+
+    resolved_lb = Dict{VarName,Any}()
+    resolved_ub = Dict{VarName,Any}()
     accs = if check_constraints_at_runtime
-        (logprob_accs(estimator)..., ConstraintCheckAccumulator(lb, ub))
+        (logprob_accs(estimator)..., ConstraintCheckAccumulator(resolved_lb, resolved_ub))
     else
         logprob_accs(estimator)
     end
-    # Note that we don't need adtype to construct the LDF, because it's specified inside the
-    # OptimizationProblem.
     ldf = LogDensityFunction(
-        model, getlogdensity, tfm_strategy, accs; fix_transforms=fix_transforms
+        model, getlogdensity, layout_varinfo, accs; fix_transforms=fix_transforms
     )
 
     # Generate bounds and initial parameters in the unlinked or linked space as requested.
     lb_vec, ub_vec, inits_vec = make_optim_bounds_and_init(
-        rng, ldf, Turing._convert_initial_params(initial_params), lb, ub
+        rng,
+        ldf,
+        Turing._convert_initial_params(initial_params),
+        lb,
+        ub,
+        resolved_lb,
+        resolved_ub,
     )
     # If there are no constraints, then we can omit them from the OptimizationProblem
     # construction. Note that lb and ub must be provided together, not just one of them.

--- a/src/optimisation/init.jl
+++ b/src/optimisation/init.jl
@@ -1,12 +1,11 @@
 using DynamicPPL: AbstractInitStrategy, AbstractAccumulator
 using Distributions
 
-# Store model-shaped constraints separately from keys retained only for reachability errors.
+# `values` uses model shapes; `unmatched` retains unrepresentable keys for diagnostics.
 struct ModelConstraints{V<:VarNamedTuple}
     values::V
     unmatched::Vector{Pair{VarName,Any}}
 end
-ModelConstraints(values::VarNamedTuple) = ModelConstraints(values, Pair{VarName,Any}[])
 
 function _model_constraints_from_pairs(constraints, template::VarNamedTuple)
     values = VarNamedTuple()
@@ -30,8 +29,8 @@ end
 function ModelConstraints(constraints::AbstractDict{<:VarName}, template::VarNamedTuple)
     return _model_constraints_from_pairs(constraints, template)
 end
-function ModelConstraints(constraints::NamedTuple, ::VarNamedTuple)
-    return ModelConstraints(VarNamedTuple(constraints))
+function ModelConstraints(constraints::NamedTuple, template::VarNamedTuple)
+    return ModelConstraints(VarNamedTuple(constraints), template)
 end
 function ModelConstraints(constraints::VarNamedTuple, template::VarNamedTuple)
     return _model_constraints_from_pairs(pairs(constraints), template)
@@ -39,6 +38,14 @@ end
 
 function _constraint_pairs(constraints::ModelConstraints)
     return Iterators.flatten((pairs(constraints.values), constraints.unmatched))
+end
+
+function _optimisation_layout_varinfo(model, transform_strategy)
+    vi = DynamicPPL.OnlyAccsVarInfo((
+        DynamicPPL.VectorValueAccumulator(), DynamicPPL.RawValueAccumulator(false)
+    ))
+    _, vi = DynamicPPL.init!!(model, vi, DynamicPPL.InitFromPrior(), transform_strategy)
+    return vi
 end
 
 """
@@ -356,25 +363,27 @@ function make_optim_bounds_and_init(
     lb::VarNamedTuple,
     ub::VarNamedTuple,
 )
-    return make_optim_bounds_and_init(
+    layout_varinfo = _optimisation_layout_varinfo(ldf.model, ldf.transform_strategy)
+    parameter_template = DynamicPPL.get_raw_values(layout_varinfo)
+    return _make_optim_bounds_and_init!(
         rng,
         ldf,
         initial_params,
-        ModelConstraints(lb),
-        ModelConstraints(ub),
+        ModelConstraints(lb, parameter_template),
+        ModelConstraints(ub, parameter_template),
         Dict{VarName,Any}(),
         Dict{VarName,Any}(),
     )
 end
 
-function make_optim_bounds_and_init(
+function _make_optim_bounds_and_init!(
     rng::Random.AbstractRNG,
     ldf::LogDensityFunction,
     initial_params::AbstractInitStrategy,
     lb::ModelConstraints,
     ub::ModelConstraints,
-    resolved_lb::AbstractDict,
-    resolved_ub::AbstractDict,
+    resolved_lb::Dict{VarName,Any},
+    resolved_ub::Dict{VarName,Any},
 )
     # Initialise a VarInfo with parameters that satisfy the constraints.
     # ConstraintAccumulator only needs the raw value so we can use UnlinkAll() as the
@@ -393,13 +402,6 @@ function make_optim_bounds_and_init(
     inits = fill(et(NaN), nelems)
     lb_vec = fill(et(-Inf), nelems)
     ub_vec = fill(et(Inf), nelems)
-    # Which variables a bound was actually written for. `check_constraints_reached` needs this
-    # rather than a prediction of it: asking `get_constraints` instead reported a bound as used
-    # whenever the collection could answer for the variable, which is not the same as the bound
-    # reaching this assembly. A bound naming non-leading elements of a variable the model writes
-    # whole -- `x[2]`, or `x[1]` and `x[3]` -- never arrives here at all, and was passed as
-    # harmless while the mode came back unconstrained.
-    applied_lb, applied_ub = VarName[], VarName[]
     for (vn, init_val) in constraint_acc.init_vecs
         range = DynamicPPL.get_range_and_transform(ldf, vn).range
         inits[range] = init_val
@@ -414,7 +416,6 @@ function make_optim_bounds_and_init(
             # refuse a bound the caller deliberately wrote as infinite.
             site_lb = get_constraints(lb, vn)
             if site_lb !== nothing
-                push!(applied_lb, vn)
                 resolved_lb[vn] = site_lb
             end
         end
@@ -423,15 +424,14 @@ function make_optim_bounds_and_init(
             ub_vec[range] = constraint_acc.ub_vecs[vn]
             site_ub = get_constraints(ub, vn)
             if site_ub !== nothing
-                push!(applied_ub, vn)
                 resolved_ub[vn] = site_ub
             end
         end
     end
     # The loop above visits the model's variables, so a bound whose key names none of them is
     # never consulted and the mode comes back unconstrained. Name it instead.
-    check_constraints_reached(lb, "lb", applied_lb, keys(constraint_acc.init_vecs))
-    check_constraints_reached(ub, "ub", applied_ub, keys(constraint_acc.init_vecs))
+    check_constraints_reached(lb, "lb", keys(resolved_lb), keys(constraint_acc.init_vecs))
+    check_constraints_reached(ub, "ub", keys(resolved_ub), keys(constraint_acc.init_vecs))
     # Make sure we have filled in all values. This should never happen, but we should just
     # check.
     if any(isnan, inits)

--- a/src/optimisation/init.jl
+++ b/src/optimisation/init.jl
@@ -1,13 +1,53 @@
 using DynamicPPL: AbstractInitStrategy, AbstractAccumulator
 using Distributions
 
+# Store model-shaped constraints separately from keys retained only for reachability errors.
+struct ModelConstraints{V<:VarNamedTuple}
+    values::V
+    unmatched::Vector{Pair{VarName,Any}}
+end
+ModelConstraints(values::VarNamedTuple) = ModelConstraints(values, Pair{VarName,Any}[])
+
+function _model_constraints_from_pairs(constraints, template::VarNamedTuple)
+    values = VarNamedTuple()
+    unmatched = Pair{VarName,Any}[]
+    for (vn, value) in constraints
+        sym = AbstractPPL.getsym(vn)
+        if !haskey(template.data, sym)
+            push!(unmatched, vn => value)
+            continue
+        end
+        try
+            values = DynamicPPL.templated_setindex!!(values, value, vn, template.data[sym])
+        catch err
+            err isa BoundsError || rethrow()
+            # Preserve out-of-range keys for the domain-specific coverage check below.
+            push!(unmatched, vn => value)
+        end
+    end
+    return ModelConstraints(values, unmatched)
+end
+function ModelConstraints(constraints::AbstractDict{<:VarName}, template::VarNamedTuple)
+    return _model_constraints_from_pairs(constraints, template)
+end
+function ModelConstraints(constraints::NamedTuple, ::VarNamedTuple)
+    return ModelConstraints(VarNamedTuple(constraints))
+end
+function ModelConstraints(constraints::VarNamedTuple, template::VarNamedTuple)
+    return _model_constraints_from_pairs(pairs(constraints), template)
+end
+
+function _constraint_pairs(constraints::ModelConstraints)
+    return Iterators.flatten((pairs(constraints.values), constraints.unmatched))
+end
+
 """
     InitWithConstraintCheck(lb, ub, actual_strategy) <: AbstractInitStrategy
 
 Initialise parameters with `actual_strategy`, but check that the initialised
 parameters satisfy any bounds in `lb` and `ub`.
 """
-struct InitWithConstraintCheck{Tlb<:VarNamedTuple,Tub<:VarNamedTuple} <:
+struct InitWithConstraintCheck{Tlb<:ModelConstraints,Tub<:ModelConstraints} <:
        AbstractInitStrategy
     lb::Tlb
     ub::Tub
@@ -20,6 +60,9 @@ function get_constraints(constraints::VarNamedTuple, vn::VarName)
     else
         return nothing
     end
+end
+function get_constraints(constraints::ModelConstraints, vn::VarName)
+    return get_constraints(constraints.values, vn)
 end
 
 const MAX_ATTEMPTS = 1000
@@ -168,7 +211,7 @@ can_have_linked_constraints(::Dirichlet) = false
 can_have_linked_constraints(::LKJCholesky) = false
 
 struct ConstraintAccumulator{
-    T<:DynamicPPL.AbstractTransformStrategy,Vlb<:VarNamedTuple,Vub<:VarNamedTuple
+    T<:DynamicPPL.AbstractTransformStrategy,Vlb<:ModelConstraints,Vub<:ModelConstraints
 } <: AbstractAccumulator
     "Whether to store constraints in linked space or not."
     transform_strategy::T
@@ -186,7 +229,9 @@ struct ConstraintAccumulator{
     space (if link=false)."
     ub_vecs::Dict{VarName,AbstractVector}
     function ConstraintAccumulator(
-        link::DynamicPPL.AbstractTransformStrategy, lb::VarNamedTuple, ub::VarNamedTuple
+        link::DynamicPPL.AbstractTransformStrategy,
+        lb::ModelConstraints,
+        ub::ModelConstraints,
     )
         return new{typeof(link),typeof(lb),typeof(ub)}(
             link,
@@ -311,6 +356,26 @@ function make_optim_bounds_and_init(
     lb::VarNamedTuple,
     ub::VarNamedTuple,
 )
+    return make_optim_bounds_and_init(
+        rng,
+        ldf,
+        initial_params,
+        ModelConstraints(lb),
+        ModelConstraints(ub),
+        Dict{VarName,Any}(),
+        Dict{VarName,Any}(),
+    )
+end
+
+function make_optim_bounds_and_init(
+    rng::Random.AbstractRNG,
+    ldf::LogDensityFunction,
+    initial_params::AbstractInitStrategy,
+    lb::ModelConstraints,
+    ub::ModelConstraints,
+    resolved_lb::AbstractDict,
+    resolved_ub::AbstractDict,
+)
     # Initialise a VarInfo with parameters that satisfy the constraints.
     # ConstraintAccumulator only needs the raw value so we can use UnlinkAll() as the
     # transform strategy for this
@@ -347,12 +412,20 @@ function make_optim_bounds_and_init(
             # `x[1] ~` leaves an infinite bound behind, and counting that as applied dropped
             # the caller's bound in silence. Testing `isfinite` on the result instead would
             # refuse a bound the caller deliberately wrote as infinite.
-            get_constraints(lb, vn) === nothing || push!(applied_lb, vn)
+            site_lb = get_constraints(lb, vn)
+            if site_lb !== nothing
+                push!(applied_lb, vn)
+                resolved_lb[vn] = site_lb
+            end
         end
         if haskey(constraint_acc.ub_vecs, vn)
             check_bound_covers(ub, "ub", vn, range)
             ub_vec[range] = constraint_acc.ub_vecs[vn]
-            get_constraints(ub, vn) === nothing || push!(applied_ub, vn)
+            site_ub = get_constraints(ub, vn)
+            if site_ub !== nothing
+                push!(applied_ub, vn)
+                resolved_ub[vn] = site_ub
+            end
         end
     end
     # The loop above visits the model's variables, so a bound whose key names none of them is
@@ -383,17 +456,15 @@ and `lb = (x = (a = [0.1, 0.1], b = 0.1),)` covers three. A key coarser than `vn
 a value can be read for `vn` -- a scalar `lb = (x = 0.9,)` holds nothing for an element-wise
 `x[1] ~` and is never applied.
 """
-function check_bound_covers(constraints::DynamicPPL.VarNamedTuple, name, vn, range)
+function check_bound_covers(constraints::ModelConstraints, name, vn, range)
     covered = 0
-    for leaf in keys(constraints)
-        if AbstractPPL.subsumes(vn, leaf)
+    for (key, value) in _constraint_pairs(constraints)
+        if AbstractPPL.subsumes(vn, key)
             # A key inside `vn` contributes the scalar leaves it holds, not the length of its
             # value: `(a = [0.1, 0.1], b = 0.1)` is one key of length two holding three
             # elements.
-            covered += count(
-                Returns(true), DynamicPPL.varname_leaves(leaf, constraints[leaf])
-            )
-        elseif AbstractPPL.subsumes(leaf, vn)
+            covered += count(Returns(true), DynamicPPL.varname_leaves(key, value))
+        elseif AbstractPPL.subsumes(key, vn)
             # A key coarser than `vn` covers it only if a value can actually be read for `vn`:
             # `lb = (x = [0.9, 0.9],)` bounds both of an element-wise `x[1] ~`, `x[2] ~`, while
             # a scalar `lb = (x = 0.9,)` holds nothing for `x[1]` and is never applied. Asking
@@ -433,13 +504,14 @@ a value the model writes whole cannot be honoured. When no reached variable cove
 is merely moot -- the key may name a variable that is conditioned, fixed, or in a branch not
 taken, which is indistinguishable here from one naming nothing -- so that warns.
 """
-function check_constraints_reached(constraints::VarNamedTuple, name, applied, model_vns)
+function check_constraints_reached(constraints::ModelConstraints, name, applied, model_vns)
     claims(vns, leaf) =
         any(vns) do vn
             AbstractPPL.subsumes(vn, leaf) || AbstractPPL.subsumes(leaf, vn)
         end
     leaves = Iterators.flatten(
-        DynamicPPL.varname_leaves(key, constraints[key]) for key in keys(constraints)
+        DynamicPPL.varname_leaves(key, value) for
+        (key, value) in _constraint_pairs(constraints)
     )
     unapplied = [leaf for leaf in leaves if !claims(applied, leaf)]
     isempty(unapplied) && return nothing

--- a/test/optimisation/Optimisation.jl
+++ b/test/optimisation/Optimisation.jl
@@ -218,7 +218,7 @@ end
         @test whole_result.params[@varname(x)] ≈ [0.9, 0.9] atol = 1e-4
 
         lb_vnt, ub_vnt = Logging.with_logger(Logging.NullLogger()) do
-            return (
+            (
                 VarNamedTuple(Dict(@varname(x[1]) => 0.9, @varname(x[2]) => 0.9)),
                 VarNamedTuple(Dict(@varname(x[1]) => 9.0, @varname(x[2]) => 9.0)),
             )

--- a/test/optimisation/Optimisation.jl
+++ b/test/optimisation/Optimisation.jl
@@ -930,7 +930,7 @@ end
         @model function collinear(x, y)
             a ~ Normal(0, 1)
             b ~ Normal(0, 1)
-            return y ~ MvNormal(a .* x .+ b .* x, 1)
+            return y ~ MvNormal(a .* x .+ b .* x, I)
         end
 
         model = collinear(xs, ys)

--- a/test/optimisation/Optimisation.jl
+++ b/test/optimisation/Optimisation.jl
@@ -204,12 +204,29 @@ end
             x[1:2] ~ MvNormal(zeros(2), I)
             return 1.0 ~ Normal(sum(x), 1)
         end
-        @test maximum_a_posteriori(slice(); lb=Dict(@varname(x[1:2]) => [0.9, 0.9]), ub=Dict(@varname(x[1:2]) => [9.0, 9.0])).params[@varname(
-            x[1]
-        )] ≈ 0.9 atol = 1e-4
-        @test maximum_a_posteriori(whole(); lb=Dict(@varname(x[1]) => 0.9, @varname(x[2]) => 0.9), ub=Dict(@varname(x[1]) => 9.0, @varname(x[2]) => 9.0)).params[@varname(
-            x
-        )] ≈ [0.9, 0.9] atol = 1e-4
+        slice_result = @test_logs min_level = Logging.Warn maximum_a_posteriori(
+            slice();
+            lb=Dict(@varname(x[1:2]) => [0.9, 0.9]),
+            ub=Dict(@varname(x[1:2]) => [9.0, 9.0]),
+        )
+        @test slice_result.params[@varname(x[1])] ≈ 0.9 atol = 1e-4
+        whole_result = @test_logs min_level = Logging.Warn maximum_a_posteriori(
+            whole();
+            lb=Dict(@varname(x[1]) => 0.9, @varname(x[2]) => 0.9),
+            ub=Dict(@varname(x[1]) => 9.0, @varname(x[2]) => 9.0),
+        )
+        @test whole_result.params[@varname(x)] ≈ [0.9, 0.9] atol = 1e-4
+
+        lb_vnt, ub_vnt = Logging.with_logger(Logging.NullLogger()) do
+            return (
+                VarNamedTuple(Dict(@varname(x[1]) => 0.9, @varname(x[2]) => 0.9)),
+                VarNamedTuple(Dict(@varname(x[1]) => 9.0, @varname(x[2]) => 9.0)),
+            )
+        end
+        vnt_result = @test_logs min_level = Logging.Warn maximum_a_posteriori(
+            whole(); lb=lb_vnt, ub=ub_vnt
+        )
+        @test vnt_result.params[@varname(x)] ≈ [0.9, 0.9] atol = 1e-4
         # A compound key covering more elements than the model reaches drops the surplus.
         # Accounting per key rather than per leaf let the one element `x[1]` consumes stand for
         # the whole of `x`, so the bound on `x[2]` disappeared without a word.
@@ -257,14 +274,16 @@ end
                 Dict(@varname(x[1]) => 0.5, @varname(x[3]) => 0.5),
             )
                 ub3 = Dict(k => 9.0 for k in keys(lb3))
-                @test_throws "element(s) under" maximum_a_posteriori(m3; lb=lb3, ub=ub3)
+                @test_logs min_level = Logging.Warn @test_throws(
+                    "element(s) under", maximum_a_posteriori(m3; lb=lb3, ub=ub3)
+                )
             end
             @test maximum_a_posteriori(m3; lb=(x=fill(0.5, 3),), ub=(x=fill(9.0, 3),)).params[@varname(
                 x[1]
             )] ≈ 0.5 atol = 1e-4
         end
 
-        @test_throws(
+        @test_logs min_level = Logging.Warn @test_throws(
             "which the model writes as one value",
             maximum_a_posteriori(
                 whole(); lb=Dict(@varname(x[1]) => 0.9), ub=Dict(@varname(x[1]) => 9.0)
@@ -273,7 +292,7 @@ end
         # Counting elements alone cannot tell a covering bound from one that names as many
         # elements somewhere else, so the coincidence has to be caught by the reachability
         # accounting instead.
-        @test_throws(
+        @test_logs min_level = Logging.Warn @test_throws(
             "cannot be applied",
             maximum_a_posteriori(
                 whole();


### PR DESCRIPTION
Indexed bounds previously emitted repeated DynamicPPL growable-array warnings:

```julia
using Turing, Distributions, LinearAlgebra

@model demo() = x ~ MvNormal(zeros(2), I)

lb = Dict(@varname(x[1]) => 0.0, @varname(x[2]) => 0.0)
ub = Dict(@varname(x[1]) => 1.0, @varname(x[2]) => 1.0)
maximum_a_posteriori(demo(); lb, ub)
```

Before:

```text
Warning: Creating a growable Base.Array...
Warning: Extracting a value from a growable Base.Array...
```

After:

```text
No warnings.
```

Bounds now use model-shaped templates, while runtime checks retain exact sampling-site keys. This also updates a deprecated `MvNormal` test call.