### PR TITLE
Fix Gibbs handling of wrapped external samplers and conditional sites

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -41,7 +41,10 @@ Gibbs chains now include component-sampler statistics
 `Prior()` now warns that `initial_params` has no effect instead of discarding it silently ([#2881](https://github.com/TuringLang/Turing.jl/pull/2881)).
 
 `Gibbs` now rejects an external sampler whose state inherits AbstractMCMC's model-dropping
-three-argument `setparams!!` fallback, rather than running with stale model-dependent caches.
+three-argument `setparams!!` fallback, rather than running with stale model-dependent caches
+([#2891](https://github.com/TuringLang/Turing.jl/pull/2891)).
+
+`GibbsConditional` now distinguishes a ranged tilde statement from multiple element-wise statements when given one conditional distribution ([#2891](https://github.com/TuringLang/Turing.jl/pull/2891)).
 
 # 0.47.4
 

--- a/README.md
+++ b/README.md
@@ -15,19 +15,12 @@
 
 `Turing.jl` is a general-purpose probabilistic programming package for Bayesian and
 likelihood-based inference. Implemented in Julia, it is designed to interoperate with the
-language's scientific computing ecosystem. Models defined with `@model` specify joint
-distributions and support Markov chain Monte Carlo, variational inference, maximum
-likelihood and maximum a posteriori estimation, and customised inference through Turing's
+language's scientific computing ecosystem. Models can be written with
+[`@model`](https://github.com/TuringLang/DynamicPPL.jl), in BUGS syntax via
+[JuliaBUGS.jl](https://github.com/TuringLang/JuliaBUGS.jl), or graphically with
+[DoodlePPL](https://turinglang.org/JuliaBUGS.jl/DoodlePPL/), and support MCMC, variational
+inference, maximum likelihood and MAP estimation, and customised inference through Turing's
 log-density and gradient interface.
-
-Turing is the user-facing entry point to the TuringLang ecosystem. Models can be written
-as Julia programs with [DynamicPPL.jl](https://github.com/TuringLang/DynamicPPL.jl) or in
-BUGS syntax with [JuliaBUGS.jl](https://github.com/TuringLang/JuliaBUGS.jl).
-[DoodlePPL](https://turinglang.org/JuliaBUGS.jl/DoodlePPL/) provides a browser-based
-graphical editor. Turing connects probabilistic models to inference algorithms provided by
-[AdvancedHMC.jl](https://github.com/TuringLang/AdvancedHMC.jl),
-[AdvancedMH.jl](https://github.com/TuringLang/AdvancedMH.jl),
-[AdvancedVI.jl](https://github.com/TuringLang/AdvancedVI.jl), and others.
 
 Turing's preferred automatic differentiation backends for gradient-based algorithms
 are [ForwardDiff.jl](https://github.com/JuliaDiff/ForwardDiff.jl) and

--- a/src/mcmc/external_sampler.jl
+++ b/src/mcmc/external_sampler.jl
@@ -351,11 +351,12 @@ end
 gibbs_get_stats(state::TuringState) = AbstractMCMC.getstats(state.state)
 
 function gibbs_update_state!!(
-    ::ExternalSampler,
+    sampler::ExternalSampler,
     state::TuringState,
     model::DynamicPPL.Model,
     global_vals::DynamicPPL.VarNamedTuple,
 )
+    _check_external_sampler_setparams_for_gibbs(sampler, state)
     new_ldf, new_params, _ = gibbs_recompute_ldf_and_params(state.ldf, model, global_vals)
     # Update the inner sampler's state with the new parameters.
     new_inner_state = AbstractMCMC.setparams!!(

--- a/src/mcmc/gibbs_conditional.jl
+++ b/src/mcmc/gibbs_conditional.jl
@@ -134,11 +134,9 @@ function build_values_vnt(model::DynamicPPL.Model)
     return vals
 end
 
-@inline _to_varnamedtuple(dists::NamedTuple, ::DynamicPPL.VarNamedTuple) =
-    DynamicPPL.VarNamedTuple(dists)
-@inline _to_varnamedtuple(dists::DynamicPPL.VarNamedTuple, ::DynamicPPL.VarNamedTuple) =
-    dists
-function _to_varnamedtuple(dists::AbstractDict{<:VarName}, ::DynamicPPL.VarNamedTuple)
+@inline _to_varnamedtuple(dists::NamedTuple) = DynamicPPL.VarNamedTuple(dists)
+@inline _to_varnamedtuple(dists::DynamicPPL.VarNamedTuple) = dists
+function _to_varnamedtuple(dists::AbstractDict{<:VarName})
     vnt = DynamicPPL.VarNamedTuple()
     for (vn, dist) in dists
         vnt = DynamicPPL.templated_setindex!!(vnt, dist, vn, _shape_template(dist))
@@ -166,31 +164,33 @@ one at an indexed `VarName` does not, and does not need it.
 _shape_template(::Distributions.UnivariateDistribution) = DynamicPPL.NoTemplate()
 _shape_template(d::Distributions.Distribution) = Array{eltype(d)}(undef, size(d))
 _shape_template(_) = DynamicPPL.NoTemplate()
-function _to_varnamedtuple(dist::Distribution, raw_values::DynamicPPL.VarNamedTuple)
-    vns = collect(keys(raw_values))
-    # Distinct variables, not distinct keys. One tilde statement can leave several: a
-    # `theta[:] ~ MvNormal(...)` site stores `theta[1], theta[2]`, so counting keys refused
-    # the very form this method exists to support.
-    syms = unique(AbstractPPL.getsym(vn) for vn in vns)
-    if length(syms) > 1
-        msg = (
-            "In GibbsConditional, `get_cond_dists` returned a single distribution," *
-            " but multiple variables ($syms) are being sampled. Please return a" *
-            " VarNamedTuple mapping variable names to distributions instead."
-        )
-        throw(ArgumentError(msg))
-    end
-    top_sym = only(syms)
-    # Key the conditional at the variable even when it currently has one leaf: a ranged site
-    # of length one is stored as `theta[1]` but is evaluated as `theta[:]`.
-    vn = VarName{top_sym}()
-    template = get(raw_values.data, top_sym, DynamicPPL.NoTemplate())
-    return DynamicPPL.templated_setindex!!(DynamicPPL.VarNamedTuple(), dist, vn, template)
-end
 
 struct InitFromCondDists{V<:DynamicPPL.VarNamedTuple} <: DynamicPPL.AbstractInitStrategy
     cond_dists::V
 end
+
+mutable struct InitFromSingleCondDist{D<:Distribution} <: DynamicPPL.AbstractInitStrategy
+    dist::D
+    used::Bool
+end
+InitFromSingleCondDist(dist::Distribution) = InitFromSingleCondDist(dist, false)
+
+function DynamicPPL.init(
+    rng::Random.AbstractRNG, ::VarName, ::Distribution, init_strat::InitFromSingleCondDist
+)
+    if init_strat.used
+        throw(
+            ArgumentError(
+                "In GibbsConditional, `get_cond_dists` returned a single distribution, " *
+                "but the model requested it for more than one tilde statement. Return a " *
+                "VarNamedTuple mapping variable names to distributions instead.",
+            ),
+        )
+    end
+    init_strat.used = true
+    return DynamicPPL.TransformedValue(rand(rng, init_strat.dist), DynamicPPL.NoTransform())
+end
+
 """
     _cond_dist_for(cond_dists, vn)
 
@@ -264,10 +264,12 @@ function AbstractMCMC.step(
     #   - a VarNamedTuple of distributions
     #   - a NamedTuple of distributions
     #   - an AbstractDict mapping VarNames to distributions
-    raw_values = DynamicPPL.get_raw_values(state)
-    conddists = _to_varnamedtuple(sampler.get_cond_dists(condvals), raw_values)
-
-    init_strategy = InitFromCondDists(conddists)
+    dists = sampler.get_cond_dists(condvals)
+    init_strategy = if dists isa Distribution
+        InitFromSingleCondDist(dists)
+    else
+        InitFromCondDists(_to_varnamedtuple(dists))
+    end
     _, new_state = DynamicPPL.init!!(
         rng, model, state, init_strategy, DynamicPPL.UnlinkAll()
     )

--- a/test/mcmc/external_sampler.jl
+++ b/test/mcmc/external_sampler.jl
@@ -151,6 +151,13 @@ using Turing.Inference: AdvancedHMC
     @testset "Gibbs requires model-aware state updates" begin
         spl = Gibbs(@varname(a) => externalsampler(MySampler()), @varname(b) => MH())
         @test_throws "Turing.jl/issues/2875" AbstractMCMC.step(StableRNG(42), model, spl)
+
+        repeated = Turing.Inference.RepeatSampler(externalsampler(MySampler()), 2)
+        spl = Gibbs(@varname(a) => repeated, @varname(b) => MH())
+        _, state = AbstractMCMC.step(StableRNG(42), model, spl)
+        @test_throws "Turing.jl/issues/2875" AbstractMCMC.step(
+            StableRNG(43), model, spl, state
+        )
     end
 
     @testset "warmup steps reach the external sampler" begin

--- a/test/mcmc/gibbs_conditional.jl
+++ b/test/mcmc/gibbs_conditional.jl
@@ -9,10 +9,9 @@ using Test: @test, @test_throws, @testset
 using Turing
 
 @testset "GibbsConditional" begin
-    @testset "a ranged site is one variable, not several" begin
+    @testset "single conditional distribution" begin
         # `theta[:] ~ MvNormal(...)` is one tilde statement stored under `theta[1], theta[2]`,
-        # so counting keys refused the single-distribution form it is meant to support. The
-        # conditional is stored at `theta` and each tilde key resolves to it by subsumption.
+        # so counting stored keys refused the single-distribution form it is meant to support.
         @model function ranged(n)
             theta = Vector{Float64}(undef, n)
             theta[:] ~ MvNormal(zeros(n), LinearAlgebra.I)
@@ -27,13 +26,24 @@ using Turing
                 Xoshiro(1), ranged(n), spl, 20; check_model=false, progress=false
             ) isa VNChain
         end
+        # Separate tilde statements under the same top-level symbol are separate variables.
+        @model function elementwise()
+            x = Vector{Float64}(undef, 2)
+            x[1] ~ Normal()
+            return x[2] ~ Normal()
+        end
+        conditional = GibbsConditional(_ -> MvNormal(zeros(2), LinearAlgebra.I))
+        spl = Gibbs(@varname(x) => conditional)
+        @test_throws "more than one tilde statement" sample(
+            Xoshiro(1), elementwise(), spl, 2; check_model=false, progress=false
+        )
         # Two genuine variables under one distribution are still refused.
         @model function two()
             a ~ Normal()
             b ~ Normal()
             return 1.0 ~ Normal(a + b, 1)
         end
-        @test_throws "multiple variables" sample(
+        @test_throws "more than one tilde statement" sample(
             Xoshiro(1),
             two(),
             Gibbs((@varname(a), @varname(b)) => GibbsConditional(_ -> Normal())),

--- a/test/mcmc/gibbs_conditional.jl
+++ b/test/mcmc/gibbs_conditional.jl
@@ -32,7 +32,7 @@ using Turing
             x[1] ~ Normal()
             return x[2] ~ Normal()
         end
-        conditional = GibbsConditional(_ -> MvNormal(zeros(2), LinearAlgebra.I))
+        conditional = GibbsConditional(_ -> Normal())
         spl = Gibbs(@varname(x) => conditional)
         @test_throws "more than one tilde statement" sample(
             Xoshiro(1), elementwise(), spl, 2; check_model=false, progress=false


### PR DESCRIPTION
Fixes two Gibbs edge cases. `RepeatSampler(externalsampler(...))` now validates model-aware state updates on subsequent sweeps, preventing AbstractMCMC’s fallback from discarding the reconditioned model. `GibbsConditional` now distinguishes executed tilde sites directly: `x[:] ~ MvNormal(...)` remains one site, while separate `x[1] ~ ...` and `x[2] ~ ...` sites require a `VarNamedTuple` of conditionals. Also updates the README introduction and adds focused regressions.